### PR TITLE
Add RMSNorm

### DIFF
--- a/llm/llama2/rms_norm.py
+++ b/llm/llama2/rms_norm.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from torch import nn, Tensor
+
+
+class RMSNorm(nn.Module):
+    """
+    Implements Root Mean Square Normalization introduced in
+    https://arxiv.org/pdf/1910.07467.pdf
+
+    Reference implementation (used for correctness verfication)
+    can be found here:
+    https://github.com/facebookresearch/llama/blob/main/llama/model.py
+
+    Attributes:
+        dim (int): embedding size
+        eps (float): small value to avoid division by zero. Default: 1e-6
+
+    Args:
+        x (Tensor): input tensor to normalize
+
+    Returns:
+        torch.Tensor: The output tensor after applying RMSNorm.
+
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.eps = eps
+        self.scale = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: Tensor) -> Tensor:
+        # computation is in fp32
+        x = x.float()
+        x_normed = (
+            x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps) * self.scale
+        ).type_as(x)
+        return x_normed * self.scale

--- a/tests/llm/llama2/test_rms_norm.py
+++ b/tests/llm/llama2/test_rms_norm.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+import torch
+from llm.llama2.rms_norm import RMSNorm
+from torch.nn.functional import normalize
+
+from tests.test_utils import assert_expected, set_rng_seed
+
+
+@pytest.fixture(autouse=True)
+def random():
+    set_rng_seed(0)
+
+
+class TestRMSNorm:
+    """
+    Class for testing our RMSNorm implementation. Expected tensors
+    are generated using torch.nn.functional.normalization:
+
+    RMSNorm(x) = normalize(x, p=2, dim=-1) * (dim ** 0.5)
+    """
+
+    @pytest.fixture
+    def dim(self) -> int:
+        return 8
+
+    @pytest.fixture
+    def eps(self) -> float:
+        return 1e-6
+
+    @pytest.fixture
+    def input_ones(self, dim) -> torch.Tensor:
+        return torch.ones(dim, dtype=torch.float)
+
+    @pytest.fixture
+    def input_random(self, dim) -> torch.Tensor:
+        return torch.randn(dim, dtype=torch.float)
+
+    @pytest.fixture
+    def input_random_fp16(self, dim) -> torch.Tensor:
+        return torch.randn(dim, dtype=torch.float16)
+
+    @pytest.fixture
+    def rms_norm(self, dim, eps) -> RMSNorm:
+        return RMSNorm(dim, eps=eps)
+
+    def test_forward(self, rms_norm, input_ones, input_random, dim) -> None:
+        output_ones = rms_norm(input_ones)
+        output_random = rms_norm(input_random)
+
+        expected_random = normalize(input_random, p=2, dim=-1) * (dim**0.5)
+
+        assert_expected(output_ones, input_ones)
+        assert_expected(output_random, expected_random)
+
+    def test_forward_fp16(self, rms_norm, input_random_fp16, dim) -> None:
+        output_fp16 = rms_norm(input_random_fp16)
+
+        # convert input to float since rms_norm computes in fp32
+        expected_fp16 = normalize(input_random_fp16.float(), p=2, dim=-1) * (dim**0.5)
+
+        assert_expected(output_fp16, expected_fp16)
+        assert output_fp16.dtype == torch.float32


### PR DESCRIPTION
Summary:

This PR adds RMSNorm (https://arxiv.org/pdf/1910.07467.pdf) as a component to the repo, along with the associated tests. For testing, we use ```torch.nn.functional.normalize``` to get the expected tensors.

Test Plan:

Unit tests succeeded. Commands used:

```
cd ~/torch_tbd/tests/llm/llama2
pytest test_rms_norm.py
```