### PR TITLE
Add docstring lint as precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: 6306a48f7dae5861702d573c9c247e4e9498e867
     hooks:
     -   id: trailing-whitespace
     -   id: check-ast
@@ -17,7 +17,7 @@ repos:
     -   id: end-of-file-fixer
 
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.7
+    rev: v1.5.4
     hooks:
     -   id: insert-license
         files: \.py$
@@ -26,7 +26,7 @@ repos:
         - docs/license_header.txt
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 34cbf8ef3950f43d09b85e2e45c15ae5717dc37b
     hooks:
     -   id: flake8
         additional_dependencies:
@@ -35,9 +35,15 @@ repos:
         args: ['--config=.flake8']
 
 -   repo: https://github.com/omnilib/ufmt
-    rev: v2.0.1
+    rev: v2.3.0
     hooks:
     -   id: ufmt
         additional_dependencies:
           - black == 22.12.0
           - usort == 1.0.5
+
+- repo: https://github.com/jsh9/pydoclint
+  rev: d88180a8632bb1602a4d81344085cf320f288c5a
+  hooks:
+    - id: pydoclint
+      args: [--style=google, --check-return-types=False]

--- a/llm/llama2/position_embeddings.py
+++ b/llm/llama2/position_embeddings.py
@@ -6,7 +6,7 @@
 
 import torch
 
-from torch import nn
+from torch import nn, Tensor
 
 
 class RotaryPositionalEmbeddings(nn.Module):
@@ -18,20 +18,13 @@ class RotaryPositionalEmbeddings(nn.Module):
     can be found here:
     https://github.com/facebookresearch/llama/blob/main/llama/model.py#L450
 
-    Attributes:
+    Args:
         dim (int): Embedding dimension for each head, computed as:
             embed_size //  num_heads
         max_seq_len (int): Maximum expected sequence length for the
             model, if exceeded the cached freqs will be recomputed
         base (int): The base for the geometric progression used to compute
             the rotation angles
-
-    Args:
-        x (tensor): input tensor to which rope is applied
-
-    Returns:
-        torch.Tensor: output tensor with RoPE applied
-
     """
 
     def __init__(
@@ -59,10 +52,16 @@ class RotaryPositionalEmbeddings(nn.Module):
         cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
         self.register_buffer("cache", cache)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """
         TODO: The implementation below can be made more efficient
         for inference.
+
+        Args:
+            x (Tensor): input tensor to which rope is applied
+
+        Returns:
+            Tensor: output tensor with RoPE applied
         """
         seq_len = x.size(1)
         rope_cache = self.cache[:seq_len]

--- a/llm/llama2/rms_norm.py
+++ b/llm/llama2/rms_norm.py
@@ -18,16 +18,9 @@ class RMSNorm(nn.Module):
     can be found here:
     https://github.com/facebookresearch/llama/blob/main/llama/model.py
 
-    Attributes:
+    Args:
         dim (int): embedding size
         eps (float): small value to avoid division by zero. Default: 1e-6
-
-    Args:
-        x (Tensor): input tensor to normalize
-
-    Returns:
-        torch.Tensor: The output tensor after applying RMSNorm.
-
     """
 
     def __init__(self, dim: int, eps: float = 1e-6) -> None:
@@ -36,6 +29,13 @@ class RMSNorm(nn.Module):
         self.scale = nn.Parameter(torch.ones(dim))
 
     def forward(self, x: Tensor) -> Tensor:
+        """
+        Args:
+            x (Tensor): input tensor to normalize
+
+        Returns:
+            Tensor: The output tensor after applying RMSNorm.
+        """
         # computation is in fp32
         x = x.float()
         x_normed = (


### PR DESCRIPTION
### Summary

Adding a linter for catching issues with docstrings and adding this as a precommit hook.

### Test Plan

Eyes