### PR TITLE
Add FFN to LLaMA

### DIFF
--- a/llm/llama2/feed_forward.py
+++ b/llm/llama2/feed_forward.py
@@ -19,20 +19,25 @@ class FeedForward(nn.Module):
     Args:
         dim (int): Input dimension.
         hidden_dim (int): Hidden dimension of the feedforward layer. `hidden_dim` should be a large multiple of 2
-            and can additionally include a custom multiplier which increases the model capacity for LLaMA V2. Based
-            on experiments, the LLaMA team recommends using a custom multiplier of 4 and rounding the result to a
-            multiple of 256. E.g. for LLaMA 7B, the hidden dimension would be 896000.
+            and can additionally include a custom multiplier which increases the model capacity for LLaMA V2.
+        multiple_of (int): After scaling, `hidden_dim` must be rounded to nearest multiple provided. Based on experiments,
+            the LLaMA team recommends rounding the result to a multiple of 256. E.g. for LLaMA 7B, the hidden dimension
+            would be 11008 after scaling and rounding.
     """
 
     def __init__(
         self,
         dim: int,
         hidden_dim: int,
+        multiple_of: int = 256,
     ):
         super().__init__()
-        # Scale hidden dimension by 2/3 for SwiGLU to keep number of
+        # Scale hidden dimension by (2/3)4d for SwiGLU to keep number of
         # parameters and computation constant
-        hidden_dim = int(2 * hidden_dim / 3)
+        hidden_dim = 4 * int(2 * hidden_dim / 3)
+
+        # Round hidden dimension to nearest multiple of `multiple_of`
+        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
         self.w1 = nn.Linear(dim, hidden_dim, bias=False)
         self.w2 = nn.Linear(hidden_dim, dim, bias=False)

--- a/tests/llm/llama2/test_feed_forward.py
+++ b/tests/llm/llama2/test_feed_forward.py
@@ -23,34 +23,21 @@ class TestFeedForward:
     @pytest.fixture
     def input_params(self):
         dim = 4096
-        hidden_dim = 4 * dim
-        hidden_dim_multiple_of = 256
-        ffn_dim_multiplier = None
-        return dim, hidden_dim, hidden_dim_multiple_of, ffn_dim_multiplier
+        hidden_dim = 4096
+        return dim, hidden_dim
 
     @pytest.fixture
     def input(self, input_params):
-        dim, _, _, _ = input_params
+        dim, _ = input_params
         return torch.randn(1, dim)
 
     @pytest.fixture
     def ffn(self, input_params):
-        dim, hidden_dim, hidden_dim_multiple_of, ffn_dim_multiplier = input_params
-        return FeedForward(dim, hidden_dim, hidden_dim_multiple_of, ffn_dim_multiplier)
-
-    @pytest.fixture
-    def ffn_with_multiplier(self, input_params):
-        dim, hidden_dim, hidden_dim_multiple_of, _ = input_params
-        return FeedForward(dim, hidden_dim, hidden_dim_multiple_of, 0.75)
+        dim, hidden_dim = input_params
+        return FeedForward(dim, hidden_dim)
 
     def test_forward(self, input, ffn):
         x_out = ffn(input)
         assert_expected(x_out.mean(), torch.tensor(0.0011))
         assert_expected(x_out.sum(), torch.tensor(4.3965))
         assert_expected(x_out.max(), torch.tensor(0.3466))
-
-    def test_forward_with_multiplier(self, input, ffn_with_multiplier):
-        x_out = ffn_with_multiplier(input)
-        assert_expected(x_out.mean(), torch.tensor(0.0004))
-        assert_expected(x_out.sum(), torch.tensor(1.7033))
-        assert_expected(x_out.max(), torch.tensor(0.3901))


### PR DESCRIPTION
Summary:

This PR adds the LLaMA FFN as a component to the repo, along with the associated tests. For testing, we use the official llama repo FFN (https://github.com/facebookresearch/llama/blob/main/llama/model.py#L307) to get the expected tensors.

Notably, this adds the SwiGLU definition used by LLaMA.

Test Plan:

Unit tests succeeded. Commands used:

```
cd ~/torch_tbd/tests/llm/llama2
pytest test_feed_forward.py
```