### PR TITLE
Bug in RMSNorm + add additional tests

### DIFF
--- a/llm/llama2/rms_norm.py
+++ b/llm/llama2/rms_norm.py
@@ -37,8 +37,8 @@ class RMSNorm(nn.Module):
             Tensor: The output tensor after applying RMSNorm.
         """
         # computation is in fp32
-        x = x.float()
+        x_fp32 = x.float()
         x_normed = (
-            x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps) * self.scale
+            x_fp32 * torch.rsqrt(x_fp32.pow(2).mean(-1, keepdim=True) + self.eps)
         ).type_as(x)
         return x_normed * self.scale

--- a/tests/llm/llama2/test_feed_forward.py
+++ b/tests/llm/llama2/test_feed_forward.py
@@ -38,6 +38,6 @@ class TestFeedForward:
 
     def test_forward(self, input, ffn):
         x_out = ffn(input)
-        assert_expected(x_out.mean(), torch.tensor(0.0011))
-        assert_expected(x_out.sum(), torch.tensor(4.3965))
-        assert_expected(x_out.max(), torch.tensor(0.3466))
+        assert_expected(x_out.mean(), torch.tensor(0.0011), atol=1e-4, rtol=1e-3)
+        assert_expected(x_out.sum(), torch.tensor(4.3965), atol=1e-7, rtol=1e-3)
+        assert_expected(x_out.max(), torch.tensor(0.3466), atol=1e-7, rtol=1e-3)

--- a/tests/llm/llama2/test_rms_norm.py
+++ b/tests/llm/llama2/test_rms_norm.py
@@ -65,5 +65,5 @@ class TestRMSNorm:
         # convert input to float since rms_norm computes in fp32
         expected_fp16 = normalize(input_random_fp16.float(), p=2, dim=-1) * (dim**0.5)
 
-        assert_expected(output_fp16, expected_fp16)
+        assert_expected(output_fp16, expected_fp16, atol=1e-7, rtol=1e-3)
         assert output_fp16.dtype == torch.float32


### PR DESCRIPTION
### Summary

We had a bug in the RMSNorm implementation which scaled the input twice. Unfortunately, since we were testing downstream components with initialization to 1.0, we werent catching such bugs. Fixed the bug itself and added additional tests to attention with different initialization values. Also added test for MQA

### Test Plan

Run unit tests

```
cd ~torch_tbd/tests/llm/llama2

pytest

```