### PR TITLE
Add comparison scripts for FF, Decoder Layer and Decoder

### DIFF
--- a/tests/llm/llama2/scripts/compare_attention.py
+++ b/tests/llm/llama2/scripts/compare_attention.py
@@ -137,9 +137,15 @@ def compare_rope(bsz: int, num_heads: int, embed_dim: int, seq_len: int) -> None
 
     # Validate correctness
     assert torch.allclose(x_out_ref, x_out, atol=1e-6)
-    print(f"mean value for x_out: {x_out.mean()}")
-    print(f"sum value for x_out: {x_out.sum()}")
-    print(f"max value for x_out: {x_out.max()}")
+
+    # value: tensor(-4.3060e-05)
+    print(x_out.mean())
+
+    # value: tensor(-2889.6772)
+    print(x_out.sum())
+
+    # value: tensor(5.6446)
+    print(x_out.max())
 
 
 def compare_attention(
@@ -186,8 +192,8 @@ def compare_attention(
     with torch.no_grad():
         attn_out = attn(input_t)
 
+    # value: tensor(-27.5074)
     print(attn_out.mean())
-    print(attn_out_ref.mean())
 
     # output tensors should be similar
     assert torch.allclose(attn_out, attn_out_ref, atol=1e-5, rtol=1e-3)
@@ -225,7 +231,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    compare_rope(args.seed, args.bsz, args.num_heads, args.embed_dim, args.max_seq_len)
+    compare_rope(args.bsz, args.num_heads, args.embed_dim, args.max_seq_len)
 
     compare_attention(
         args.bsz,

--- a/tests/llm/llama2/scripts/compare_decoder.py
+++ b/tests/llm/llama2/scripts/compare_decoder.py
@@ -1,0 +1,175 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from llm.llama2.transformer import TransformerDecoder
+
+from torch import nn
+
+from tests.llm.llama2.scripts.compare_attention import precompute_freqs_cis
+from tests.llm.llama2.scripts.compare_decoder_layer import RMSNorm, TransformerBlock
+
+from tests.test_utils import init_weights_with_constant
+
+"""
+Reference implementation of Transformer from:
+https://github.com/facebookresearch/llama/blob/main/llama/model.py#L413
+
+Replicating code here to minimize dependencies. The code is modified to
+include params for the constructor and remove start_pos (not supported).
+"""
+
+
+class Transformer(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        dim: int,
+        n_layers: int,
+        n_heads: int,
+        max_seq_len: int,
+        n_kv_heads: int,
+    ):
+
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.n_layers = n_layers
+
+        self.tok_embeddings = nn.Embedding(vocab_size, dim)
+
+        self.layers = torch.nn.ModuleList()
+        for _ in range(n_layers):
+            self.layers.append(
+                TransformerBlock(n_heads=n_heads, dim=dim, n_kv_heads=n_kv_heads)
+            )
+
+        self.norm = RMSNorm(dim)
+        self.output = nn.Linear(dim, vocab_size, bias=False)
+
+        self.freqs_cis = precompute_freqs_cis(dim // n_heads, max_seq_len * 2)
+
+    def forward(self, tokens: torch.Tensor, start_pos: int = 0):
+        _bsz, seqlen = tokens.shape
+        h = self.tok_embeddings(tokens)
+        self.freqs_cis = self.freqs_cis.to(h.device)
+        freqs_cis = self.freqs_cis[start_pos : start_pos + seqlen]
+
+        mask = None
+        if seqlen > 1:
+            mask = torch.full(
+                (1, 1, seqlen, seqlen), float("-inf"), device=tokens.device
+            )
+            mask = torch.triu(mask, diagonal=start_pos + 1).type_as(h)
+
+        for layer in self.layers:
+            h = layer(h, freqs_cis, mask)
+        h = self.norm(h)
+        output = self.output(h).float()
+        return output
+
+
+def compare_decoder(
+    bsz: int,
+    seq_len: int,
+    embed_dim: int,
+    num_heads: int,
+    num_kv_heads: int,
+    max_seq_len: int,
+    vocab_size: int,
+    num_layers: int,
+) -> None:
+
+    # make sure we have the right seed for generating outputs
+    # this should match up the seed value set in the corresponding
+    # unit test
+    torch.manual_seed(16)
+
+    head_dim = embed_dim // num_heads
+
+    # generate input tensor used by both implementations
+    x_input = torch.randint(low=0, high=vocab_size, size=(bsz, seq_len))
+
+    # reference implementation; initialize with constant to compare outputs
+    decoder_ref = Transformer(
+        vocab_size=vocab_size,
+        dim=embed_dim,
+        n_layers=num_layers,
+        n_heads=num_heads,
+        max_seq_len=max_seq_len,
+        n_kv_heads=num_kv_heads,
+    )
+    init_weights_with_constant(decoder_ref, constant=0.2)
+
+    with torch.no_grad():
+        output_ref = decoder_ref(x_input)
+
+    # current implementation; initialize with constant to compare outputs
+    decoder = TransformerDecoder(
+        vocab_size=vocab_size,
+        embed_dim=embed_dim,
+        num_layers=num_layers,
+        num_heads=num_heads,
+        max_seq_len=max_seq_len,
+        num_kv_heads=num_kv_heads,
+    )
+    init_weights_with_constant(decoder, constant=0.2)
+
+    with torch.no_grad():
+        output = decoder(x_input)
+
+    # value: tensor(163.8399)
+    print(output.mean())
+
+    assert torch.allclose(output_ref, output, atol=1e-6, rtol=1e-6)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Compare Attention implementations")
+    parser.add_argument("--bsz", type=int, default=4, help="Batch size of input tensor")
+    parser.add_argument(
+        "--seq_len", type=int, default=2048, help="input sequence length"
+    )
+    parser.add_argument(
+        "--embed_dim",
+        type=int,
+        default=4096,
+        help="Embedding dimension used to compute the dim for RopE",
+    )
+    parser.add_argument(
+        "--num_heads",
+        type=int,
+        default=32,
+        help="Number of heads in the attention layer",
+    )
+    parser.add_argument(
+        "--num_kv_heads",
+        type=int,
+        default=8,
+        help="Number of key/value heads in the attention layer",
+    )
+    parser.add_argument(
+        "--max_seq_len", type=int, default=4096, help="max sequence length"
+    )
+    parser.add_argument("--vocab_size", type=int, default=1024, help="vocab size")
+    parser.add_argument(
+        "--num_layers", type=int, default=4, help="number of transformer layers"
+    )
+
+    args = parser.parse_args()
+
+    compare_decoder(
+        args.bsz,
+        args.seq_len,
+        args.embed_dim,
+        args.num_heads,
+        args.num_kv_heads,
+        args.max_seq_len,
+        args.vocab_size,
+        args.num_layers,
+    )

--- a/tests/llm/llama2/scripts/compare_decoder_layer.py
+++ b/tests/llm/llama2/scripts/compare_decoder_layer.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+
+from llm.llama2.transformer import TransformerDecoderLayer
+
+from torch import nn
+
+from tests.llm.llama2.scripts.compare_attention import Attention, precompute_freqs_cis
+from tests.llm.llama2.scripts.compare_feed_forward import FeedForwardRef
+
+from tests.test_utils import init_weights_with_constant
+
+
+"""
+Reference implementation of RMSNorm from:
+https://github.com/facebookresearch/llama/blob/main/llama/model.py#L34
+
+Replicating code here to minimize dependencies. The code is modified to
+include params for the constructor and remove start_pos (not supported).
+"""
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+"""
+Reference implementation of Transformer Decoder Layer from:
+https://github.com/facebookresearch/llama/blob/main/llama/model.py#L351
+
+Replicating code here to minimize dependencies. The code is modified to
+include params for the constructor and remove start_pos (not supported).
+"""
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, n_heads: int, dim: int, n_kv_heads: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.dim = dim
+        # self.head_dim = args.dim // args.n_heads
+        self.attention = Attention(n_heads=n_heads, n_kv_heads=n_kv_heads, dim=dim)
+        self.feed_forward = FeedForwardRef(dim=dim, hidden_dim=4 * dim)
+        self.attention_norm = RMSNorm(dim=dim)
+        self.ffn_norm = RMSNorm(dim=dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        mask: Optional[torch.Tensor],
+    ):
+        norm_out = self.attention_norm(x)
+        attn_out = self.attention.forward(norm_out, freqs_cis, mask)
+        h = x + attn_out
+        ffn_norm_out = self.ffn_norm(h)
+        mlp_out = self.feed_forward.forward(ffn_norm_out)
+        out = h + mlp_out
+        return out
+
+
+def compare_decoder_layer(
+    bsz: int,
+    seq_len: int,
+    embed_dim: int,
+    num_heads: int,
+    num_kv_heads: int,
+    max_seq_len: int,
+) -> None:
+    # make sure we have the right seed for generating outputs
+    # this should match up the seed value set in the corresponding
+    # unit test
+    torch.manual_seed(16)
+
+    head_dim = embed_dim // num_heads
+
+    # generate input tensor used by both implementations
+    input_t = torch.randn(bsz, seq_len, embed_dim)
+
+    # generate mask and frequencies tensor needed for the reference
+    # implementation
+    mask = torch.full((1, 1, seq_len, seq_len), float("-inf"))
+    mask = torch.triu(mask, diagonal=1)
+    freq_cis = precompute_freqs_cis(dim=head_dim, end=seq_len)
+
+    # reference implementation; initialize with constant to compare outputs
+    transformer_block = TransformerBlock(
+        n_heads=num_heads, n_kv_heads=num_kv_heads, dim=embed_dim
+    )
+    init_weights_with_constant(transformer_block, constant=0.05)
+
+    with torch.no_grad():
+        block_out = transformer_block(x=input_t, freqs_cis=freq_cis, mask=mask)
+
+    # current implementation; initialize with constant to compare outputs
+    transformer_layer = TransformerDecoderLayer(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        max_seq_len=max_seq_len,
+    )
+    init_weights_with_constant(transformer_layer, constant=0.05)
+
+    with torch.no_grad():
+        layer_out = transformer_layer(input_t)
+
+    # value: torch.tensor(18261.0156)
+    print(layer_out.mean())
+
+    assert torch.allclose(block_out, layer_out, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Compare Attention implementations")
+    parser.add_argument("--bsz", type=int, default=4, help="Batch size of input tensor")
+    parser.add_argument(
+        "--seq_len", type=int, default=2048, help="input sequence length"
+    )
+    parser.add_argument(
+        "--embed_dim",
+        type=int,
+        default=4096,
+        help="Embedding dimension used to compute the dim for RopE",
+    )
+    parser.add_argument(
+        "--num_heads",
+        type=int,
+        default=32,
+        help="Number of heads in the attention layer",
+    )
+    parser.add_argument(
+        "--num_kv_heads",
+        type=int,
+        default=8,
+        help="Number of key/value heads in the attention layer",
+    )
+    parser.add_argument(
+        "--max_seq_len", type=int, default=4096, help="max sequence length"
+    )
+
+    args = parser.parse_args()
+
+    compare_decoder_layer(
+        args.bsz,
+        args.seq_len,
+        args.embed_dim,
+        args.num_heads,
+        args.num_kv_heads,
+        args.max_seq_len,
+    )

--- a/tests/llm/llama2/scripts/compare_feed_forward.py
+++ b/tests/llm/llama2/scripts/compare_feed_forward.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+
+from llm.llama2.feed_forward import FeedForward
+
+from torch import nn
+
+from tests.test_utils import fixed_init_model
+
+
+"""
+Reference implementation of FeedForward from:
+https://github.com/facebookresearch/llama/blob/main/llama/model.py#L307
+
+Replicating code here to minimize dependencies.
+"""
+
+
+class FeedForwardRef(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+        multiple_of: int = 256,
+        ffn_dim_multiplier: Optional[float] = None,
+    ):
+        super().__init__()
+        hidden_dim = int(2 * hidden_dim / 3)
+        # custom dim factor multiplier
+        if ffn_dim_multiplier is not None:
+            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        return self.w2(nn.functional.silu(self.w1(x)) * self.w3(x))
+
+
+def compare_feed_forward(embed_dim: int, hidden_dim: int) -> None:
+
+    # make sure we have the right seed for generating outputs
+    # this should match up the seed value set in the corresponding
+    # unit test
+    torch.manual_seed(0)
+
+    # generate input tensor used by both implementations
+    input_t = torch.randn(1, embed_dim)
+
+    # reference implementation; initialize with constant to compare outputs
+    ff_ref = FeedForwardRef(dim=embed_dim, hidden_dim=4 * embed_dim)
+    fixed_init_model(ff_ref)
+
+    with torch.no_grad():
+        ff_out_ref = ff_ref(input_t)
+
+    # current implementation; initialize with constant to compare outputs
+    ff = FeedForward(dim=embed_dim, hidden_dim=embed_dim)
+    fixed_init_model(ff)
+
+    with torch.no_grad():
+        ff_out = ff(input_t)
+
+    assert torch.allclose(ff_out, ff_out_ref, atol=1e-5, rtol=1e-5)
+    print(ff_out.mean())
+    print(ff_out.max())
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Compare RMS Norm implementations")
+    parser.add_argument(
+        "--embed_dim",
+        type=int,
+        default=4096,
+        help="Embedding dimension used to compute the dim for RopE",
+    )
+    parser.add_argument(
+        "--hidden_dim",
+        type=int,
+        default=4096,
+        help="Hidden dimension in the feed forward layer",
+    )
+
+    args = parser.parse_args()
+
+    compare_feed_forward(args.embed_dim, args.hidden_dim)

--- a/tests/llm/llama2/test_feed_forward.py
+++ b/tests/llm/llama2/test_feed_forward.py
@@ -4,12 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Tuple
+
 import pytest
 
 import torch
+
 from llm.llama2.feed_forward import FeedForward
 
-from tests.test_utils import assert_expected, set_rng_seed
+from torch import Tensor
+
+from tests.test_utils import assert_expected, fixed_init_model, set_rng_seed
 
 
 @pytest.fixture(autouse=True)
@@ -21,23 +26,26 @@ class TestFeedForward:
     """Class for testing FFN implementation."""
 
     @pytest.fixture
-    def input_params(self):
+    def input_params(self) -> Tuple[int, int]:
         dim = 4096
         hidden_dim = 4096
         return dim, hidden_dim
 
     @pytest.fixture
-    def input(self, input_params):
+    def input(self, input_params: Tuple[int, int]) -> Tensor:
         dim, _ = input_params
         return torch.randn(1, dim)
 
     @pytest.fixture
-    def ffn(self, input_params):
+    def ffn(self, input_params: Tuple[int, int]) -> FeedForward:
         dim, hidden_dim = input_params
-        return FeedForward(dim, hidden_dim)
+        ff = FeedForward(dim, hidden_dim).eval()
+        fixed_init_model(ff)
+        ff.eval()
+        return ff
 
-    def test_forward(self, input, ffn):
-        x_out = ffn(input)
-        assert_expected(x_out.mean(), torch.tensor(0.0011), atol=1e-4, rtol=1e-3)
-        assert_expected(x_out.sum(), torch.tensor(4.3965), atol=1e-7, rtol=1e-3)
-        assert_expected(x_out.max(), torch.tensor(0.3466), atol=1e-7, rtol=1e-3)
+    def test_forward(self, input: Tensor, ffn: FeedForward) -> None:
+        with torch.no_grad():
+            x_out = ffn(input)
+        assert_expected(x_out.mean(), torch.tensor(251.5356), atol=1e-7, rtol=1e-3)
+        assert_expected(x_out.max(), torch.tensor(503.0614), atol=1e-7, rtol=1e-3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,6 @@ def fixed_init_tensor(
     """
     n_elements = math.prod(shape)
     step_size = (max_val - min_val) / n_elements
-    print(f"RV: step_size {step_size}")
     x = torch.arange(min_val, max_val, step_size, dtype=dtype)
     x = x.reshape(shape)
     if nonlinear:


### PR DESCRIPTION
### Summary 

To make sure our model and module implementations are correct, we compare our implementation against reference implementations where possible. This PR contains scripts used for these comparisons. Specifically this includes the FeedForward layer, DecoderLayer and Decoder. The PR also includes some small fixes to the feed forward test.

### Test Plan

Run the script:

```
cd ~/torch_tbd

python3 -m tests.llm.llama2.scripts.compare_attention
```

Run Unit Tests

```
cd ~/torch_tbd/tests/llm/llams2

pytest

```

