### PR TITLE
experimental kv cache

### DIFF
--- a/llm/llama2/position_embeddings.py
+++ b/llm/llama2/position_embeddings.py
@@ -58,12 +58,11 @@ class RotaryPositionalEmbeddings(nn.Module):
         cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
         self.register_buffer("cache", cache)
 
-    def forward(self, x: Tensor, curr_pos: int = 0) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """
         Args:
             x (Tensor): input tensor with shape
                 [bsz, seq_len, num_heads, head_dim]
-            curr_pos (int): current position in the sequence. Defaults to 0.
 
         Returns:
             Tensor: output tensor with RoPE applied
@@ -76,7 +75,7 @@ class RotaryPositionalEmbeddings(nn.Module):
         """
         # input tensor has shape [b, s, n_h, n_d]
         seq_len = x.size(1)
-        rope_cache = self.cache[curr_pos : curr_pos + seq_len]
+        rope_cache = self.cache[:seq_len]
 
         # reshape input; the last dimension is used for computing the output.
         # Cast to float to match the reference implementation

--- a/tests/llm/llama2/test_transformer.py
+++ b/tests/llm/llama2/test_transformer.py
@@ -162,7 +162,6 @@ class TestTransformerDecoder:
             num_kv_heads=num_kv_heads,
             embed_dim=embed_dim,
             max_seq_len=max_seq_len,
-            max_bsz_for_kv_cache=32,
         )
         init_weights_with_constant(decoder, constant=0.2)
         decoder.eval()
@@ -194,7 +193,12 @@ class TestTransformerDecoder:
         decoder_with_kv_cache_enabled: TransformerDecoder,
         decoder: TransformerDecoder,
     ) -> None:
+        import time
+
         with torch.no_grad():
+            decoder_with_kv_cache_enabled.initialize_kv_cache_for_inference(max_bsz=32)
             output_cache = decoder_with_kv_cache_enabled(input)
+            decoder_with_kv_cache_enabled.clear_kv_cache()
             output_no_cache = decoder(input)
+
         assert_expected(output_cache.mean(), output_no_cache.mean())


### PR DESCRIPTION
Expected use:

```
decoder.initialize_kv_cache_for_inference(max_bsz=32)
for cur_pos in range(min_prompt_len, total_len):
    decoder.forward(tokens)
    ....
decoder.reset_kv_cache()
```
