### PR TITLE
Add tokenizer tests to ensure proper use

### DIFF
--- a/tests/llm/llama2/test_tokenizer.py
+++ b/tests/llm/llama2/test_tokenizer.py
@@ -51,3 +51,11 @@ class TestTokenizer:
 
     def test_decode(self, tokenizer):
         assert tokenizer.decode([1, 12, 1803, 1024, 103, 2]) == "Hello world!"
+
+    def test_token_ids(self, tokenizer):
+        assert tokenizer.eos_id == 2
+        assert tokenizer.pad_id == -1
+        assert tokenizer.bos_id == 1
+
+    def test_tokenizer_vocab_size(self, tokenizer):
+        assert tokenizer.vocab_size == 2000

--- a/torchtune/llm/llama2/tokenizer.py
+++ b/torchtune/llm/llama2/tokenizer.py
@@ -53,7 +53,7 @@ class Tokenizer:
         """
         spm = SentencePieceProcessor()
         spm.load(path)
-        return cls(spm, spm.vocab_size, spm.bos_id(), spm.eos_id(), spm.pad_id())
+        return cls(spm, spm.vocab_size(), spm.bos_id(), spm.eos_id(), spm.pad_id())
 
     def encode(
         self,


### PR DESCRIPTION
### Summary

While working on #49, discovered a bug related to loading the vocab_size from Tokenizer.
This fixes that bug and adds tests.

### Testing

`pytest tests/llm/llama2/test_tokenizer.py`
