### PR TITLE
[DO NOT MERGE] Fine-tuning w/ Deepspeed

### DIFF
--- a/torchtune/llm/scripts/recipes/deepspeed_finetune_alpaca.py
+++ b/torchtune/llm/scripts/recipes/deepspeed_finetune_alpaca.py
@@ -1,0 +1,207 @@
+import argparse
+import os
+from typing import Callable, List, Tuple
+
+import deepspeed
+
+import torch
+import torch.nn.functional as F
+from torch.nn.utils.rnn import pad_sequence
+from torch.optim.optimizer import Optimizer
+from torch.utils.data import DataLoader
+
+from torchtune.llm.datasets import get_dataset
+from torchtune.llm.llama2.tokenizer import Tokenizer
+from torchtune.llm.llama2.transformer import TransformerDecoder
+from tqdm import tqdm
+
+
+def get_argparser():
+    """Return an argument parser for the script. Add all arguments here."""
+    parser = argparse.ArgumentParser(
+        description="Fine-tune a native PyTorch LLaMA model."
+    )
+    # Dataset arguments
+    parser.add_argument("--dataset", type=str, required=True, help="Dataset name.")
+    parser.add_argument(
+        "--shuffle", action="store_true", help="Shuffle dataset.", default=True
+    )
+    # Model arguments
+    parser.add_argument(
+        "--tokenizer-checkpoint",
+        type=str,
+        required=True,
+        help="Path to SentencePiece tokenizer.",
+    )
+    parser.add_argument(
+        "--model-checkpoint",
+        type=str,
+        required=True,
+        help="Path to native PyTorch LLaMA model checkpoint.",
+    )
+    # Fine-tuning arguments
+    parser.add_argument(
+        "--batch-size", type=int, default=128, help="Batch size for fine-tuning."
+    )
+    parser.add_argument(
+        "--lr", type=float, default=2e-5, help="Learning rate for fine-tuning."
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=3, help="Number of epochs for fine-tuning"
+    )
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="AdamW",
+        choices=["AdamW"],
+        help="Optimizer to use for fine-tuning.",
+    )
+    parser.add_argument(
+        "--loss-fn",
+        type=str,
+        default="cross_entropy",
+        choices=["cross_entropy"],
+        help="Loss function to use for fine-tuning",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="/tmp/llama-finetune",
+        help="Directory in which to save checkpoints during fine-tuning.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="`cuda` or `cpu`",
+    )
+    return parser
+
+
+def batch_pad_to_longest_seq(
+    batch: List[Tuple[List[int], List[int]]]
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pad a batch of sequences to the longest sequence length in the batch.
+
+    Args:
+        batch (List of tuples): A list of tuples containing input, label pairs.
+
+    Returns:
+        Collated input and label tensors.
+    """
+    input_ids = pad_sequence(
+        [torch.tensor(x[0]) for x in batch], batch_first=True, padding_value=0
+    )
+    labels = pad_sequence(
+        [torch.tensor(x[1]) for x in batch], batch_first=True, padding_value=-100
+    )
+
+    input_ids_seq_len = input_ids.shape[-1]
+    labels_seq_len = labels.shape[-1]
+
+    # Hack to pad correctly and not use max_seq_len, which is costly
+    if input_ids_seq_len > labels_seq_len:
+        labels = F.pad(labels, (0, input_ids_seq_len - labels_seq_len), value=-100)
+    elif labels_seq_len > input_ids_seq_len:
+        input_ids = F.pad(
+            input_ids,
+            (0, labels_seq_len - input_ids_seq_len),
+            value=0,
+        )
+    return input_ids, labels
+
+
+def get_optimizer(model: torch.nn.Module, optimizer: str, lr: float) -> Optimizer:
+    return getattr(torch.optim, optimizer)(model.parameters(), lr=lr)
+
+
+def get_loss(loss_fn: str) -> Callable:
+    return getattr(torch.nn.functional, loss_fn)
+
+
+def get_logger():
+    import logging
+
+    logger = logging.getLogger(__name__)
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
+    return logger.info
+
+
+def main():
+    # ---- Parse arguments ---- #
+    parser = get_argparser()
+    parser = deepspeed.add_config_arguments(parser)
+    args = parser.parse_args()
+
+    # ---- Initialize components ---- #
+    logger = get_logger()
+
+    tokenizer = Tokenizer.from_file(args.tokenizer_checkpoint)
+    tokenizer.pad_id = 0  # Original tokenizer has no pad_id, which causes indexing errors when batch training
+    logger(msg=f"Loaded tokenizer from {args.tokenizer_checkpoint}")
+
+    device = args.device
+    with torch.device(device):
+        model = TransformerDecoder(
+            vocab_size=tokenizer.vocab_size,
+            num_layers=32,
+            num_heads=32,
+            embed_dim=4096,
+            max_seq_len=2048,
+            norm_eps=1e-5,
+        )
+    model.load_state_dict(torch.load(args.model_checkpoint))
+    logger(msg=f"Loaded model from {args.model_checkpoint}")
+
+    opt = get_optimizer(model, args.optimizer, args.lr)
+    loss_fn = get_loss(args.loss_fn)
+
+    # ---- Load dataset ---- #
+    dataset = get_dataset(args.dataset, split="train", tokenizer=tokenizer)
+    dataloader = DataLoader(
+        dataset,
+        args.batch_size,
+        shuffle=args.shuffle,
+        collate_fn=batch_pad_to_longest_seq,
+    )
+
+    model_engine, opt, _, _ = deepspeed.initialize(
+        args=args, model=model, model_parameters=model.parameters()
+    )
+
+    # ---- Train loop ---- #
+    for epoch in tqdm(range(args.epochs)):
+        for i, batch in enumerate(dataloader):
+            opt.zero_grad()
+
+            input_ids, labels = batch
+            input_ids = input_ids.to(device)
+
+            logits = model_engine(input_ids)
+
+            logits = logits.cpu()
+            # Shift so that tokens < n predict n
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            # Flatten the tokens
+            shift_logits = shift_logits.view(-1, tokenizer.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            # Compute loss
+            loss = loss_fn(shift_logits, shift_labels)
+            logger(msg=f"Loss @ step {i} in epoch {epoch}: {loss}")
+
+            model_engine.backward(loss)
+            model_engine.step()
+
+        # Save checkpoint at end of each epoch (to be changed later)
+        output_loc = f"{args.output_dir}/model_{epoch}.ckpt"
+        torch.save(model.state_dict(), output_loc)
+        logger(
+            msg=f"Model checkpoint of size {os.path.get_size(output_loc)} bytes saved to {output_loc}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtune/llm/scripts/recipes/ds_config.json
+++ b/torchtune/llm/scripts/recipes/ds_config.json
@@ -1,0 +1,36 @@
+{
+    "train_batch_size": 8,
+    "gradient_accumulation_steps": 1,
+    "bf16": {
+        "enabled": "auto"
+    },
+    "optimizer": {
+        "type": "AdamW",
+        "params": {
+            "lr": 2e5
+        }
+    },
+    "zero_optimization": {
+        "stage": 3,
+        "offload_optimizer": {
+            "device": "cpu",
+            "pin_memory": true
+        },
+        "offload_param": {
+            "device": "cpu",
+            "pin_memory": true
+        },
+        "overlap_comm": true,
+        "contiguous_gradients": true,
+        "sub_group_size": 1e9,
+        "reduce_bucket_size": "auto",
+        "stage3_prefetch_bucket_size": "auto",
+        "stage3_param_persistence_threshold": "auto",
+        "stage3_max_live_parameters": 1e9,
+        "stage3_max_reuse_distance": 1e9,
+        "stage3_gather_16bit_weights_on_model_save": false
+    },
+    "steps_per_print": 2000,
+    "train_micro_batch_size_per_gpu": 8,
+    "wall_clock_breakdown": false
+  }


### PR DESCRIPTION
### Summary

Adds an example of how to run w/ Deepspeed. Purely for informational purposes.

### Requirements

`pip install deepspeed`

In addition, you may also need to install `cuda-toolkit` via conda with `conda install -c nvidia cuda-toolkit`

### Testing

With Deepspeed's CPU offloading, (Zero-3), a user can fully fine-tune Llama2.

```
python -m torchtune.llm.scripts.recipes.deepspeed_finetune_alpaca --dataset alpaca --tokenizer PATH_TO_TOKENIZER --model-checkpoint PATH_TO_MODEL_CHECKPOINT --batch-size 8 --device cuda --deepspeed_config ~/projects/torchtune/torchtune/llm/scripts/recipes/ds_config.json
```
