### PR TITLE
Reproducibility: Use the seed set as shuffling seed and base_seed for workers

### DIFF
--- a/tests/torchtune/generation/__init__.py
+++ b/tests/torchtune/generation/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/torchtune/llama2/test_reproducible_dataloader.py
+++ b/tests/torchtune/llama2/test_reproducible_dataloader.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from torch.utils.data import Dataset, IterableDataset
+from torchtune.trainer import ReproducibleDataLoader
+
+from tests.test_utils import assert_expected, set_rng_seed
+
+
+@pytest.fixture(autouse=True)
+def random():
+    set_rng_seed(7)
+
+
+class InMemoryMapDataset(Dataset):
+    def __init__(self, length):
+        self._length = length
+
+    def __getitem__(self, index):
+        if index >= self._length:
+            raise IndexError
+        return index
+
+    def __len__(self):
+        return self._length
+
+
+class DummyIterableDataset(IterableDataset):
+    def __init__(self, length):
+        super().__init__()
+        self._length = length
+
+    def __iter__(self):
+        for i in range(self._length):
+            yield i
+
+
+class TestReproducibleDataLoader:
+    @pytest.mark.parametrize("batch_size,num_workers", [(1, 2), (4, 0), (3, 3)])
+    def test_map_dataset_determinism_with_same_seed(self, batch_size, num_workers):
+        seed = 12
+        map_dataset = InMemoryMapDataset(100)
+        results = []
+
+        for run in range(4):
+            dataloader = ReproducibleDataLoader(
+                map_dataset, batch_size=2, shuffle=True, num_workers=4, seed=seed
+            )
+            for idx, batch in enumerate(dataloader):
+                assert_expected(dataloader.sampler.seed, seed)
+                if run == 0:
+                    results.append(batch)
+                else:
+                    assert_expected(results[idx], batch)
+
+    @pytest.mark.parametrize("num_workers", [0, 2])
+    def test_map_dataset_across_epoch_shuffle_data(self, num_workers):
+        dataset_size, batch_size = 100, 2
+        map_dataset = InMemoryMapDataset(dataset_size)
+        results = []
+        compare = []
+
+        dataloader = ReproducibleDataLoader(
+            map_dataset,
+            batch_size=batch_size,
+            shuffle=True,
+            num_workers=num_workers,
+            seed=None,
+            collate_fn=lambda x: x,
+        )
+        for run in range(4):
+            for idx, batch in enumerate(dataloader):
+                if run == 0:
+                    results.append(batch)
+                else:
+                    compare.append(batch)
+            if run > 0:
+                assert results != compare
+                assert len(compare) == len(results) == (dataset_size // batch_size)
+                compare = []
+
+    @pytest.mark.parametrize("shuffle", [False, True])
+    def test_map_dataset_order_with_no_fixed_seed(self, shuffle):
+        dataset_size = 100
+        map_dataset = InMemoryMapDataset(dataset_size)
+        results = []
+        compare = []
+
+        seed = None
+        for run in range(4):
+            dataloader = ReproducibleDataLoader(map_dataset, shuffle=shuffle)
+            for idx, batch in enumerate(dataloader):
+                if run == 0:
+                    results.append(batch)
+                else:
+                    compare.append(batch)
+            if run > 0:
+                if shuffle:
+                    assert results != compare
+                else:
+                    assert results == compare
+                assert len(compare) == len(results) == dataset_size
+                compare = []
+
+    def test_iterable_dataset(self):
+        # For now make sure initialization with iterable dataset fails
+        with pytest.raises(ValueError):
+            iterable_dataset = DummyIterableDataset(100)
+            dataloader = ReproducibleDataLoader(iterable_dataset)

--- a/tests/torchtune/utils/__init__.py
+++ b/tests/torchtune/utils/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torch.utils.data import Dataset
 
 from .alpaca import AlpacaDataset

--- a/torchtune/datasets/alpaca.py
+++ b/torchtune/datasets/alpaca.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import List, Tuple
 
 from datasets import load_dataset

--- a/torchtune/trainer/__init__.py
+++ b/torchtune/trainer/__init__.py
@@ -3,3 +3,5 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from .reproducible_dataloader import ReproducibleDataLoader

--- a/torchtune/trainer/reproducible_dataloader.py
+++ b/torchtune/trainer/reproducible_dataloader.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Iterable, Optional, Union
+
+import torch
+from torch.utils.data import (
+    DataLoader,
+    Dataset,
+    DistributedSampler,
+    IterableDataset,
+    Sampler,
+)
+from torch.utils.data.dataloader import _get_distributed_settings
+
+
+class ReproducibleDataLoader(DataLoader):
+    """
+    A version of :class:`~torch.utils.data.DataLoader` that supports
+    reproducing the order of iteration over the dataset and shuffling the
+    iteration order across epoch boundaries through the ``seed`` parameter.
+    This provides repeatibility in dataloading and transforms executed in dataloader workers.
+
+    [Typical usage] If users don't pass in a sampler, then :class:`~torch.utils.
+    data.DistributedSampler` is used and its `set_epoch` method is called every time iter is called on the `DataLoader.
+
+    If users provide a custom sampler, then the sampler will be used as is and
+    user is responsible for managing that sampler, including setting epoch. No
+    reproducibility is guaranteed in this case.
+
+    See :class:`~torch.utils.data.DataLoader` for arguments except ``seed``
+
+    Args:
+        seed (int, optional): Seed used to initialize a :class:`~torch.utils.
+        data.DistributedSampler` sampler if no custom sampler is provided by the
+        user. If no generator is provided, seed is also used to set the
+        base_seed for all dataloader workers to ensure transforms are
+        repeatable. If no seed is provided, a random number is used as the seed.
+        (default: ``None``)
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        shuffle: Optional[bool] = None,
+        sampler: Union[Sampler, Iterable, None] = None,
+        drop_last: bool = False,
+        generator=None,
+        *args,
+        seed: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Raises:
+        ValueError: if dataset is IterableDataset
+        """
+        if isinstance(dataset, IterableDataset):
+            raise ValueError("ReproducibleDataLoader only supports Map style datasets.")
+
+        self._epoch = 0
+        self._is_custom_sampler = sampler is not None
+        # If seed is not set, set it to a random number
+        if seed is None:
+            seed = torch.empty((), dtype=torch.int64).random_().item()
+        # TODO: Log the seed value for debugging purposes
+
+        # Use the seed as base_seed for all workers to ensure transforms are repeatible
+        if generator is None:
+            generator = torch.Generator()
+            generator.manual_seed(seed)
+
+        world_size, rank = _get_distributed_settings()
+        if not self._is_custom_sampler:
+            # For map-style dataset, use DistributedSampler that ensures that
+            # seed can be provided and shuffling order can be different at
+            # epoch intervals
+            sampler = DistributedSampler(
+                dataset,
+                num_replicas=world_size,
+                rank=rank,
+                shuffle=shuffle,
+                seed=seed,
+                drop_last=drop_last,
+            )
+            # Shuffle can't be set if a sampler is provided to DataLoader
+            shuffle = None
+
+        super().__init__(
+            dataset=dataset,
+            shuffle=shuffle,
+            sampler=sampler,
+            drop_last=drop_last,
+            generator=generator,
+            *args,
+            **kwargs,
+        )
+
+    def __iter__(self):
+        # For every iterator creation, need to set the epoch for the sampler
+        # if it is a DistributedSampler to ensure shuffling order is different # across epochs.
+        #
+        # Note: This is making an assumption that every time an iterator is
+        # created, it is start of a new epoch.
+        if not self._is_custom_sampler and isinstance(self.sampler, DistributedSampler):
+            self.sampler.set_epoch(self._epoch)
+            self._epoch += 1
+        return super().__iter__()

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Addressing issue https://github.com/pytorch-labs/torchtune/issues/55

Without this change, a random seed is used for shuffling and a new random number is generated every epoch. 

Instead with this change, the user can control the seed that is used for:
i) Shuffling - order changes every epoch if desired by the user but the run is repeatable by using the same seed
ii) Transforms that uses the RNG state is also derived from the seed that is set
