### PR TITLE
Lint on 3.11 only

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR removes the lint job on Python 3.10 (since 3.11 should be enough).

If this was discussed already, definitely feel free to close this PR.


BTW, slightly related @rohan-varma @ebsmothers : The tests currently run on 3.10 and 3.11. The next Pytorch release will run on 3.8-3.11. The following one will probably be 3.8 - 3.12 (perhaps 3.8 will be dropped, I'm not sure). Should we test against these Python versions as well? It is rare, but not too uncommon either to have failures that are specific to one Python version, especially when dependencies are involved. Whether we want them on the CI on each PR is up for discussion, that being said, we should absolutely be testing all these versions before a release.