### PR TITLE
Add basic doc build CI job

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -38,3 +38,7 @@ jobs:
         run: |
           cd docs
           make html
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Built-Docs
+          path: docs/build/html/


### PR DESCRIPTION
This PR adds a basic doc build job - see `Build Docs / build_docs` below.

To see the build logs: just click on the  `Build Docs / build_docs`  and then on the "Build docs" part.

To download the generated docs (html files): 

- Go to "Summary"

![image](https://github.com/pytorch-labs/torchtune/assets/1190450/d88cd49f-37f2-426b-917a-cb480169aec7)




- Download zip file in the Artifacts section
![image](https://github.com/pytorch-labs/torchtune/assets/1190450/11b42ae6-18d8-4d54-a23a-fc2ee156fe67)






**Still TODO, for other PRS:** We should have a nice way to visualize the generated docs from the PR, without having to download and decompress the whole zip. Not too sure how to set that up right now, we'll probably have to upload those docs somewhere and make that link accessible.