### PR TITLE
[RFC] Proposed design for LoRA integration (very hacky, please read description first)

### DIFF
--- a/torchtune/models/llama2/transformer.py
+++ b/torchtune/models/llama2/transformer.py
@@ -10,9 +10,36 @@ import torch
 
 from torch import nn, Tensor
 
-from torchtune.models.llama2.attention import LlamaSelfAttention
-from torchtune.models.llama2.feed_forward import FeedForward
+from torchtune.models.llama2.attention import llama_self_attention, LlamaSelfAttention
+from torchtune.models.llama2.feed_forward import FeedForward, llama_feedforward
 from torchtune.models.llama2.rms_norm import RMSNorm
+
+
+def llama_transformer_decoder_layer(
+    embed_dim: int,
+    num_heads: int,
+    max_seq_len: int = 4096,
+    num_kv_heads: Optional[int] = None,
+    attn_dropout: float = 0.0,
+    max_batch_size: Optional[int] = None,
+):
+    self_attention = llama_self_attention(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        max_seq_len=max_seq_len,
+        attn_dropout=attn_dropout,
+        max_batch_size=max_batch_size,
+    )
+    mlp = llama_feedforward(dim=embed_dim, hidden_dim=embed_dim)
+    attn_norm = RMSNorm(dim=embed_dim)
+    ff_norm = RMSNorm(dim=embed_dim)
+    return TransformerDecoderLayer(
+        self_attention=self_attention,
+        mlp=mlp,
+        attn_norm=attn_norm,
+        ff_norm=ff_norm,
+    )
 
 
 class TransformerDecoderLayer(nn.Module):
@@ -23,18 +50,10 @@ class TransformerDecoderLayer(nn.Module):
         2) Normalization is applied before the attention and FF layer
 
     Args:
-        embed_dim (int): embedding dimension for the model
-        num_heads (int): number of query heads. To enable MHA, set
-            ```num_kv_heads``` = ```num_heads``` or ```num_kv_heads``` = None
-        max_seq_len (int): maximum sequence length supported by the model.
-            This is needed to compute the RoPE Cache. Default value is 4096
-        num_kv_heads (Optional[int]): number of key and value heads. User should
-            ensure `num_heads` % `num_kv_heads` == 0. Default value is None, in
-            which case this is the same as MHA
-        attn_dropout (float): dropout value passed onto the
-            scaled_dot_product_attention function. This argument is ignored if the
-            self.training is False. Default value is 0.0
-        max_batch_size (Optional[int]): max batch size
+        self_attention (LlamaSelfAttention):
+        feedforward (FeedForward):
+        self_attention_norm (RMSNorm):
+        feedforward_norm (RMSNorm):
 
     Implementation Note:
         Arg values (eg: attn_dropout) are checked for correctness (eg: belongs to [0,1])
@@ -44,29 +63,20 @@ class TransformerDecoderLayer(nn.Module):
 
     def __init__(
         self,
-        embed_dim: int,
-        num_heads: int,
-        max_seq_len: int = 4096,
-        num_kv_heads: Optional[int] = None,
-        attn_dropout: float = 0.0,
-        max_batch_size: Optional[int] = None,
+        self_attention: LlamaSelfAttention,
+        feedforward: FeedForward,
+        self_attention_norm: RMSNorm,
+        feedforward_norm: RMSNorm,
     ) -> None:
         super().__init__()
         self.max_batch_size = max_batch_size
         # norm applied before self-attention
-        self.attn_norm = RMSNorm(dim=embed_dim)
-        self.attn = LlamaSelfAttention(
-            embed_dim=embed_dim,
-            num_heads=num_heads,
-            num_kv_heads=num_kv_heads,
-            max_seq_len=max_seq_len,
-            attn_dropout=attn_dropout,
-            max_batch_size=max_batch_size,
-        )
+        self.attn_norm = self_attention_norm
+        self.attn = self_attention
 
         # norm applied before the feedforward layer
-        self.ff_norm = RMSNorm(dim=embed_dim)
-        self.mlp = FeedForward(dim=embed_dim, hidden_dim=embed_dim)
+        self.ff_norm = feedforward_norm
+        self.mlp = feedforward
 
     def forward(
         self,
@@ -107,6 +117,39 @@ class TransformerDecoderLayer(nn.Module):
         return out
 
 
+def llama_transformer_decoder(
+    vocab_size: int,
+    embed_dim: int,
+    # transformer layer params
+    num_layers: int,
+    num_heads: int,
+    max_seq_len: int = 4096,
+    num_kv_heads: Optional[int] = None,
+    attn_dropout: float = 0.0,
+    # RMS Norm params
+    norm_eps: float = 1e-6,
+    max_batch_size: Optional[int] = None,
+):
+    token_embeddings = nn.Embedding(vocab_size, embed_dim)
+    layer = TransformerDecoderLayer(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        max_seq_len=max_seq_len,
+        attn_dropout=attn_dropout,
+        max_batch_size=self.max_batch_size,
+    )
+    norm = RMSNorm(embed_dim, eps=norm_eps)
+    output = nn.Linear(embed_dim, vocab_size, bias=False)
+    return TransformerDecoder(
+        token_embeddings=token_embeddings,
+        layer=layer,
+        num_layers=num_layers,
+        norm=norm,
+        output=output,
+    )
+
+
 class TransformerDecoder(nn.Module):
     """
     Transformer Decoder used by the Llama2 model. This has a few
@@ -115,22 +158,11 @@ class TransformerDecoder(nn.Module):
         2) Normalization is applied before the attention and FF layer
 
     Args:
-        vocab_size (int): Size of the vocabulary supported by the model. This
-            controls the number of rows in the embedding table
-        embed_dim (int): embedding dimension for the model
-        num_layers (int): number of TransformerDecoderLayers
-        num_heads (int): number of query heads. To enable MHA, set
-            ```num_kv_heads``` = ```num_heads``` or ```num_kv_heads``` = None
-        max_seq_len (int): maximum sequence length supported by the model.
-            This is needed to compute the RoPE Cache. Default value is 4096
-        num_kv_heads (Optional[int]): number of key and value heads. User should
-            ensure `num_kv_heads` % `num_heads` == 0. Default value is None, in
-            which case this is the same as MHA
-        attn_dropout (float): dropout value passed onto the
-            scaled_dot_product_attention function. This argument is ignored if the
-            self.training is False. Default value is 0.0
-        norm_eps (float): eps value of for RMS Norm
-        max_batch_size (Optional[int]): max batch size
+        token_embeddings (nn.Embedding):
+        layer (TransformerDecoderLayer):
+        num_layers (int):
+        norm (RMSNorm):
+        output (nn.Linear):
 
     TODO: A few TODOs
             - Make norm configurable
@@ -139,40 +171,25 @@ class TransformerDecoder(nn.Module):
 
     def __init__(
         self,
-        # embedding params
-        vocab_size: int,
-        embed_dim: int,
-        # transformer layer params
+        token_embeddings: nn.Embedding,
+        layer: TransformerDecoderLayer,
         num_layers: int,
-        num_heads: int,
-        max_seq_len: int = 4096,
-        num_kv_heads: Optional[int] = None,
-        attn_dropout: float = 0.0,
-        # RMS Norm params
-        norm_eps: float = 1e-6,
-        max_batch_size: Optional[int] = None,
+        norm: RMSNorm,
+        output: nn.Linear,
     ) -> None:
         super().__init__()
         self.max_batch_size = max_batch_size
 
         self.max_seq_len = max_seq_len
-        self.tok_embeddings = nn.Embedding(vocab_size, embed_dim)
+        self.tok_embeddings = token_embeddings
 
         self.layers = torch.nn.ModuleList()
-        for _ in range(num_layers):
-            self.layers.append(
-                TransformerDecoderLayer(
-                    embed_dim=embed_dim,
-                    num_heads=num_heads,
-                    num_kv_heads=num_kv_heads,
-                    max_seq_len=max_seq_len,
-                    attn_dropout=attn_dropout,
-                    max_batch_size=self.max_batch_size,
-                )
-            )
 
-        self.norm = RMSNorm(embed_dim, eps=norm_eps)
-        self.output = nn.Linear(embed_dim, vocab_size, bias=False)
+        for _ in range(num_layers):
+            self.layers.append(layer)
+
+        self.norm = norm
+        self.output = output
 
     def forward(self, tokens: Tensor, curr_pos: int = 0) -> Tensor:
         """

--- a/torchtune/modules/__init__.py
+++ b/torchtune/modules/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtune/modules/peft/__init__.py
+++ b/torchtune/modules/peft/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtune/modules/peft/lora.py
+++ b/torchtune/modules/peft/lora.py
@@ -1,0 +1,205 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtune.models.llama2.attention import LlamaSelfAttention
+
+
+class LoRALinear(nn.Module):
+    def __init__(
+        self,
+        in_dim: int,
+        rank: int,
+        out_dim: int,
+        alpha: float,
+        use_bias: bool = False,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.rank = rank
+        self.alpha = alpha
+        self.out_dim = out_dim
+        self.linear = nn.Linear(in_features=in_dim, out_features=out_dim)
+        self.lora_a = nn.Linear(in_features=in_dim, out_features=rank, bias=use_bias)
+        self.lora_b = nn.Linear(in_features=rank, out_features=out_dim, bias=use_bias)
+
+    def forward(self, x: Tensor) -> Tensor:
+        out = self.linear(x)
+        out = self.dropout(out)
+        lora_out = self.lora_a(x)
+        lora_out = (alpha / r) * self.lora_b(lora_out)
+        return out + lora_out
+
+
+# Note: we can also use dataclass to simplify passing LoRA args around
+def llama_lora_self_attention(
+    self,
+    embed_dim: int,
+    num_heads: int,
+    lora_rank: int,
+    lora_alpha: float,
+    max_seq_len: int = 4096,
+    num_kv_heads: Optional[int] = None,
+    attn_dropout: float = 0.0,
+    max_batch_size: Optional[int] = None,
+    lora_use_bias: bool = False,
+    lora_dropout: float = 0.0,
+):
+
+    # Output dimension of the qkv projection matrix depends on the
+    # total number of heads and the dimension of each head.
+    # For MHA this is simply 3 * embed_dim since num_kv_heads = num_heads
+    head_dim = embed_dim // num_heads
+    qkv_dim = (num_heads + 2 * num_kv_heads) * head_dim
+
+    qkv_proj = LoRALinear(
+        embed_dim, lora_rank, qkv_dim, lora_alpha, lora_use_bias, lora_dropout
+    )
+    output_proj = LoRALinear(
+        embed_dim, lora_rank, embed_dim, lora_alpha, lora_use_bias, lora_dropout
+    )
+
+    # Build the RoPE cache
+    rope_embeddings = RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len)
+
+    qkv_proj = nn.Linear(embed_dim, qkv_dim, bias=False)
+    rope_embeddings = RotaryPositionalEmbeddings(embed_dim)
+    sdpa = nn.functional.scaled_dot_product_attention
+    return LlamaSelfAttention(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        qkv_proj=qkv_proj,
+        out_proj=out_proj,
+        rope_embeddings=rope_embeddings,
+        sdpa=sdpa,
+        max_seq_len=max_seq_len,
+        num_kv_heads=num_kv_heads,
+        attn_dropout=attn_dropout,
+        max_batch_size=max_batch_size,
+    )
+
+
+# Note that some LoRA configs do not even apply to FFN
+# In that case we can just use llama_feedforward directly
+def llama_lora_feedforward(
+    dim: int,
+    hidden_dim: int,
+    lora_rank: int,
+    lora_alpha: float,
+    multiple_of: int = 256,
+    num_kv_heads: Optional[int] = None,
+    attn_dropout: float = 0.0,
+    max_batch_size: Optional[int] = None,
+    lora_use_bias: bool = False,
+    lora_dropout: float = 0.0,
+):
+
+    # TODO: if we go this route and have this calculation in a bunch of places
+    # just make it a util
+    hidden_dim = 4 * int(2 * hidden_dim / 3)
+    hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+
+    w1 = nn.LoRALinear(
+        dim, lora_rank, hidden_dim, lora_alpha, bias=lora_use_bias, dropout=lora_dropout
+    )
+    w2 = nn.LoRALinear(
+        hidden_dim, lora_rank, dim, lora_alpha, bias=lora_use_bias, dropout=lora_dropout
+    )
+    w3 = nn.Linear(
+        dim, lora_rank, hidden_dim, lora_alpha, bias=lora_use_bias, dropout=lora_dropout
+    )
+    activation = F.silu
+    return FeedForward(linear1=w1, linear2=w2, linear3=w3, activation=activation)
+
+
+# Q: should we expose these params at all levels of builder functions?
+def llama_lora_transformer_decoder_layer(
+    # Should also follow Nicolas's suggestion and go the keywords-only route here
+    embed_dim: int,
+    num_heads: int,
+    lora_rank: int,
+    lora_alpha: float,
+    max_seq_len: int = 4096,
+    num_kv_heads: Optional[int] = None,
+    attn_dropout: float = 0.0,
+    max_batch_size: Optional[int] = None,
+    lora_use_bias: bool = False,
+    lora_dropout: float = 0.0,
+):
+    self_attention = llama_lora_self_attention(
+        embed_dim,
+        num_heads,
+        lora_rank,
+        lora_alpha,
+        max_seq_len,
+        num_kv_heads,
+        attn_dropout,
+        max_batch_size,
+        lora_use_bias,
+        lora_dropout,
+    )
+    mlp = llama_lora_feedforward(
+        embed_dim,
+        embed_dim,
+        lora_rank,
+        lora_alpha,
+        num_kv_heads,
+        attn_dropout,
+        max_batch_size,
+        lora_use_bias,
+        lora_dropout,
+    )
+    attn_norm = RMSNorm(dim=embed_dim)
+    ff_norm = RMSNorm(dim=embed_dim)
+    return TransformerDecoderLayer(
+        self_attention=self_attention,
+        mlp=mlp,
+        attn_norm=attn_norm,
+        ff_norm=ff_norm,
+    )
+
+
+def llama_lora_transformer_decoder(
+    vocab_size,
+    embed_dim,
+    # transformer layer params
+    num_layers,
+    num_heads,
+    max_seq_len,
+    # RMS Norm params
+    norm_eps,
+    lora_rank: int,
+    lora_alpha: float,
+    num_kv_heads: Optional[int] = None,
+    attn_dropout: float = 0.0,
+    max_batch_size: Optional[int] = None,
+    lora_use_bias: bool = False,
+    lora_dropout: float = 0.0,
+):
+    token_embeddings = nn.Embedding(vocab_size, embed_dim)
+    layer = llama_lora_transformer_decoder_layer(
+        embed_dim,
+        num_heads,
+        lora_rank,
+        lora_alpha,
+        max_seq_len,
+        num_kv_heads,
+        attn_dropout,
+        max_batch_size,
+        num_kv_heads,
+        attn_dropout,
+        max_batch_size,
+        lora_use_bias,
+        lora_dropout,
+    )
+    norm = RMSNorm(embed_dim, eps=norm_eps)
+    output = nn.Linear(embed_dim, vocab_size, bias=False)
+    return TransformerDecoder(
+        token_embeddings=token_embeddings,
+        layer=layer,
+        num_layers=num_layers,
+        norm=norm,
+        output=output,
+    )


### PR DESCRIPTION
This PR contains a very hacky set of changes meant to illustrate the general idea of our proposal for LoRA (and more general PEFT) integration into torchtune components, which is outlined below. The code changes are intended for illustrative purposes with no plans of landing, so please don't worry about incorrectness/lack of documentation/general messiness.

**TLDR**: we can parametrize lower-level components in our nn.Modules, then write builders for specific instantiations. This way we still achieve configurability of different PEFT methods, but via composability (i.e. not via deeply embedded configs, inheritance, or excessive copy-pasting), and we balance that with providing general components with clear contracts.

Taking `LlamaSelfAttention` as an example:

```
# First generalize LlamaSelfAttentionModule class to take in nn.Modules
class LlamaSelfAttention(nn.Module):
    def __init__(
        self,
        qkv_proj: nn.Module,
        output_proj: nn.Module,
    ...
    ):
        self.qkv_proj = qkv_proj
        self.output_proj = output_proj
        ...

    def forward(...):
        # normal forward logic here

# Now the canonical LLaMA self-attention can be constructed via a builder function
def llama_self_attention(
    embed_dim: int,
    qkv_dim: int, 
    ... # other primitive args go here
):
    qkv_proj = nn.Linear(embed_dim, qkv_dim)
    output_proj = nn.Linear(embed_dim, embed_dim)
    return LlamaSelfAttention(
        qkv_proj=qkv_proj,
        output_proj=output_proj,
        ...
    )

# But we can also easily construct a LoRA version from the same class
# using our own lower-level modules
def llama_lora_self_attention(
    embed_dim: int,
    qkv_dim: int, 
    ... # other primitive args go here
):
    # LoRALinear defined as a standalone module (see e.g. lit-gpt codebase)
    # Has same forward signature as nn.Linear
    qkv_proj = LoRALinear(embed_dim, qkv_dim)
    output_proj = LoRALinear(embed_dim, embed_dim)
    return LlamaSelfAttention(
        qkv_proj=qkv_proj,
        output_proj=output_proj,
        ...
    )
```

This is illustrative of the self-attention module, but we can bubble up this parametrization to higher-level modules as well (see the changes in the PR for one version of what this can look like).

## Why do things this way/what are the alternatives?

### Alternative 1 (the HF PEFT approach): 
PEFT performs module swapping based on a base model class determined by a PEFT config object. E.g. for LoRA the logic to create new LoRA modules and replace existing layers can be found [here](https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora/model.py#L132-L212). 

**Pros**: it is easy for a user to load a pretrained model and modify it to apply a pretty wide range of configurations using the [LoRAConfig](https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora/config.py#L45) object. PEFT also provides a more general [inject_adapter_in_model](https://github.com/huggingface/peft/blob/482a2a6d9aaa01d534b1240e8c1ab6d346eb278f/src/peft/mapping.py#L136) method for further configurability, but this method only supports adapters that can be inserted into the model in-place.

**Cons**: Users do not always want in-place modification of the model ([e.g.](https://github.com/huggingface/peft/issues/1161)) and there can be challenges with composability ([e.g.](https://github.com/huggingface/peft/issues/1184)). Separately, the design decisions do not align with points (2) and (4) in the design principles outlined in #44. On intrusive configs, see also [this issue](https://github.com/huggingface/peft/issues/1197#issuecomment-1833549090) where PEFT necessitates the usage of configs and so imposes constraints on custom models.


### Alternative 2 (the lit-gpt approach) 

While Hugging Face’s PEFT takes a top-down approach (i.e. model is the entry point with a global config and module swapping is done on the full model class), lit-gpt is more bottoms-up. Imo this is closer to what we want. Adapters are often pretty simple conceptually, and taking a minimal low-level class as our entry point for thinking about them makes more sense than using the full model class with everything underneath that treated as a black box.

**Pros**: No module swapping, bottoms-up design means adding/modifying adapters is less of a black box.

**Cons**: Difficult to extend due to intrusive configs and inheritance. 


### Alternative 3: write everything from scratch.
**Pros**: High level of flexibility, no inheritance.

**Cons**: In the long run this will result in a ton of duplicative code. While it’s good to not pollute e.g. our core TransformerDecoderLayer code with a bunch of branching logic, there is also a cost to copy-pasting 80% of one implementation into another for every minor change. Imo this is what HF does in transformers quite a bit and it makes each model too monolithic. If we want our components to truly be plug-and-play we need to design with that in mind; having a separate class for self-attention under each possible PEFT permutation means we are not stress-testing our components by forcing them to be sufficiently general.

### Alternative 4 (this proposal): focus on modularity of peft-swappable components. 
The claim is that this approach will cover the majority of lego-block replacement cases (i.e. cases where there exists a natural 1:1 correspondence between an original component and its peft replacement) with minimal friction. Of course we still want to support cases beyond this: e.g. [P-Tuning v2](https://arxiv.org/pdf/2110.07602.pdf), where each layer is supplemented with additional embeddings. In that case we shouldn't expect a user to fit their implementation to the existing `TransformerDecoderLayer`, since the concatenation of additional learned embeddings fundamentally changes the module.

**Pros**: Easy experimentation for users. With other approaches a user who wants to write a new adapter either has to (a) write an entirely new model class, (b) integrate within a framework or config system, or (c) inherit from another class. With this approach a user can just write an nn.Module and plug it into the appropriate location.  

**Cons**: A user cannot simply define an arbitrary PEFTConfig object, pass it to a model, and have things (probably) work out. If they are doing something non-standard, they will need to write their own module to do it.

## FAQ

**Why not module swapping?** 

There are multiple reasons, but one big one is that module swapping does not compose well with FSDP. If e.g. I have `FullyShardedDataParallel(MyModel)` and construct `MyPEFTModel` by swapping some modules from `MyModel`, there is no way to know if `MyPEFTModel` respects the boundaries of the FSDP wrapping for `MyModel` (until we try to wrap it and fail). 


**What about loading/saving state dicts?**

This is a challenge for every adapter library. No matter what we will need to maintain a state dict mapping from a PEFT component to the module it is replacing, and likely apply this mapping recursively to a model's submodules (similar to other existing offerings).

**Where do we draw the line on further parametrization?** 
Put another way, when do we need to write a new nn.Module vs generalize an existing module/write builders?

I don’t claim this is a 100% perfect answer, but one piece of guidance is to leave forward more or less the same. If I can generalize a component without modifying the signature (e.g. I have a drop-in TransformerDecoderLayer -> SomePEFTTransformerDecoderLayer with the same forward args) , I should generalize via componentization. If SomePEFTTransformerDecoderLayer takes some additional params that don’t make sense in a general decoder layer, it’s probably time to write a standalone class. (One might be tempted to use kwargs to handle this in full generality, but tbh I don’t recommend it.)

