### PR TITLE
[TorchFix] Use weights_only for load

### DIFF
--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -139,7 +139,7 @@ def main():
 
     device = args.device
     model = get_model(args.model, device, vocab_size=tokenizer.vocab_size)
-    model.load_state_dict(torch.load(args.model_checkpoint))
+    model.load_state_dict(torch.load(args.model_checkpoint, weights_only=True))
     logger(msg=f"Loaded model from {args.model_checkpoint}")
 
     opt = get_optimizer(model, args.optimizer, args.lr)

--- a/scripts/llama2_checkpoint/convert_llama2_to_native.py
+++ b/scripts/llama2_checkpoint/convert_llama2_to_native.py
@@ -66,7 +66,7 @@ def args_7b() -> LlamaArgs:
 
 
 def load_orig_state_dict(path: str) -> Dict[str, Any]:
-    orig_sd = torch.load(path)
+    orig_sd = torch.load(path, weights_only=True)
     return orig_sd
 
 

--- a/scripts/llama2_inference/inference.py
+++ b/scripts/llama2_inference/inference.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         )
 
     # Load state_dict into decoder
-    native_state_dict = torch.load(args.native_checkpoint_path)
+    native_state_dict = torch.load(args.native_checkpoint_path, weights_only=True)
     missing, unexpected = decoder.load_state_dict(native_state_dict, strict=False)
     # Nothing should be missing or unexpected
     assert not missing and not unexpected


### PR DESCRIPTION
`torch.load` without `weights_only` is a potential security issue.

Adding  `weights_only=True` is potentially unsafe correctness-wise if full pickling functionality is needed, but it should be rare.

Similar PR for TorchVision for some discussion around the topic: https://github.com/pytorch/vision/pull/8105