### PR TITLE
Adding Torchfix linter ci

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 # Suggested config from pytorch that we can adapt
-select = B,C,E,F,N,P,T4,W,B9
+select = B,C,E,F,N,P,T4,W,B9,TOR0,TOR1,TOR2
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
         additional_dependencies:
           - flake8-bugbear == 22.4.25
           - pep8-naming == 0.12.1
+          - torchfix
         args: ['--config=.flake8']
 
 -   repo: https://github.com/omnilib/ufmt


### PR DESCRIPTION
#### Changelog
- add torchfix linter to ci from this https://github.com/pytorch-labs/torchtune/issues/110

#### Test plan
- pushed a commit that should hopefully trigger the linter warning, will fix it before landing. In that commit, I tried to reverse some of the changes that @kit1980 had made in the PR here - https://github.com/pytorch-labs/torchtune/pull/108. Then the pre-commit run shows the following linter issue:

./recipes/finetune_llm.py:142:28: TOR102 `torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

Link to the github action that shows this error - https://github.com/pytorch-labs/torchtune/actions/runs/7272455811/job/19814607767
