### PR TITLE
Add `seed` utility

### DIFF
--- a/tests/torchtune/utils/test_env.py
+++ b/tests/torchtune/utils/test_env.py
@@ -6,11 +6,18 @@
 
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+import os
 
+import numpy as np
+import pytest
 import torch
 from torch.distributed import launcher
 from torchtune.utils.device import _get_device_from_env
-from torchtune.utils.env import _get_process_group_backend_from_device, init_from_env
+from torchtune.utils.env import (
+    _get_process_group_backend_from_device,
+    init_from_env,
+    seed,
+)
 
 from tests.test_utils import get_pet_launch_config
 
@@ -76,3 +83,58 @@ class TestEnv:
         device = torch.device("cuda:0")
         pg_backend = _get_process_group_backend_from_device(device)
         assert pg_backend == "nccl"
+
+    def test_seed_range(self) -> None:
+        """
+        Verify that exceptions are raised on input values
+        """
+        with pytest.raises(ValueError, match="Invalid seed value provided"):
+            seed(-1)
+
+        invalid_max = np.iinfo(np.uint64).max
+        with pytest.raises(ValueError, match="Invalid seed value provided"):
+            seed(invalid_max)
+
+        # should not raise any exceptions
+        seed(42)
+
+    def test_deterministic_true(self) -> None:
+        for det_debug_mode, det_debug_mode_str in [(1, "warn"), (2, "error")]:
+            warn_only = det_debug_mode == 1
+            for deterministic in (det_debug_mode, det_debug_mode_str):
+                seed(42, deterministic=deterministic)
+                assert torch.backends.cudnn.deterministic
+                assert not torch.backends.cudnn.benchmark
+                assert det_debug_mode == torch.get_deterministic_debug_mode()
+                assert torch.are_deterministic_algorithms_enabled()
+                assert (
+                    warn_only == torch.is_deterministic_algorithms_warn_only_enabled()
+                )
+                assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":4096:8"
+
+    def test_deterministic_false(self) -> None:
+        for deterministic in ("default", 0):
+            seed(42, deterministic=deterministic)
+            assert not torch.backends.cudnn.deterministic
+            assert torch.backends.cudnn.benchmark
+            assert 0 == torch.get_deterministic_debug_mode()
+            assert not torch.are_deterministic_algorithms_enabled()
+            assert not torch.is_deterministic_algorithms_warn_only_enabled()
+
+    def test_deterministic_unset(self) -> None:
+        det = torch.backends.cudnn.deterministic
+        benchmark = torch.backends.cudnn.benchmark
+        det_debug_mode = torch.get_deterministic_debug_mode()
+        det_algo_enabled = torch.are_deterministic_algorithms_enabled()
+        det_algo_warn_only_enabled = (
+            torch.is_deterministic_algorithms_warn_only_enabled()
+        )
+        seed(42, deterministic=None)
+        assert det == torch.backends.cudnn.deterministic
+        assert benchmark == torch.backends.cudnn.benchmark
+        assert det_debug_mode == torch.get_deterministic_debug_mode()
+        assert det_algo_enabled == torch.are_deterministic_algorithms_enabled()
+        assert (
+            det_algo_warn_only_enabled
+            == torch.is_deterministic_algorithms_warn_only_enabled()
+        )

--- a/torchtune/utils/env.py
+++ b/torchtune/utils/env.py
@@ -6,9 +6,11 @@
 
 import logging
 import os
+import random
 from datetime import timedelta
-from typing import Optional
+from typing import Optional, Union
 
+import numpy as np
 import torch
 from torch.distributed.constants import default_pg_timeout
 
@@ -91,3 +93,50 @@ def init_from_env(
 def _get_process_group_backend_from_device(device: torch.device) -> str:
     """Function that gets the default process group backend from the device."""
     return "nccl" if device.type == "cuda" else "gloo"
+
+
+def seed(seed: int, deterministic: Optional[Union[str, int]] = None) -> None:
+    """Function that sets seed for pseudo-random number generators across commonly used libraries.
+
+    This seeds PyTorch, NumPy, and the python.random module.
+    For more details, see https://pytorch.org/docs/stable/notes/randomness.html.
+
+    Args:
+        seed (int): the integer value seed.
+        deterministic (Optional[Union[str, int]]): Controls determinism settings within PyTorch.
+            If `None`, don't set any PyTorch global values.
+            If "default" or 0, don't error or warn on nondeterministic operations and additionally enable PyTorch CuDNN benchmark.
+            If "warn" or 1, warn on nondeterministic operations and disable PyTorch CuDNN benchmark.
+            If "error" or 2, error on nondeterministic operations and disable PyTorch CuDNN benchmark.
+            For more details, see :func:`torch.set_deterministic_debug_mode` and
+            https://pytorch.org/docs/stable/notes/randomness.html#avoiding-nondeterministic-algorithms.
+
+    Raises:
+        ValueError: If the input seed value is outside the required range.
+    """
+    max_val = np.iinfo(np.uint32).max
+    min_val = np.iinfo(np.uint32).min
+    if seed < min_val or seed > max_val:
+        raise ValueError(
+            f"Invalid seed value provided: {seed}. Value must be in the range [{min_val}, {max_val}]"
+        )
+    _log.debug(f"Setting seed to {seed}")
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    random.seed(seed)
+
+    if deterministic is not None:
+        _log.debug(f"Setting deterministic debug mode to {deterministic}")
+        torch.set_deterministic_debug_mode(deterministic)
+        deterministic_debug_mode = torch.get_deterministic_debug_mode()
+        if deterministic_debug_mode == 0:
+            _log.debug("Disabling cuDNN deterministic mode")
+            torch.backends.cudnn.deterministic = False
+            torch.backends.cudnn.benchmark = True
+        else:
+            _log.debug("Enabling cuDNN deterministic mode")
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+            # reference: https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"


### PR DESCRIPTION
#### Changelog
- This abstracts out a utility function for seeding & determinism.
- Source code and tests copied directly from torchtnt utils: https://github.com/pytorch/tnt/blob/master/torchtnt/utils/env.py#L110-L155 

#### Test plan
```
pytest tests/torchtune/utils/test_env.py
```
