### PR TITLE
Replace `set_rng_seed` with `seed`

### DIFF
--- a/scripts/llama2_inference/inference.py
+++ b/scripts/llama2_inference/inference.py
@@ -13,9 +13,9 @@ from typing import Optional
 
 import torch
 
-from tests.test_utils import set_rng_seed
 from torchtune.models.llama2.tokenizer import Tokenizer
 from torchtune.models.llama2.transformer import TransformerDecoder
+from torchtune.utils.env import seed
 from torchtune.utils.generation import GenerationUtils
 from transformers import LlamaForCausalLM
 
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         tokenizer.encode(prompt, add_eos=False) for prompt in prompts
     ]
 
-    set_rng_seed(0)
+    seed(0)
 
     # --------- Initialize a decoder w/o kv-caching -------- #
     llama_7b_args = args_7b()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,19 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-import random
 import uuid
 from typing import Any, Union
 
 import torch
 import torch.distributed.launcher as pet
 from torch import nn
-
-
-def set_rng_seed(seed):
-    """Sets the seed for random number generators"""
-    torch.manual_seed(seed)
-    random.seed(seed)
 
 
 def init_weights_with_constant(model: nn.Module, constant: float = 1.0) -> None:

--- a/tests/torchtune/datasets/test_reproducible_dataloader.py
+++ b/tests/torchtune/datasets/test_reproducible_dataloader.py
@@ -8,13 +8,14 @@ import pytest
 
 from torch.utils.data import Dataset, IterableDataset
 from torchtune.trainer import ReproducibleDataLoader
+from torchtune.utils.env import seed
 
-from tests.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected
 
 
 @pytest.fixture(autouse=True)
 def random():
-    set_rng_seed(7)
+    seed(7)
 
 
 class InMemoryMapDataset(Dataset):

--- a/tests/torchtune/generation/test_generation.py
+++ b/tests/torchtune/generation/test_generation.py
@@ -10,14 +10,15 @@ import pytest
 
 import torch
 from torchtune.models.llama2.transformer import TransformerDecoder
+from torchtune.utils.env import seed
 from torchtune.utils.generation import GenerationUtils
 
-from tests.test_utils import assert_expected, init_weights_with_constant, set_rng_seed
+from tests.test_utils import assert_expected, init_weights_with_constant
 
 
 @pytest.fixture(autouse=True)
 def set_seed():
-    set_rng_seed(42)
+    seed(42)
 
 
 _test_pad_id = -1

--- a/tests/torchtune/models/llama2/test_attention.py
+++ b/tests/torchtune/models/llama2/test_attention.py
@@ -12,13 +12,14 @@ import torch
 from torch import Tensor
 
 from torchtune.models.llama2.attention import LlamaSelfAttention
+from torchtune.utils.env import seed
 
-from tests.test_utils import assert_expected, fixed_init_model, set_rng_seed
+from tests.test_utils import assert_expected, fixed_init_model
 
 
 @pytest.fixture(autouse=True)
 def random():
-    set_rng_seed(16)
+    seed(16)
 
 
 class TestLlamaSelfAttention:

--- a/tests/torchtune/models/llama2/test_feed_forward.py
+++ b/tests/torchtune/models/llama2/test_feed_forward.py
@@ -9,17 +9,17 @@ from typing import Tuple
 import pytest
 
 import torch
-
 from torch import Tensor
 
 from torchtune.models.llama2.feed_forward import FeedForward
+from torchtune.utils.env import seed
 
-from tests.test_utils import assert_expected, fixed_init_model, set_rng_seed
+from tests.test_utils import assert_expected, fixed_init_model
 
 
 @pytest.fixture(autouse=True)
 def random():
-    set_rng_seed(0)
+    seed(0)
 
 
 class TestFeedForward:

--- a/tests/torchtune/models/llama2/test_position_embeddings.py
+++ b/tests/torchtune/models/llama2/test_position_embeddings.py
@@ -11,13 +11,14 @@ import torch
 from torch import tensor
 
 from torchtune.models.llama2.position_embeddings import RotaryPositionalEmbeddings
+from torchtune.utils.env import seed
 
-from tests.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected
 
 
 @pytest.fixture(autouse=True)
 def random():
-    set_rng_seed(0)
+    seed(0)
 
 
 class TestRotaryPositionEmbedding:

--- a/tests/torchtune/models/llama2/test_rms_norm.py
+++ b/tests/torchtune/models/llama2/test_rms_norm.py
@@ -9,13 +9,14 @@ import pytest
 import torch
 from torch.nn.functional import normalize
 from torchtune.models.llama2.rms_norm import RMSNorm
+from torchtune.utils.env import seed
 
-from tests.test_utils import assert_expected, set_rng_seed
+from tests.test_utils import assert_expected
 
 
 @pytest.fixture(autouse=True)
 def random():
-    set_rng_seed(0)
+    seed(0)
 
 
 class TestRMSNorm:

--- a/tests/torchtune/models/llama2/test_transformer_decoder.py
+++ b/tests/torchtune/models/llama2/test_transformer_decoder.py
@@ -16,13 +16,14 @@ from torchtune.models.llama2.transformer import (
     TransformerDecoder,
     TransformerDecoderLayer,
 )
+from torchtune.utils.env import seed
 
-from tests.test_utils import assert_expected, init_weights_with_constant, set_rng_seed
+from tests.test_utils import assert_expected, init_weights_with_constant
 
 
 @pytest.fixture(autouse=True)
 def random():
-    set_rng_seed(16)
+    seed(16)
 
 
 class TestTransformerDecoderLayer:


### PR DESCRIPTION
#### Changelog
- Now that we have `seed` under torchtune.utils, we no longer need `set_rng_seed`
- Replacing `set_rng_seed` with `seed`

#### Test plan
```
 pytest tests/
```
