### PR TITLE
[Resubmit] Add autocast + gradient scaler to finetune script

### DIFF
--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -24,7 +24,11 @@ from torchtune.trainer import ReproducibleDataLoader
 from torchtune.utils import TuneArgumentParser
 from torchtune.utils.batch_pad_sequence import batch_pad_to_longest_seq
 from torchtune.utils.env import init_from_env
-from torchtune.utils.precision import get_autocast_manager, get_grad_scaler
+from torchtune.utils.precision import (
+    get_autocast_manager,
+    get_grad_scaler,
+    get_supported_dtypes,
+)
 from tqdm import tqdm
 
 
@@ -270,11 +274,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--autocast-precision",
         type=str,
-        choices=["fp16", "bf16"],
+        choices=get_supported_dtypes(),
         default=None,
-        help="""Low precision used for CUDA automatic mixed precision.
-            If specified, must be one of fp16 or bf16. --device argument
-            must be CUDA for this to apply.
+        help=f"""Low precision used for CUDA automatic mixed precision.
+            If specified, must be one of {get_supported_dtypes()}.
         """,
     )
 

--- a/tests/torchtune/utils/test_precision.py
+++ b/tests/torchtune/utils/test_precision.py
@@ -10,7 +10,11 @@ import pytest
 import torch
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
-from torchtune.utils.precision import get_autocast_manager, get_grad_scaler
+from torchtune.utils.precision import (
+    get_autocast_manager,
+    get_grad_scaler,
+    get_supported_dtypes,
+)
 
 from tests.test_utils import assert_expected
 
@@ -43,3 +47,6 @@ class TestPrecisionUtils:
                 get_autocast_manager(device_type="cuda", precision=precision),
                 torch.autocast,
             )
+
+    def test_get_supported_dtyes(self):
+        assert set(get_supported_dtypes()) == {"fp16", "bf16", "fp32"}

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -4,25 +4,32 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import ContextManager, Dict, Optional, Union
+from typing import ContextManager, Dict, List, Optional, Union
 
 import torch
 
 from torch.cuda.amp import GradScaler
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
-_type_str_to_dtype: Dict[str, torch.dtype] = {
+_precision_str_to_dtype: Dict[str, torch.dtype] = {
     "fp16": torch.float16,
     "bf16": torch.bfloat16,
     "fp32": None,
 }
 
 
-def _is_unsupported_precision(precision: Optional[str]) -> None:
-    if precision is not None and precision not in _type_str_to_dtype.keys():
+def _validate_precision(precision: Optional[str]) -> None:
+    if precision is not None and precision not in _precision_str_to_dtype.keys():
         raise ValueError(
-            f"`precision` must be one of None, {','.join(_type_str_to_dtype.keys())}."
+            f"`precision` must be one of None, {','.join(_precision_str_to_dtype.keys())}."
         )
+
+
+def get_supported_dtypes() -> List[str]:
+    """
+    Get a list of supported precisions to be used with `torch.autocast`.
+    """
+    return list(_precision_str_to_dtype.keys())
 
 
 def get_grad_scaler(
@@ -37,7 +44,7 @@ def get_grad_scaler(
         Optional[Union[GradScaler, ShardedGradScaler]]: Gradient scaler object if using one of the supported
         precision types, else `None`.
     """
-    _is_unsupported_precision(precision)
+    _validate_precision(precision)
 
     if precision == "fp16":
         return GradScaler(enabled=True) if not fsdp else ShardedGradScaler(enabled=True)
@@ -56,10 +63,10 @@ def get_autocast_manager(device_type: str, precision: Optional[str]) -> ContextM
             `contextlib.nullcontext`.
     """
 
-    _is_unsupported_precision(precision)
+    _validate_precision(precision)
 
     return torch.autocast(
         device_type=device_type,
-        dtype=_type_str_to_dtype.get(precision, None),
+        dtype=_precision_str_to_dtype.get(precision, None),
         enabled=(precision is not None),
     )


### PR DESCRIPTION
Rehash of https://github.com/pytorch-labs/torchtune/pull/99 which got too stale.

#### Changelog
- Adds a precision utils file to handle some str/dtype mapping + retrieving the grad scaler for fp16 autocast cases.
- Adds unittest for the above
- Adds support for ShardedGradScaler when running w/FSDP
- Integrates the above into FT recipe w/--autocast-precision arg
- Moves labels to device + computes loss on device to ensure all computation stays on GPU when GPU is specified.

#### Test plan
- `pytest tests/torchtune/utils/test_precision.py`
- With FSDP: `torchrun --nnodes 1 --nproc_per_node 2 recipes/finetune_llm.py --config recipes/configs/alpaca_llama2_finetune.yaml --autocast-precision fp16 --fsdp True &> out &`
- Local: ` python recipes/finetune_llm.py --config recipes/configs/alpaca_llama2_finetune.yaml &> out &`
