### PR TITLE
In ReproducibleDataLoader set shuffle to None when calling PyTorch DataLoader constructor

### DIFF
--- a/torchtune/trainer/reproducible_dataloader.py
+++ b/torchtune/trainer/reproducible_dataloader.py
@@ -84,12 +84,10 @@ class ReproducibleDataLoader(DataLoader):
                 seed=seed,
                 drop_last=drop_last,
             )
-            # Shuffle can't be set if a sampler is provided to DataLoader
-            shuffle = None
 
         super().__init__(
             dataset=dataset,
-            shuffle=shuffle,
+            shuffle=None,  # shuffle is handled by sampler
             sampler=sampler,
             drop_last=drop_last,
             generator=generator,


### PR DESCRIPTION
#### Changelog
- When calling PyTorch DataLoader constructor, `shuffle` should be set to None since we always have a sampler and the sampler handles shuffling (either user passes in custom sampler or we create DistributedSampler)

#### Test plan
```
pytest tests/torchtune/datasets/test_reproducible_dataloader.py
```
