### PR TITLE
Initial small update to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,29 @@ all of them, you can use a regex like `EXAMPLES_PATTERN="plot_the_best_example*"
 make html`.
 
 If the doc build starts failing for a weird reason, try `make clean`.
+
+### Iterate and Serve docs locally
+
+You can use a combination of a simple python HTTP server and port forwarding to
+serve the docs locally on your machine if you're using a remote machine for development.
+This allows you to iterate on the documentation much more quickly than relying on PR
+previews.
+
+After following the above doc build steps, run the following from the `docs/build/html` folder:
+
+```
+python -m http.server 8000 # or any free port
+```
+
+This will open up a simple HTTP server serving the files in the build directory.
+If this is done on a remote machine, you can set up port forwarding from your local machine
+to access the server, for example:
+
+```
+ssh -L 9000:localhost:8000 $REMOTE_DEV_HOST
+```
+
+Now, you can navigate to `localhost:9000` on your local machine to view the rendered documentation.
+
+To iterate on the documentation, after making your changes, simply run `make html` again (you don't need to bring the server down).
+This will update the documentation after the page is refreshed.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,49 @@
 TorchTune
 =========
 
-Hello.
+This library is part of the `PyTorch
+<http://pytorch.org/>`_ project. PyTorch is an open source
+machine learning framework.
+
+The :mod:`torchtune` package contains tools and utilities to finetune language models
+with native PyTorch techniques.
+
+Model Architectures
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    torchtune.models.llama2.models.llama2_7b
+
+
+Modeling Components and Building Blocks
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    torchtune.models.llama2.transformer.TransformerDecoder
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    torchtune.models.llama2.transformer.TransformerDecoderLayer
 
 .. autosummary::
     :toctree: generated/
     :template: class.rst
 
     torchtune.models.llama2.attention.LlamaSelfAttention
+
+Tokenizers
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    torchtune.models.llama2.models.llama2_tokenizer
 
 
 .. toctree::

--- a/torchtune/models/llama2/models.py
+++ b/torchtune/models/llama2/models.py
@@ -9,6 +9,18 @@ from torchtune.models.llama2.transformer import TransformerDecoder
 
 
 def llama2_7b(vocab_size: int) -> TransformerDecoder:
+    """
+    Returns a `TransformerDecoder` architecture consistent with the
+    Llama2 architecture: https://arxiv.org/abs/2307.09288.
+
+    Args:
+        vocab_size (int): vocabulary size to be used in the language modeling task.
+            This is typically determined from the tokenizer and is typically the
+            number of distinct tokens in the vocabulary.
+
+    Returns:
+        TransformerDecoder: A TransformerDecoder instance consistent with the Llama2 7 billion parameter architecture.
+    """
     return TransformerDecoder(
         vocab_size=vocab_size,
         num_layers=32,
@@ -20,6 +32,14 @@ def llama2_7b(vocab_size: int) -> TransformerDecoder:
 
 
 def llama2_tokenizer(path: str) -> Tokenizer:
+    """
+    Returns a `Tokenizer` instance given a pretrained tokenizer path.
+    Args:
+        path (str): The path to the SentencePiece model file.
+
+    Returns:
+        Tokenizer: A `Tokenizer` instance.
+    """
     tokenizer = Tokenizer.from_file(path)
     # Original tokenizer has no pad_id, which causes indexing errors when batch training
     tokenizer.pad_id = 0

--- a/torchtune/models/llama2/tokenizer.py
+++ b/torchtune/models/llama2/tokenizer.py
@@ -10,7 +10,10 @@ from sentencepiece import SentencePieceProcessor
 
 
 class Tokenizer:
-    """A wrapper around SentencePieceProcessor.
+    """A text tokenizer backed by a `SentencePiece` model.
+
+    NOTE: `Tokenizer` instances are not meant to be directly initialized. Users
+        should use the `from_file` class method to create a `Tokenizer` instance.
 
     Args:
         spm_model (SentencePieceProcessor): The SentencePiece model.

--- a/torchtune/models/llama2/transformer.py
+++ b/torchtune/models/llama2/transformer.py
@@ -19,8 +19,8 @@ class TransformerDecoderLayer(nn.Module):
     """
     Transformer layer used by the Llama2 model. This has a few
     differences compared to the original Transformer architecture.
-        1) Uses RMSNorm instead of LayerNorm
-        2) Normalization is applied before the attention and FF layer
+    1) Uses RMSNorm instead of LayerNorm
+    2) Normalization is applied before the attention and FF layer
 
     Args:
         embed_dim (int): embedding dimension for the model
@@ -111,8 +111,8 @@ class TransformerDecoder(nn.Module):
     """
     Transformer Decoder used by the Llama2 model. This has a few
     differences compared to the original Transformer architecture.
-        1) Uses RMSNorm instead of LayerNorm
-        2) Normalization is applied before the attention and FF layer
+    1) Uses RMSNorm instead of LayerNorm
+    2) Normalization is applied before the attention and FF layer
 
     Args:
         vocab_size (int): Size of the vocabulary supported by the model. This


### PR DESCRIPTION
#### Changelog
- Rendering llama 7b arch, tokenizers, and some more (not all) modeling components in the main index.html documentation. Note that this is not at all meant to get us to a final state or even posit how the documentation should look like in a final state, but rather to get an initial start documenting some existing APIs that we're quite confident we will have (model arches, building blocks, tokenizers) and understand how to render them in documentation. Later PRs can make organizational/structural changes once the layout of our docs is better decided.
- Also add a few docstrings to things that are now rendered.

#### Test plan
- Build docs and view (see README changes for how to do this)

<img width="913" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/8039770/4a6d305c-bd75-403a-8fd8-770134faf3fc">

