### PR TITLE
Update loss values and norm_eps in default llama2 config

### DIFF
--- a/recipes/tests/test_finetune_llm.py
+++ b/recipes/tests/test_finetune_llm.py
@@ -50,10 +50,10 @@ class TestFinetuneLLMRecipe:
             "2|2|": 10.4700,
         }
         llama2_7b_ckpt_loss_values = {
-            "1|1|": 1.3078,
-            "1|2|": 1.2878,
-            "2|1|": 1.1373,
-            "2|2|": 0.8572,
+            "1|1|": 1.3008,
+            "1|2|": 1.3043,
+            "2|1|": 1.1492,
+            "2|2|": 0.9153,
         }
         if ckpt == "small_test_ckpt":
             return small_test_ckpt_loss_values

--- a/torchtune/models/llama2/models.py
+++ b/torchtune/models/llama2/models.py
@@ -15,7 +15,7 @@ def llama2_7b(vocab_size: int) -> TransformerDecoder:
         num_heads=32,
         embed_dim=4096,
         max_seq_len=2048,
-        norm_eps=1e-5,
+        norm_eps=1e-6,
     )
 
 


### PR DESCRIPTION
#### Changelog
- Update loss values and norm_eps in default llama2 config

#### Test plan
- `pytest tests`
- `pytest recipes`
- `pytest recipes --large-scale True`

<img width="1534" alt="Screenshot 2024-01-10 at 5 05 31 PM" src="https://github.com/pytorch-labs/torchtune/assets/20175092/2e893106-ab20-418f-bd05-4661f5bd1539">
[Output of large scale test]
