### PR TITLE
Log generation only on rank 0 for distributed

### DIFF
--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -175,8 +175,12 @@ def recipe(kwargs):
                 generation_str, decoded_tokens = generate_from_prompt(
                     prompt=prompt, tokenizer=tokenizer, decoder=model
                 )
-                logger(f"Generation tokens: {decoded_tokens}")
-                logger(f"Generation: {generation_str}")
+                if (
+                    not torch.distributed.is_initialized()
+                    or torch.distributed.get_rank() == 0
+                ):
+                    logger(f"Generation tokens: {decoded_tokens}")
+                    logger(f"Generation: {generation_str}")
 
         # Save checkpoint at end of each epoch (to be changed later)
         os.makedirs(kwargs["output_dir"], exist_ok=True)


### PR DESCRIPTION
#### Changelog
- Avoids excessive log noise in the case of distributed.

#### Test plan
- Run finetune: 
```
torchrun --nnodes 1 --nproc_per_node 8 recipes/finetune_llm.py --config recipes/configs/alpaca_llama2_finetune.yaml --autocast-precision bf16 --fsdp True --batch-size 1 --run-generation 50 --optimizer AdamW
```
