### PR TITLE
Update max_seq_len to proper 7b default

### DIFF
--- a/torchtune/models/llama2.py
+++ b/torchtune/models/llama2.py
@@ -27,7 +27,7 @@ def llama2_7b() -> TransformerDecoder:
     - num_layers: 32
     - num_heads: 32
     - num_kv_heads: 32
-    - max_seq_len: 2,048
+    - max_seq_len: 4,096
     - norm_eps: 1e-6
 
     Returns:
@@ -39,8 +39,7 @@ def llama2_7b() -> TransformerDecoder:
         num_heads=32,
         num_kv_heads=32,
         embed_dim=4096,
-        # TODO: Change max_seq_len to 4096, which is the default in the original Llama2 implementation
-        max_seq_len=2048,
+        max_seq_len=4096,
         max_batch_size=None,
         attn_dropout=0.0,
         norm_eps=1e-6,


### PR DESCRIPTION
According to https://huggingface.co/meta-llama/Llama-2-7b-hf, the default context length for llama2 7b is 4k. As of #158, max_seq_len is not a part of the state_dict, so we can change this freely. 

#### Changelog
- Change `llama2_7b` max_seq_len to 4k

#### Test plan
- `pytest tests`
- `pytest recipes`


