### PR TITLE
Fix config seed null error

### DIFF
--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -56,7 +56,7 @@ def recipe(kwargs):
 
     # ---- Initialize seed ---- #
     world_size, rank = get_world_size_and_rank()
-    if "seed" in kwargs:
+    if kwargs["seed"] is not None:
         # Ensure that seed is different per rank (and its dataloader workers)
         seed(kwargs["seed"] + rank)
 


### PR DESCRIPTION
#### Changelog
- Without this, we hit an error:

Traceback (most recent call last):
  File "/home/daniellepintz/torchtune/recipes/finetune_llm.py", line 330, in <module>
    sys.exit(recipe(kwargs))
  File "/home/daniellepintz/torchtune/recipes/finetune_llm.py", line 61, in recipe
    seed(kwargs["seed"] + rank)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'

#### Test plan
- Tested using

```tune finetune_llm --config alpaca_llama2_finetune``` and finetune starts without the above error
