### PR TITLE
Skip tests that require >= 2 GPU when 2 GPUs aren't available

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,21 @@ skip_if_cuda_not_available = unittest.skipIf(
     not torch.cuda.is_available(), "CUDA is not available"
 )
 
+from functools import wraps
+
+
+def skip_if_lt_x_gpu(x):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if torch.cuda.is_available() and torch.cuda.device_count() >= x:
+                return func(*args, **kwargs)
+            raise unittest.SkipTest(f"Need {x} CUDA devices to run test.")
+
+        return wrapper
+
+    return decorator
+
 
 def init_weights_with_constant(model: nn.Module, constant: float = 1.0) -> None:
     for p in model.parameters():

--- a/tests/torchtune/utils/test_env.py
+++ b/tests/torchtune/utils/test_env.py
@@ -19,11 +19,11 @@ from torchtune.utils.env import (
     seed,
 )
 
-from tests.test_utils import get_pet_launch_config, skip_if_cuda_not_available
+from tests.test_utils import get_pet_launch_config, skip_if_lt_x_gpu
 
 
 class TestEnv:
-    @skip_if_cuda_not_available
+    @skip_if_lt_x_gpu(2)
     def test_init_from_env_non_zero_device(self) -> None:
         device = init_from_env(device_type="cuda:1")
         assert device == torch.device("cuda:1")
@@ -72,11 +72,13 @@ class TestEnv:
         lc = get_pet_launch_config(num_processes)
         launcher.elastic_launch(lc, entrypoint=self._test_worker_fn)(init_pg_explicit)
 
+    @skip_if_lt_x_gpu(2)
     def test_init_from_env_no_dup(self) -> None:
         self._test_launch_worker(2, init_pg_explicit=False)
         # trivial test case to ensure test passes with no exceptions
         assert True
 
+    @skip_if_lt_x_gpu(2)
     def test_init_from_env_dup(self) -> None:
         self._test_launch_worker(2, init_pg_explicit=True)
         # trivial test case to ensure test passes with no exceptions


### PR DESCRIPTION
#### Changelog
- Some tests in test_env require >= 2 GPUs. Skip these when the resource isn't available.
- This wasn't failing in CI as they were skipped when CUDA wasn't available at all. But some environments CUDA might be available but only 1 GPU. And `test_init_from_env_no_dup` tests weren't failing on CI because they use CPUs in CPU only environment, but again have issues when there is only 1 GPU.

#### Test plan
- Artificially limit to 1 GPU and run tests: `CUDA_VISIBLE_DEVICES='0' pytest tests`
- No GPUs and run tests: `CUDA_VISIBLE_DEVICES='' pytest tests`

Closes https://github.com/pytorch-labs/torchtune/issues/189
