### PR TITLE
Make `get_device_from_env` a public util

### DIFF
--- a/recipes/generate.py
+++ b/recipes/generate.py
@@ -10,7 +10,7 @@ import logging
 import torch
 
 from torchtune.models.llama2.models import llama2_7b, llama2_tokenizer
-from torchtune.utils.env import _get_device_from_env, seed
+from torchtune.utils.env import get_device_from_env, seed
 from torchtune.utils.generation import GenerationUtils
 
 logging.basicConfig(level=logging.INFO)
@@ -48,7 +48,7 @@ if __name__ == "__main__":
 
     seed(0)
 
-    device = _get_device_from_env()
+    device = get_device_from_env()
     # --------- Initialize a decoder w/o kv-caching -------- #
     with device:
         decoder = llama2_7b(vocab_size=tokenizer.vocab_size, max_batch_size=1)

--- a/tests/torchtune/utils/test_device.py
+++ b/tests/torchtune/utils/test_device.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 
 import torch
-from torchtune.utils.device import _get_device_from_env, set_float32_precision
+from torchtune.utils.device import get_device_from_env, set_float32_precision
 
 
 class TestDevice:
@@ -21,7 +21,7 @@ class TestDevice:
 
     @patch("torch.cuda.is_available", return_value=False)
     def test_get_cpu_device(self, _) -> None:
-        device = _get_device_from_env()
+        device = get_device_from_env()
         assert device.type == "cpu"
         assert device.index is None
 
@@ -30,7 +30,7 @@ class TestDevice:
         device_idx = torch.cuda.device_count() - 1
         assert device_idx >= 0
         with mock.patch.dict(os.environ, {"LOCAL_RANK": str(device_idx)}, clear=True):
-            device = _get_device_from_env()
+            device = get_device_from_env()
             assert device.type == "cuda"
             assert device.index == device_idx
             assert device.index == torch.cuda.current_device()
@@ -41,10 +41,10 @@ class TestDevice:
                 RuntimeError,
                 match="The local rank is larger than the number of available GPUs",
             ):
-                device = _get_device_from_env()
+                device = get_device_from_env()
 
         # Test that we fall back to 0 if LOCAL_RANK is not specified
-        device = _get_device_from_env()
+        device = get_device_from_env()
         assert device.type == "cuda"
         assert device.index == 0
         assert device.index == torch.cuda.current_device()

--- a/tests/torchtune/utils/test_env.py
+++ b/tests/torchtune/utils/test_env.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 import torch
 from torch.distributed import launcher
-from torchtune.utils.device import _get_device_from_env
+from torchtune.utils.device import get_device_from_env
 from torchtune.utils.env import (
     _get_process_group_backend_from_device,
     init_from_env,
@@ -34,7 +34,7 @@ class TestEnv:
     def test_init_from_env(self) -> None:
         """Integration test to confirm consistency across device initialization utilities."""
         device = init_from_env()
-        assert device == _get_device_from_env()
+        assert device == get_device_from_env()
         assert not torch.distributed.is_initialized()
 
     @staticmethod
@@ -47,7 +47,7 @@ class TestEnv:
         device = init_from_env()
         if not torch.distributed.is_initialized():
             raise AssertionError("Expected torch.distributed to be initialized")
-        device_from_env = _get_device_from_env()
+        device_from_env = get_device_from_env()
         if device != device_from_env:
             raise AssertionError(
                 f"Expected different device: received {device}, expected {device_from_env}"

--- a/torchtune/utils/device.py
+++ b/torchtune/utils/device.py
@@ -9,7 +9,7 @@ import os
 import torch
 
 
-def _get_device_from_env() -> torch.device:
+def get_device_from_env() -> torch.device:
     """Function that gets the torch.device based on the current environment.
 
     This currently supports only CPU and GPU devices. If CUDA is available, this function also sets the CUDA device.

--- a/torchtune/utils/env.py
+++ b/torchtune/utils/env.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from torch.distributed.constants import default_pg_timeout
 
-from torchtune.utils.device import _get_device_from_env
+from torchtune.utils.device import get_device_from_env
 
 _log: logging.Logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ def init_from_env(
     """
     # Note: This will break when we need to support devices other than {CPU, CUDA}.
     if device_type is None or device_type == "cuda":
-        device = _get_device_from_env()
+        device = get_device_from_env()
     elif device_type == "cpu":
         device = torch.device("cpu")
     elif "cuda:" in device_type:


### PR DESCRIPTION
#### Changelog
- Since we are using it in a recipe now (generate.py)

#### Test plan
- CI
