### PR TITLE
Fix training regression by removing meta device support

### DIFF
--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -79,10 +79,9 @@ def recipe(kwargs):
     )
     grad_scaler = get_grad_scaler(autocast_precision, fsdp=kwargs["fsdp"])
 
-    # When using fsdp, init on meta device to avoid OOM
     model = get_model(
         kwargs["model"],
-        "meta" if kwargs["fsdp"] else device,
+        device,
     )
 
     if kwargs["fsdp"] or kwargs["activation_checkpointing"]:


### PR DESCRIPTION
### Context
- Our current finetuning recipe broke and a few of us @daniellepintz @joecummings spent time debugging it last week. The root cause is meta device and its interaction with FSDP. Concretely, when training with FSDP, we use meta device for initialization. FSDP materializes the model w/garbage values, after which state_dict is loaded and the model has the pretrained values. However, when we landed a PR that set RoPE buffers to non-persistent, they stopped being loaded, leading to RoPE having garbage / un initialized values, breaking the training. 

- This was incredibly tricky to debug and we basically bisected ~8 commits until we found the root cause commit. At this point we confirmed that reverting the commit fixes the training, but weren’t sure if its due to faulty model checkpoint or the commit itself. 

- To mitigate for now, we're just removing meta device support so that the un-checkpointed RoPE buffers are initialized properly, instead of going with the revert in https://github.com/pytorch-labs/torchtune/pull/197. This leads to the RoPE buffers having the correct values to begin with.

#### Changelog
- Remove meta device support from the finetuning recipe.

#### Test plan

- Run on current main (bad): `torchrun --nnodes 1 --nproc_per_node 8 recipes/finetune_llm.py --config recipes/configs/alpaca_llama2_finetune.yaml --autocast-precision bf16 --fsdp True --batch-size 1 --run-generation 50 --optimizer AdamW --model-checkpoint /tmp/llama2-7b-01112024`. Loss logs: https://gist.github.com/rohan-varma/a21f5285d525e52ea7bd3eb7673bb084
- Run on this commint (good): `torchrun --nnodes 1 --nproc_per_node 8 recipes/finetune_llm.py --config recipes/configs/alpaca_llama2_finetune.yaml --autocast-precision bf16 --fsdp True --batch-size 1 --run-generation 50 --optimizer AdamW --model-checkpoint /tmp/llama2-7b-01112024`. Loss logs: https://gist.github.com/rohan-varma/2ff6073413abf986201ae948ce7fd352
- Run on last known good commit (`86c23185f3b1c68d957b08355faceb3562daf784`): `torchrun --nnodes 1 --nproc_per_node 8 recipes/finetune_llm.py --config recipes/configs/alpaca_llama2_finetune.yaml --autocast-precision bf16 --fsdp True --batch-size 1 --run-generation 50 --optimizer AdamW --model-checkpoint /tmp/llama2-7b-01052024`. This requires patching the old commit to seed the distributed sampler. Loss logs: https://gist.github.com/rohan-varma/c2e73089605ab95308d4172a7d798a1a
- Loss logs between (1) and (3) are accurate up to 2 decimal points, giving me confidence that the issue is fixed.
- Ensured RoPE values are the same after init as the 01052024 checkpointed values (saving the tensors after init and comparing to the previous state_dict) - 
<img width="690" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/8039770/0d7560f9-32dc-4ab4-afc4-a60cbdac424a">
The loaded tensors were saved directly from the model after init on this commit:
<img width="585" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/8039770/e67f694f-d1e4-4bc2-b608-50e1fcd2966a">

- checked generation quality (just eyeballing) on models trained with this commit and the last known good commit.
- verified single GPU training does not change before/after this commit (this should also be captured by CI).
