### PR TITLE
Download checkpoints from HF

### DIFF
--- a/scripts/llama2_checkpoint/README.md
+++ b/scripts/llama2_checkpoint/README.md
@@ -23,7 +23,7 @@ Assuming your original checkpoint lives at `path_to_original_checkpoint`, invoki
 `/tmp/native_checkpoints/llama2-{x}b` where x is the model size. Currently, only the 7b parameter model is supported.
 
 ```bash
-cd torchtune # run next command from torchtune root
+cd torchtune
 python -m scripts.llama2_checkpoint.convert_llama2_to_native --checkpoint_path <path_to_original_checkpoint> --device cuda:0
 ```
 


### PR DESCRIPTION
Can also confirm I'm still seeing the OOM running the conversion script issue on A10G with 23GB of VRAM

```
  File "/opt/conda/envs/tune/lib/python3.10/site-packages/torch/utils/_device.py", line 77, in __torch_function__
    return func(*args, **kwargs)
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 172.00 MiB. GPU 0 has a total capacty of 22.19 GiB of which 91.50 MiB is free. Including non-PyTorch memory, this process has 22.09 GiB memory in use. Of the allocated memory 21.81 GiB is allocated by PyTorch, and 5.10 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```