### PR TITLE
Limit CI concurrency per PR

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
+  group: build-docs-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: lint-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/recipe_integration_test.yaml
+++ b/.github/workflows/recipe_integration_test.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: recipe-integration-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: recipe-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
Right now the way the CI is setup means if you make many small commits on a single PR you'll need to run the CI per commit even if that commit is stale. This will be very annoying especially for integration tests where we have limited GPU budget available so this makes sure at most one CI job is queued per workflow per PR

Test been doing this for ages here https://github.com/pytorch/serve/tree/master/.github/workflows and see the canceled jobs like here https://github.com/pytorch-labs/torchtune/actions/runs/7619713483