### PR TITLE
[WIP] checkpoint conversion works on 23GB of VRAM

### DIFF
--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import copy
 from typing import Optional
 
 import torch


### PR DESCRIPTION
Checkpoint conversion was OOMing on 23GB of VRAM primarly because of the way we do correctness checks

Won't land this as is but it's worth considering only enabling correctness checks in CI and disabling them otherwise

I also added some progress bars because otherwise the conversion can take a while and you might think the script is hanging

```
(tune) ubuntu@ip-172-31-36-68:~/torchtune$ python -m scripts.llama2_checkpoint.convert_llama2_to_native --checkpoint_path /home/ubuntu/.cache/huggingface/hub/models--meta-llama--Llama-2-7b/snapshots/1c9f047f0e1dbe2e1be6f15f5107bf9f74bb425f/consolidated.00.pth --device cuda:0
/opt/conda/envs/tune/lib/python3.10/site-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  return self.fget.__get__(instance, owner)()
 77%|█████████████████████████████████████████████████████████████████████████████████████████████████████████▊                                | 224/292 [00:00<00:00, 774.97it/s]WARNING:__main__:Warning: rope.freqs in orig state_dict, but not mapped!
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 292/292 [00:00<00:00, 755.93it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32/32 [00:00<00:00, 103.84it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32/32 [00:00<00:00, 280.28it/s]
INFO:__main__:Wrote native checkpoint to /tmp/native_checkpoints/llama2-7b
```