### PR TITLE
Log loss only on rank 0

### DIFF
--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -105,7 +105,7 @@ def recipe(
     # ---- Train loop ---- #
     for epoch in range(epochs):
         sampler.set_epoch(epoch)  # distributed sampler requires set_epoch
-        for idx, batch in enumerate(pbar := tqdm(dataloader, disable=not(rank==0))):
+        for idx, batch in enumerate(pbar := tqdm(dataloader, disable=not (rank == 0))):
             if max_steps_per_epoch is not None and idx == max_steps_per_epoch:
                 break
             opt.zero_grad()


### PR DESCRIPTION
#### Context

Trying to debug fluctuating loss is really hard since we're logging loss from each rank. Restricting this to only log from rank 0.

#### Changelog
- Disable logs for ranks != 0
- Remove some commented out code

#### Test plan
- Run unit tests (output in screenshot)

<img width="1728" alt="Screenshot 2024-01-22 at 6 50 28 PM" src="https://github.com/pytorch-labs/torchtune/assets/47255723/a9a47666-0a13-4ca9-b393-61f14f5bd3f5">


```
pytest
```

- Kick off fine-tuning run (ongoing run shown in screenshot)

```
torchrun --nnodes 1 --nproc_per_node 8 recipes/finetune_llm.py --config recipes/configs/alpaca_lla
ma2_finetune.yaml --fsdp --batch-size 1 --optimizer AdamW --model-checkpoint /tmp/llama2-7b-01222024 --seed 18
```
<img width="1725" alt="Screenshot 2024-01-22 at 6 52 03 PM" src="https://github.com/pytorch-labs/torchtune/assets/47255723/e04cc5e0-0c30-47a0-b8f9-bbcec5515e60">
