### PR TITLE
Log mean loss instead of per iteration loss

### DIFF
--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -127,7 +127,7 @@ def recipe(
             # TODO: avoid recompute this every iteration as .item() triggers
             # a device sync
             mean_loss = (
-                mean_loss
+                loss.item()
                 if mean_loss is None
                 else (loss.item() + (idx - 1) * mean_loss) / idx
             )


### PR DESCRIPTION
#### Context
- Debugging loss curves / values is harder if we report the loss every iteration, which can fluctuate. Mean loss will likely give us a better understanding of how the loss changes across iterations.

#### Changelog
- Added functionality to compute + log mean_loss in recipe

#### Test plan
- Eyes
