### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,23 @@ pip install -e .
 To confirm that the package is installed correctly, you can run the following command:
 
 ```
-tune
+tune recipe --help
 ```
 
 And should see the following output:
 
 ```
-usage: tune [options] <recipe> [recipe_args]
-tune: error: the following arguments are required: recipe, recipe_args
+usage: tune recipe
+
+Utility for information relating to recipes
+
+positional arguments:
+
+    list      List recipes
+    cp        Copy recipe to local path
+
+options:
+  -h, --help  show this help message and exit
 ```
 
 &nbsp;

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,11 +16,20 @@ To confirm that the package is installed correctly, you can run the following co
 
 .. code-block:: bash
 
-    tune
+    tune recipe --help
 
 And should see the following output:
 
 ::
 
-    usage: tune [options] <recipe> [recipe_args]
-    tune: error: the following arguments are required: recipe, recipe_args
+    usage: tune recipe
+
+    Utility for information relating to recipes
+
+    positional arguments:
+
+        list      List recipes
+        cp        Copy recipe to local path
+
+    options:
+    -h, --help  show this help message and exit


### PR DESCRIPTION
#### Context
Adding installation instructions to the README

#### Changelog
- Update docs to include install instructions
- Update README install instructions to match docs
- Add `torch` as a requirement

#### Test plan
EYES on the following render
<img width="886" alt="Screenshot 2024-01-31 at 2 03 34 PM" src="https://github.com/pytorch-labs/torchtune/assets/20175092/f1338d7f-d652-4069-b3ef-0ff10704d1f8">

I also attempted a clean installation on my Mac and in a new conda environment on my DevGPU
![Screenshot 2024-01-31 at 2 20 56 PM](https://github.com/pytorch-labs/torchtune/assets/20175092/45dbbe38-e7a4-4519-93a3-7e3f7171f02e)

