### PR TITLE
In new recipe, create output dir if not exists

### DIFF
--- a/recipes/full_finetune.py
+++ b/recipes/full_finetune.py
@@ -60,6 +60,8 @@ class FullFinetuneRecipe(FTRecipeInterface):
         self.dtype = utils.get_dtype(dtype=params.dtype)
         self.seed = utils.set_seed(seed=params.seed)
         self.output_dir = params.output_dir
+        # Create output directory if it doesn't exist
+        os.makedirs(self.output_dir, exist_ok=True)
 
         _, rank = utils.get_world_size_and_rank()
         self.is_rank_zero = rank == 0


### PR DESCRIPTION
#### Context
- Useful to create the output dir if it does not exist

#### Changelog
- Create output dir in recipe init if not exists.

#### Test plan
- `torchrun --nnodes 1 --nproc_per_node 8 recipes/full_finetune.py --config recipes/configs/alpaca_llama2_full_finetune.yaml --model-checkpoint /home/rvarm1/local/dev/assets/llama2-7b-01242024 --seed 18 --tokenizer-checkpoint /home/rvarm1/local/dev/assets/tokenizer.model --epochs 1 --max-steps-per-epoch 10 &> out &` doesn't crash when there is no tmp alpaca dir.
