### PR TITLE
Add unittest for distributed dataloader save / resume

### DIFF
--- a/tests/torchtune/utils/test_checkpointable_dataloader.py
+++ b/tests/torchtune/utils/test_checkpointable_dataloader.py
@@ -6,8 +6,11 @@
 
 import pytest
 import torch
+from torch.distributed import launcher
 from torch.utils.data import Dataset, DistributedSampler, IterableDataset
 from torchtune.utils import CheckpointableDataLoader
+
+from tests.test_utils import get_pet_launch_config
 
 
 class _DummyIterableDataset(IterableDataset):
@@ -244,3 +247,61 @@ class TestCheckpointableDataLoader:
             CheckpointableDataLoader._DISTRIBUTED_SAMPLER_SHUFFLE_SEED: 5,
             CheckpointableDataLoader._SKIP_INDEX_KEY: 1,
         }
+
+    def _test_distributed_data_loader_save_load(self) -> None:
+        torch.distributed.init_process_group(backend="gloo")
+        dataset = _IdentityMapDataset(16 * torch.distributed.get_world_size())
+        # Create a sampler and dataloader that we will checkpoint
+        ws, rank = torch.distributed.get_world_size(), torch.distributed.get_rank()
+        sampler = DistributedSampler(
+            dataset, num_replicas=ws, rank=rank, shuffle=True, seed=5
+        )
+        dataloader = CheckpointableDataLoader(
+            dataset,
+            batch_size=1,
+            shuffle=None,
+            sampler=sampler,
+        )
+
+        # Iterate through the DL to save the expected order of samples.
+        dataloader_iterator = iter(dataloader)
+        data_for_rank = []
+        for x in dataloader_iterator:
+            data_for_rank.append(x)
+
+        # Now check if we pause training and restore into a different dataloader, we should get the same data.
+        # Now checkpoint the dataloader in the middle of iterating
+        restore_data_for_rank = []
+        dataloader_iterator = iter(dataloader)
+        for i, x in enumerate(dataloader_iterator):
+            restore_data_for_rank.append(x)
+            if i == 7:
+                break
+        state = dataloader.state_dict()
+
+        # Create a new dataloader / sampler pair and load the state in.
+        restore_sampler = DistributedSampler(
+            dataset, num_replicas=ws, rank=rank, shuffle=True, seed=5
+        )
+        restore_dataloader = CheckpointableDataLoader(
+            dataset,
+            batch_size=1,
+            shuffle=None,
+            sampler=sampler,
+        )
+        restore_dataloader.load_state_dict(state)
+        # Now upon iterating the dataloader, we should resume at the appropriate index and get the same data
+        # as when we did a full iteration before checkpointing.
+        restore_dataloader_iterator = iter(restore_dataloader)
+        for x in restore_dataloader_iterator:
+            restore_data_for_rank.append(x)
+
+        assert (
+            restore_data_for_rank == data_for_rank
+        ), f"mismatch: {data_for_rank} vs {restore_data_for_rank} on {torch.distributed.get_rank()}"
+
+    def test_dist_dataloader_save_load(self) -> None:
+        lc = get_pet_launch_config(nproc=4)
+        launcher.elastic_launch(
+            lc, entrypoint=self._test_distributed_data_loader_save_load
+        )()


### PR DESCRIPTION
#### Context
- We need to ensure our stateful dataloader works in a distributed setting, meaning that each rank resumes correctly with respect to its portion of samples. 

#### Changelog
- Added test to ensure dataloader resume works as expected when restoring into _same_ world size.

#### Test plan
- `pytest tests/torchtune/utils/test_checkpointable_dataloader.py -v -k test_dist_dataloader_save_load`
