### PR TITLE
Mock load_dataset call in slimorca unit test

### DIFF
--- a/tests/torchtune/datasets/test_slimorca_dataset.py
+++ b/tests/torchtune/datasets/test_slimorca_dataset.py
@@ -108,15 +108,15 @@ class TestSlimOrcaDataset:
                 "conversations": [
                     {
                         "from": "system",
-                        "value": "You are an AI assistant. User will you give you a task. Your goal is to complete the task as faithfully as you can. While performing the task think step-by-step and justify your steps.",  # noqa
+                        "value": "You are an AI assistant. User will you give you a task. Your goal is to complete the task as faithfully as you can. While performing the task think step-by-step and justify your steps.",  # noqa: B950
                     },
                     {
                         "from": "human",
-                        "value": "Please briefly summarize this news article:\n\nAOL.com Video - Father Lets 8-Year-Old Drive On Icy Road\n\nDescription:Would you let your 8-year-old drive your car? How about on an icy road? Well one father in Russia did just that, and recorded the entire thing. To her credit, the child seemed to be doing a great job. (0:44)\n\nTags: 8-year-old driver , caught on camera , child driver , pix11\n\nSummary:",  # noqa
+                        "value": "Please briefly summarize this news article:\n\nAOL.com Video - Father Lets 8-Year-Old Drive On Icy Road\n\nDescription:Would you let your 8-year-old drive your car? How about on an icy road? Well one father in Russia did just that, and recorded the entire thing. To her credit, the child seemed to be doing a great job. (0:44)\n\nTags: 8-year-old driver , caught on camera , child driver , pix11\n\nSummary:",  # noqa: B950
                     },
                     {
                         "from": "gpt",
-                        "value": "A father in Russia allowed his 8-year-old child to drive his car on an icy road and recorded the event. The child appeared to be handling the situation well, showcasing their driving skills despite the challenging conditions.",  # noqa
+                        "value": "A father in Russia allowed his 8-year-old child to drive his car on an icy road and recorded the event. The child appeared to be handling the situation well, showcasing their driving skills despite the challenging conditions.",  # noqa: B950
                     },
                 ]
             }


### PR DESCRIPTION
#### Context
- load_dataset call makes network calls to download entire slimorca dataset in test_slimorca_dataset.py unit test. This leads to long runtimes as well as flakiness in testing in CI (https://github.com/pytorch-labs/torchtune/actions/runs/7735460632/job/21091161010?pr=278)

#### Changelog
- Mock load_dataset call to return empty data or mock data as necessary in the unit test methods

#### Test plan
- Existing tests pass. pytest test_slimorca_dataset.py used to take ~15seconds now runs in ~5seconds
