### PR TITLE
Update get_fsdp, rename, add testing

### DIFF
--- a/docs/source/api_ref_utilities.rst
+++ b/docs/source/api_ref_utilities.rst
@@ -15,7 +15,7 @@ Distributed
 
     distributed.init_distributed
     distributed.get_world_size_and_rank
-    distributed.get_fsdp
+    distributed.wrap_fsdp
 
 .. _mp_label:
 

--- a/recipes/finetune_llm.py
+++ b/recipes/finetune_llm.py
@@ -65,7 +65,7 @@ def recipe(
         )
 
     if distributed:  # Use FSDP model for distributed training
-        model = utils.get_fsdp(
+        model = utils.wrap_fsdp(
             model=model,
             device=device,
             dtype=dtype,

--- a/recipes/full_finetune.py
+++ b/recipes/full_finetune.py
@@ -201,7 +201,7 @@ class FullFinetuneRecipe(FTRecipeInterface):
         """
         model = models.get_model(model, device=self._device)
         model = (
-            utils.get_fsdp(
+            utils.wrap_fsdp(
                 model=model,
                 device=self._device,
                 dtype=self._dtype,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+import os
 import sys
 import unittest
 import uuid
@@ -119,6 +120,20 @@ def get_pet_launch_config(nproc: int) -> pet.LaunchConfig:
         max_restarts=0,
         monitor_interval=1,
     )
+
+
+@contextmanager
+def single_box_init():
+    os.environ["MASTER_ADDR"] = "localhost"
+    # TODO: Don't hardcode ports as this could cause flakiness if tests execute
+    # in parallel.
+    os.environ["MASTER_PORT"] = str(12345)
+    os.environ["LOCAL_RANK"] = str(0)
+    torch.distributed.init_process_group(backend="gloo", world_size=1, rank=0)
+    try:
+        yield
+    finally:
+        torch.distributed.destroy_process_group()
 
 
 @contextmanager

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -8,7 +8,7 @@ from .checkpoint import save_checkpoint, transform_opt_state_dict, validate_chec
 from .checkpointable_dataloader import CheckpointableDataLoader
 from .collate import padded_collate
 from .device import get_device
-from .distributed import get_fsdp, get_world_size_and_rank, init_distributed
+from .distributed import get_world_size_and_rank, init_distributed, wrap_fsdp
 from .logging import get_logger
 from .memory import set_activation_checkpointing
 from .metric_logging import get_metric_logger, list_metric_loggers
@@ -24,7 +24,7 @@ __all__ = [
     "get_autocast",
     "get_device",
     "get_dtype",
-    "get_fsdp",
+    "wrap_fsdp",
     "get_gradient_scaler",
     "get_logger",
     "get_world_size_and_rank",

--- a/torchtune/utils/distributed.py
+++ b/torchtune/utils/distributed.py
@@ -7,7 +7,7 @@
 
 import logging
 import os
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, Optional, Set, Tuple, Type
 
 import torch
 import torch.distributed as dist
@@ -98,12 +98,12 @@ def get_world_size_and_rank() -> Tuple[int, int]:
         return 1, 0
 
 
-def get_fsdp(
+def wrap_fsdp(
     model: nn.Module,
     device: torch.device,
     dtype: torch.dtype,
     strategy: Optional[str] = None,
-    auto_wrap_policy: Optional[Set[nn.Module]] = None,
+    auto_wrap_policy: Optional[Set[Type]] = None,
     cpu_offload: bool = False,
     **kwargs
 ) -> nn.Module:
@@ -126,10 +126,19 @@ def get_fsdp(
     Args:
         model (nn.Module): Model to wrap for distributed training.
         device (torch.device): Device for host model.
-        dtype (torch.dtype): dtype used to determine if mixed precision training is used.
-        strategy (Optional[str]): Sharding strategy to use. The main options are (FULL_SHARD, SHARD_GRAD_OP, NO_SHARD)
-        auto_wrap_policy (Optional[Set[nn.Module]]): Set of model blocks to shard for sharding.
-        cpu_offload (bool): Whether to offload sharded parameters to CPU.
+        dtype (torch.dtype): dtype for mixed precision training. FSDP mixed precision will be
+            configured to use this dtype for both computation and communication.
+        strategy (Optional[str]): Sharding strategy to use. Please see
+            torch.distributed.fsdp.ShardingStrategy for options. Default: "FULL_SHARD", which
+            shards parameters, gradients, and optimizer states.
+        auto_wrap_policy (Optional[Set[Type]]): nn.Module types to recursively apply FSDP to. FSDP
+            will wrap each instance of the specified nn.Module type in its own atomic FSDP unit.
+            Please see https://pytorch.org/tutorials/intermediate/FSDP_adavnced_tutorial.html#transformer-wrapping-policy
+            for details.
+            Default: Empty set, meaning that FSDP is only applied to the top level module. In this
+            case, entire model is unsharded during computation and memory is only saved due to
+            sharding optimizer states.
+        cpu_offload (bool): Whether to offload sharded parameters to CPU. Default: False
         **kwargs: additional arguments to pass to FSDP for distributed training.
 
     Returns:
@@ -137,10 +146,14 @@ def get_fsdp(
 
     Raises:
         RuntimeError: If environment not setup for distributed training.
+
+    NOTE:
+        Please use caution if running with cpu_offload=True, as this is known to have
+        significant training performance issues at the moment.
     """
     if dist.is_available() and dist.is_initialized():
         if strategy is None:
-            strategy = "NO_SHARD"
+            strategy = "FULL_SHARD"
         _validate_device_from_env(device)
         wrap_policy = ModuleWrapPolicy(auto_wrap_policy or set())
         mp = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
@@ -152,7 +165,6 @@ def get_fsdp(
             model,
             auto_wrap_policy=wrap_policy,
             device_id=device,
-            param_init_fn=lambda m: m.to_empty(device=device, recurse=False),
             mixed_precision=mp,
             sharding_strategy=_get_sharding_strategy(strategy),
             cpu_offload=CPUOffload(offload_params=True) if cpu_offload else None,


### PR DESCRIPTION
#### Context
- get_fsdp needed a bit of fixing up & doc enhancements, doing so in this PR.

#### Changelog
- Rename get_fsdp -> wrap_fsdp to better indicate model is being wrapped
- Add details on documentation
- fix up some typing
- Remove param_init_fn as we don't yet support meta device, and this is not needed.
- Change default NO_SHARD -> FULL_SHARD to be consistent w/FSDP defaults

#### Test plan
- Added unittest
