### PR TITLE
Enforce PyTorch >= 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The library provides:
 - Support for distributed training using FSDP from PyTorch Distributed
 - Yaml configs for easily configuring training runs
 
+NOTE: TorchTune is currently only tested with the latest stable PyTorch release, which is currently [2.2.0](https://pytorch.org/get-started/locally/).
+
 &nbsp;
 
 | Model                                         | Sizes     |   Finetuning Methods |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install PyTorch
-torch>=2.0.0
+torch>=2.2.0
 
 # HuggingFace Integration Reqs
 datasets==2.15.0


### PR DESCRIPTION
#### Context
- Our finetuning scripts crash on 2.1.0 and work on 2.2.0. Since 2.2.0 is the latest stable version, limiting support (i.e. what we run in CI) to 2.2.0.
- Many developers are developing on nightly, but since this isn't formally in CI, not stating we officially support it.

#### Changelog
- Bump torch to 2.2.0 & reflect in README

#### Test plan
- CI is green
- Fresh install of torchtune from requirements.txt && `pytest` on root directory passes
