### PR TITLE
Add --output-dir to tune download call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Follow the instructions on the official [`meta-llama`](https://huggingface.co/me
 You can find your token at https://huggingface.co/settings/tokens
 
 ```
-tune download --repo-id meta-llama/Llama-2-7b --hf-token <HF_TOKEN>
+tune download --repo-id meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir /tmp/llama2
 ```
 
 &nbsp;


### PR DESCRIPTION
- So users don't have to do extra searching for where their checkpoint might be.

#### Context
- ...

#### Changelog
- ...

#### Test plan
- ....
