### PR TITLE
Add LoRA recipe and config to tune CLI

### DIFF
--- a/recipes/__init__.py
+++ b/recipes/__init__.py
@@ -5,9 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 
-_RECIPE_LIST = ["full_finetune", "alpaca_generate"]
+_RECIPE_LIST = ["full_finetune", "lora_finetune", "alpaca_generate"]
 _CONFIG_LISTS = {
     "full_finetune": ["alpaca_llama2_full_finetune"],
+    "lora_finetune": ["alpaca_llama2_lora_finetune"],
     "alpaca_generate": [],
 }
 


### PR DESCRIPTION
#### Context
- Make these accessible from tune CLI

#### Changelog
- Update recipe list and config list

#### Test plan

```
tune recipe list
full_finetune
lora_finetune
alpaca_generate

tune config list lora_finetune
alpaca_llama2_lora_finetune
```

```
python -m pytest tests/
...
========== 139 passed, 5 warnings in 118.45s (0:01:58) ==============
```
