### PR TITLE
README: 2.2.0 -> 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The library provides:
 - Support for distributed training using FSDP from PyTorch Distributed
 - Yaml configs for easily configuring training runs
 
-NOTE: TorchTune is currently only tested with the latest stable PyTorch release, which is currently [2.2.0](https://pytorch.org/get-started/locally/).
+NOTE: TorchTune is currently only tested with the latest stable PyTorch release, which is currently [2.2](https://pytorch.org/get-started/locally/).
 
 &nbsp;
 


### PR DESCRIPTION
The `.0` part is irrelevant (the release is 2.2, not 2.2.x) and will become outdated in a matter of weeks when the 2.2.1 bugfix release is out. In contrast, the 2.2 release will only become outdated in ~3 months when 2.1 is out.