### PR TITLE
Add LoRA recipe config to test_configs.py

### DIFF
--- a/recipes/tests/configs/test_configs.py
+++ b/recipes/tests/configs/test_configs.py
@@ -7,13 +7,14 @@ import os
 
 import pytest
 
-from recipes.params import FullFinetuneParams
+from recipes.params import FullFinetuneParams, LoRAFinetuneParams
 from torchtune.utils.argparse import TuneArgumentParser
 
 ROOT_DIR: str = os.path.join(os.path.abspath(__file__), "../../../configs")
 
 config_to_params = {
     os.path.join(ROOT_DIR, "alpaca_llama2_full_finetune.yaml"): FullFinetuneParams,
+    os.path.join(ROOT_DIR, "alpaca_llama2_lora_finetune.yaml"): LoRAFinetuneParams,
 }
 
 


### PR DESCRIPTION
#### Changelog
- Add LoRA config path and dataclass to the config_to_params mapping in config unit test

#### Test plan

```
python -m pytest -v recipes/tests/configs/test_configs.py
...
========= 1 passed, 11 warnings in 4.74s ==========
```
