### PR TITLE
Update HF upload instructions

### DIFF
--- a/_scripts/hf_upload/README.md
+++ b/_scripts/hf_upload/README.md
@@ -49,11 +49,10 @@ Default `LICENSE` is the Llama2 one
 
 ```bash
 python upload.py \
-  --repo_name tune \
+  --repo_name <YOUR_REPO_NAME> \
   --model_path <PATH_TO_PTH_FILE> \
   --hf_username <YOUR_HF_USERNAME> \
   --hf_token <YOUR_HF_TOKEN> \
-  --private
 ```
 
 ## Eval


### PR DESCRIPTION
Since we're opening up soon, I'm removing references to my old HF token. I've also invalidated it so there is no security risk