### PR TITLE
[README] Add single device run instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,15 @@ To run a full finetune on a single device on the Alpaca dataset using FSDP:
 tune --nnodes 1 --nproc_per_node 1 full_finetune --config alpaca_llama2_full_finetune
 ```
 
-The argument passed to `--nproc_per_node` can be varied depending on how many GPUs you have. A full finetune can be memory-intensive, so make sure you are running on enough devices. See [this table](https://github.com/pytorch-labs/torchtune/blob/main/README.md#finetuning-resource-requirements) for resource requirements on common hardware setups.
-
 Similarly, you can finetune with LoRA on the Alpaca dataset a single device via
 
 ```
 tune --nnodes 1 --nproc_per_node 1 lora_finetune --config alpaca_llama2_lora_finetune
 ```
 
-Again, the argument to `--nproc_per_node` can be varied subject to memory constraints of your device(s). For example, if you want to finetune with LoRA on two devices:
+The argument passed to `--nproc_per_node` can be varied depending on how many GPUs you have. A full finetune can be memory-intensive, so make sure you are running on enough devices. See [this table](https://github.com/pytorch-labs/torchtune/blob/main/README.md#finetuning-resource-requirements) for resource requirements on common hardware setups.
+
+For example, if you want to finetune with LoRA on two devices:
 
 ```
 tune --nnodes 1 --nproc_per_node 2 lora_finetune --config alpaca_llama2_lora_finetune

--- a/README.md
+++ b/README.md
@@ -118,21 +118,25 @@ tune convert_checkpoint --checkpoint-path /tmp/llama2/consolidated.00.pth --outp
 
 TorchTune contains recipes for [full finetuning](https://github.com/pytorch-labs/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/full_finetune.py), [LoRA finetuning](https://github.com/pytorch-labs/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/lora_finetune.py), and [generation](https://github.com/pytorch-labs/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/alpaca_generate.py).
 
-To run a full finetune on two devices on the Alpaca dataset using FSDP:
+To run a full finetune on a single device on the Alpaca dataset using FSDP:
 
 ```
-tune --nnodes 1 --nproc_per_node 2 full_finetune --config alpaca_llama2_full_finetune
+tune --nnodes 1 --nproc_per_node 1 full_finetune --config alpaca_llama2_full_finetune
 ```
 
 The argument passed to `--nproc_per_node` can be varied depending on how many GPUs you have. A full finetune can be memory-intensive, so make sure you are running on enough devices. See [this table](https://github.com/pytorch-labs/torchtune/blob/main/README.md#finetuning-resource-requirements) for resource requirements on common hardware setups.
 
-Similarly, you can finetune with LoRA on the Alpaca dataset on two devices via
+Similarly, you can finetune with LoRA on the Alpaca dataset a single device via
+
+```
+tune --nnodes 1 --nproc_per_node 1 lora_finetune --config alpaca_llama2_lora_finetune
+```
+
+Again, the argument to `--nproc_per_node` can be varied subject to memory constraints of your device(s). For example, if you want to finetune with LoRA on two devices:
 
 ```
 tune --nnodes 1 --nproc_per_node 2 lora_finetune --config alpaca_llama2_lora_finetune
 ```
-
-Again, the argument to `--nproc_per_node` can be varied subject to memory constraints of your device(s).
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Similarly, you can finetune with LoRA on the Alpaca dataset a single device via
 tune --nnodes 1 --nproc_per_node 1 lora_finetune --config alpaca_llama2_lora_finetune
 ```
 
-The argument passed to `--nproc_per_node` can be varied depending on how many GPUs you have. A full finetune can be memory-intensive, so make sure you are running on enough devices. See [this table](https://github.com/pytorch-labs/torchtune/blob/main/README.md#finetuning-resource-requirements) for resource requirements on common hardware setups.
+The argument passed to `--nproc_per_node` can be varied depending on how many GPUs you have. Finetune can be memory-intensive, so make sure you are running on enough devices. See [this table](https://github.com/pytorch-labs/torchtune/blob/main/README.md#finetuning-resource-requirements) for resource requirements on common hardware setups.
 
 For example, if you want to finetune with LoRA on two devices:
 


### PR DESCRIPTION
#### Context
- I have a node with single GPU. I simply copy-pasted the tune command without realizing that it is for two devices. The run just failed saying number of ranks is incorrect. It took me sometime to figure out the right args for nnodes, nproc_per_node for 1 GPU case (it is 1,1 not 0, 1). Most users would come in with the single device case and thus README can reflect that as first usecase and subsequently talk about two GPU case. 

#### Changelog
- Modify README to document single GPU case followed by two GPUs case

#### Test plan
- Readme change, attached screenshot:
<img width="920" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/558459/d2edcb55-0874-42bf-a108-8b6025ace13a">

