### PR TITLE
[RFC] Single Device Full Fine-tune for Llama7B in < 16GB

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -1,0 +1,426 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+import sys
+import time
+
+from functools import partial
+from typing import Any, Dict, Optional, Tuple
+from warnings import warn
+
+import torch
+
+from recipes.interfaces import FTRecipeInterface
+from recipes.params.full_finetune import FullFinetuneParams
+
+from torch import nn
+from torch.cuda.amp import GradScaler
+from torch.distributed import init_process_group
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader, DistributedSampler
+
+from torchtune import datasets, models, modules, utils
+from torchtune.utils.constants import (
+    EPOCHS_KEY,
+    MAX_STEPS_KEY,
+    MODEL_KEY,
+    OPT_KEY,
+    SEED_KEY,
+    TOTAL_EPOCHS_KEY,
+)
+
+from tqdm import tqdm
+
+
+log = utils.get_logger("DEBUG")
+
+
+def memory_stats_log(msg: str) -> str:
+    return f"""
+    Memory Stats {msg}:
+    Memory Allocated: {torch.cuda.memory_allocated() / 1000**3:.2f} GB
+    Memory Reserved: {torch.cuda.memory_reserved() / 1000**3:.2f} GB
+    Peak Memory: {torch.cuda.max_memory_allocated() / 1000**3:.2f} GB
+    """
+
+
+class FullFinetuneSingleDeviceRecipe(FTRecipeInterface):
+    """
+
+    """
+
+    def __init__(self, params: FullFinetuneParams) -> None:
+
+        self._device = utils.get_device(device=params.device)
+        self._dtype = utils.get_dtype(dtype=params.dtype)
+
+        # logging attributes
+        self._output_dir = params.output_dir
+        self._metric_logger = utils.get_metric_logger(
+            metric_logger_type=params.metric_logger_type,
+            project=params.project,
+            log_dir=params.output_dir,
+        )
+        self._log_every_n_steps = (
+            params.log_every_n_steps if params.log_every_n_steps else 1
+        )
+
+        # Training params
+        self._gradient_accumulation_steps = params.gradient_accumulation_steps
+
+        self.seed = utils.set_seed(seed=params.seed)
+        self.epochs_run = 0
+        self.total_epochs = params.epochs
+        self.max_steps_per_epoch = params.max_steps_per_epoch
+        self.total_training_steps = 0
+
+    def load_checkpoint(self, ckpt_path: str):
+        """
+        Extract the checkpoint state from file and validate.
+        """
+        ckpt_dict = torch.load(ckpt_path, map_location="cpu", weights_only=True)
+        return ckpt_dict
+
+    def setup(self, params: FullFinetuneParams) -> None:
+        """
+        Sets up the recipe state correctly.
+        """
+
+        ckpt_dict = self.load_checkpoint(ckpt_path=params.model_checkpoint)
+
+        log.info(memory_stats_log("after checkpoint load"))
+
+        # ``_setup_model`` handles initialization and loading the state dict
+        self._model = self._setup_model(
+            model=params.model,
+            enable_activation_checkpointing=params.enable_activation_checkpointing,
+            model_state_dict=ckpt_dict[MODEL_KEY],
+        )
+
+        log.info(memory_stats_log("after model setup"))
+
+        self._tokenizer = self._setup_tokenizer(
+            tokenizer=params.tokenizer, tokenizer_checkpoint=params.tokenizer_checkpoint
+        )
+
+        if params.optimizer_in_bwd:
+            self._optimizer_dict = self._setup_optimizer_in_bwd(
+                optimizer=params.optimizer,
+                lr=params.lr,
+            )
+        else:
+            self._optimizer = self._setup_optimizer(
+                optimizer=params.optimizer,
+                lr=params.lr,
+            )
+        self._optimizer_in_bwd = params.optimizer_in_bwd
+
+        self._loss_fn = self._setup_loss(loss=params.loss)
+
+        # sampler and dataloader depend on the tokenizer and loss_fn and should be
+        # setup after both of these are initialized
+        self._sampler, self._dataloader = self._setup_data(
+            dataset=params.dataset,
+            train_on_input=params.train_on_input,
+            shuffle=params.shuffle,
+            batch_size=params.batch_size,
+        )
+
+        # Finally update the recipe state which can only be correctly set after all of the
+        # other components have been initialized and updated.
+        #
+        # Number of training steps in each epoch depends on the number of batches produced
+        # by the dataloader, the max_steps_per_epoch param set by the user and the
+        # gradient_accumulation_steps param. This value is used for logging and tracking
+        # training state. The computation should happen after the dataloader has been setup
+        self._steps_per_epoch = (
+            len(self._dataloader) // self._gradient_accumulation_steps
+        )
+        if (
+            self.max_steps_per_epoch is not None
+            and self.max_steps_per_epoch < self._steps_per_epoch
+        ):
+            self._steps_per_epoch = self.max_steps_per_epoch
+        self.total_training_steps = self.epochs_run * self._steps_per_epoch
+
+    def _setup_model(
+        self,
+        model: str,
+        enable_activation_checkpointing: bool,
+        model_state_dict: Dict[str, Any],
+    ) -> nn.Module:
+        """
+
+        """
+        load_on_cpu = True
+
+        t0 = time.time()
+        model = models.get_model(
+            model,
+            device=torch.device("cpu") if load_on_cpu else self._device,
+        )
+
+        model.bfloat16()
+        model.to(self._device)
+        print(f"Time to load model: {time.time() - t0:.02f} seconds.")
+
+        if enable_activation_checkpointing:
+            utils.set_activation_checkpointing(
+                model, auto_wrap_policy={modules.TransformerDecoderLayer}
+            )
+
+        model.load_state_dict(model_state_dict)
+
+        log.info("Model is initialized.")
+        return model
+
+    def _setup_tokenizer(
+        self, tokenizer: str, tokenizer_checkpoint: str
+    ) -> modules.Tokenizer:
+        """
+        Unlike ```setup_model```, this takes in the checkpoint and loads the sentencepiece
+        tokenizer model. This is related to how the tokenizer is implemented and should
+        change in a future iteration.
+        """
+        tokenizer = models.get_tokenizer(tokenizer, path=tokenizer_checkpoint)
+
+        log.info("Tokenizer is initialized from file.")
+        return tokenizer
+
+    def _setup_optimizer(self, optimizer: str, lr: float) -> Optimizer:
+        """
+        Set up the optimizer.
+        """
+
+        trainable_params = [p for n, p in self._model.named_parameters() if p.requires_grad]
+
+        if optimizer == "AdamW8Bit":
+            try:
+                import bitsandbytes as bnb
+            except AttributeError as e:
+                raise ValueError(
+                    "Bits and Bytes is not installed. Please install with `pip install bitsandbytes"
+                )
+            return bnb.optim.AdamW8bit(trainable_params, lr=lr)
+        else:
+            try:
+                return getattr(torch.optim, optimizer)(
+                    trainable_params, lr=lr, foreach=False
+                )
+            except AttributeError as e:
+                raise ValueError(
+                    f"{optimizer} is not a valid optimizer from torch.optim"
+                ) from e
+
+        log.info("Optimizer is initialized.")
+        return optimizer
+
+    def _setup_optimizer_in_bwd(self, optimizer: str, lr: float):
+        if optimizer == "AdamW8Bit":
+            import bitsandbytes as bnb
+            optimizer_dict = {p: bnb.optim.AdamW8bit([p], lr=lr) for p in self._model.parameters()}
+        elif optimizer == "AdamW":
+            optimizer_dict = {p: torch.optim.AdamW([p], lr=lr) for p in self._model.parameters()}
+        elif optimizer == "SGD":
+            optimizer_dict = {p: torch.optim.SGD([p], lr=lr) for p in self._model.parameters()}
+        else:
+            raise ValueError(f"{optimizer} is not supported in bwd")
+
+        def optimizer_hook(parameter) -> None:
+            optimizer_dict[parameter].step()
+            optimizer_dict[parameter].zero_grad()
+
+        for p in self._model.parameters():
+            p.register_post_accumulate_grad_hook(optimizer_hook)
+
+    def _setup_loss(self, loss: str) -> nn.Module:
+        loss_fn = modules.get_loss(loss)
+
+        log.info("Loss is initialized.")
+        return loss_fn
+
+    def _setup_data(
+        self, dataset: str, shuffle: bool, batch_size: int, train_on_input: bool
+    ) -> Tuple[DistributedSampler, DataLoader]:
+        """
+        All data related setup happens here. Currently this recipe only supports the
+        DistributedSamplers with Map-style Datasets which fit into memory. Other samplers,
+        iterable datasets and streaming datasets are not supported.
+        """
+        world_size, rank = utils.get_world_size_and_rank()
+        ds = datasets.get_dataset(
+            dataset,
+            split="train",
+            tokenizer=self._tokenizer,
+            train_on_input=train_on_input,
+        )
+        sampler = DistributedSampler(
+            ds,
+            num_replicas=world_size,
+            rank=rank,
+            shuffle=shuffle,
+            seed=0,
+        )
+        dataloader = DataLoader(
+            dataset=ds,
+            batch_size=batch_size,
+            sampler=sampler,
+            collate_fn=partial(
+                utils.padded_collate,
+                padding_idx=self._tokenizer.pad_id,
+                ignore_idx=self._loss_fn.ignore_index,  # TODO support loss without ignore_index
+            ),
+        )
+
+        log.info("Dataset and Sampler are initialized.")
+
+        return sampler, dataloader
+
+    def save_checkpoint(self, epoch: int) -> None:
+        """
+        Checkpoint the relevant state of a recipe.
+
+        This makes use of the `save_checkpoint` utility which is responsible for
+        writing the checkpoint dictionary to file. The contents of the dict are dictated
+        by whether training is complete or not.
+
+        If training is ongoing, optimizer state, seed and epochs_run are saved along with the
+        model weights.
+        """
+        os.makedirs(self._output_dir, exist_ok=True)
+        output_loc = f"{self._output_dir}/model_{epoch}.ckpt"
+        ckpt_dict = {MODEL_KEY: self._model}
+        utils.save_checkpoint(ckpt_dict, output_loc)
+
+        log.info(
+            f"Model checkpoint of size {os.path.getsize(output_loc) >> 20} MB saved to {output_loc}"
+        )
+
+    def _should_update_weights(self, curr_step: int) -> bool:
+        """
+        Determines whether the weights should be updated on the current step or not.
+        True is returned either if we've accumulated gradients for enough steps or if this
+        is the last step in the epoch.
+        """
+        should_update_weights = (
+            (curr_step + 1) % self._gradient_accumulation_steps == 0 or
+            (curr_step + 1) // self._gradient_accumulation_steps == self._steps_per_epoch
+        )
+        return should_update_weights
+
+    def train(self) -> None:
+        """
+        The core training loop. Supports training on subsets of the dataset using the
+        ``max_steps_per_epoch``.
+        """
+        _, rank = utils.get_world_size_and_rank()
+
+        # zero out the gradients before starting training
+        if not self._optimizer_in_bwd:
+            self._optimizer.zero_grad()
+
+        # self.epochs_run should be non-zero when we're resuming from a checkpoint
+        for curr_epoch in range(self.epochs_run, self.total_epochs):
+
+            # Update the sampler to ensure data is correctly shuffled across epochs
+            # in case shuffle is True
+            self._sampler.set_epoch(curr_epoch)
+
+            for idx, batch in enumerate(
+                pbar := tqdm(self._dataloader, disable=not (rank == 0))
+            ):
+                if (
+                    self.max_steps_per_epoch is not None
+                    and (idx // self._gradient_accumulation_steps)
+                    == self.max_steps_per_epoch
+                ):
+                    break
+
+                input_ids, labels = batch
+                input_ids = input_ids.to(self._device)
+                labels = labels.to(self._device)
+
+                # with self._autocast:
+                logits = self._model(input_ids)
+                # Shift so that tokens < n predict n
+                logits = logits[..., :-1, :].contiguous()
+                labels = labels[..., 1:].contiguous()
+                logits = logits.transpose(1, 2)
+                # Compute loss
+                loss = self._loss_fn(logits, labels)
+
+                log.info(memory_stats_log("after fwd"))
+
+                # Note: We're always logging the loss before normalizing it
+                # Check if this is the norm or not
+                pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
+
+                if self.total_training_steps % self._log_every_n_steps == 0:
+                    self._metric_logger.log_dict(
+                        {
+                            "loss": loss.item(),
+                            # "lr": self._optimizer.param_groups[0]["lr"],
+                            "allocated_memory": torch.cuda.memory_allocated(),
+                            "peak_memory": torch.cuda.max_memory_allocated(),
+                        },
+                        step=self.total_training_steps,
+                    )
+
+                # Does loss normalization need to happen within autocast context?
+                loss = loss / self._gradient_accumulation_steps
+                loss.backward()
+
+                log.info(memory_stats_log("after bwd"))
+
+                if self._should_update_weights(idx):
+                    if not self._optimizer_in_bwd:
+                        self._optimizer.step()
+                        self._optimizer.zero_grad()
+                        log.info(memory_stats_log("opt step"))
+
+                    # Update the number of steps when the weights are updated
+                    self.total_training_steps += 1
+
+                if self.total_training_steps % 8 == 0:
+                    log.info(memory_stats_log("Memory Stats: "))
+
+            self.epochs_run += 1
+            self.save_checkpoint(epoch=curr_epoch)
+
+    def cleanup(self) -> None:
+        self._metric_logger.close()
+
+
+def recipe_main() -> None:
+    """
+    Entry point for the recipe.
+
+    Configurable parameters are read in the following order:
+        - Parameters specified in ``FullFinetuneParams``
+        - Overwritten by Parameters specified in ``alpaca_llama2_full_finetune.yaml``
+        - Overwritten by arguments from the command-line using ``TuneArgumentParser``
+    """
+    parser = utils.TuneArgumentParser(
+        description=FullFinetuneParams.__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    args, _ = parser.parse_known_args()
+    args = vars(args)
+    recipe_params = FullFinetuneParams(**args)
+
+    # Env variables set by torch run; only need to initialize process group
+    init_process_group(backend="nccl")
+
+    recipe = FullFinetuneSingleDeviceRecipe(params=recipe_params)
+    recipe.setup(params=recipe_params)
+    recipe.train()
+    recipe.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(recipe_main())

--- a/recipes/params/full_finetune.py
+++ b/recipes/params/full_finetune.py
@@ -33,6 +33,7 @@ class FullFinetuneParams:
         optimizer (str): String specifying optimizer to use. See ``torchtune.optim.get_optimizer`` for options.
         loss (str): String specifying loss function to use. See ``torchtune.losses.get_loss`` for options.
         lr (float): Learning rate to use for optimizer.
+        optimizer_in_bwd (bool): Whether to fuse the optimizer step into the backward pass
         activation_checkpointing (bool): Whether to use activation checkpointing.
         output_dir (str): Local path to save checkpoints and logs to.
         run_generation (int): Run eval on a prompt every ``run_generation`` steps. Set to 0 to disable.
@@ -66,6 +67,7 @@ class FullFinetuneParams:
     lr: float = 2e-5
     loss: str = "CrossEntropyLoss"
     gradient_accumulation_steps: int = 1
+    optimizer_in_bwd: bool = False
 
     # Training
     epochs: int = 3


### PR DESCRIPTION
## Context

On a single device, our current Llama7B full fine-tune recipe either OOMs with the ```AdamW``` optimizer, or takes > 55GB with ```SGD```. Given the importance of single device fine-tuning on "commodity" GPUs (this is a critical value-prop of TorchTune), it's important for us to understand if we can reduce the memory footprint for this scenario, and the impact of these improvements on model quality. In this RFC, I present:
- An analysis of why our current recipe makes sub-optimal use of GPU memory
- Techniques we can use to reduce the memory footprint
- Prototype recipe with all of the techniques implemented
- Loss curves showing that the model continues to learn even after these improvements

Overall, I show that we can full-finetune a Llama7B model in <16GB of memory with reasonable loss curves.

**Note**: Performing detailed evals of the models fine-tuned using this recipe is beyond the scope of this RFC. We can do this as a follow-up. 

&nbsp;

## Baselines: Current State

As a baseline, I consider the following setting:
- ```batch_size``` = ```1``` (minimum possible)
- ```optimizer``` = ```AdamW``` (known to produce higher quality models than SGD)
- ```enable_activation_checkpointing``` = ```False``` (has negligible footprint compared to weights, gradients and opt state - more details below)
- ```dtype``` = ```fp32``` (mixed precision training uses more memory - more details below)

We can run this training using the following command:
```
tune --nnodes 1 --nproc_per_node 1 recipes/full_finetune.py \
--config recipes/configs/alpaca_llama2_full_finetune.yaml \
--override model_checkpoint=/home/kartikayk/cpts/llama2-7b-01242024 \
seed=30 \
tokenizer_checkpoint=/home/kartikayk/cpts/tokenizer.model \
epochs=3 \
batch_size=1 \
gradient_accumulation_steps=1 \
enable_activation_checkpointing=False \
enable_fsdp=False \
optimizer=AdamW
```

This particular run will OOM. To understand why, let's breakdown how the memory is used.
```
Model Weights in full precision: 4 * num_params = ~27GB
Gradients in full precision: 4 * num_params = ~27GB
AdamW State in full precision: 2 * 4 * num_params = ~54 GB
Total = ~108GB

Note: Activations are ignored since the peak memory is after bwd (during opt step) 
when activations are no longer in memory. These are <1GB anyways.
```

One way around this OOM is to take the quality hit and use SGD. Since SGD doesn't keep around expensive state, we can reduce peak memory by ~54GB. The only change in the above config is
```
...
optimizer=SGD
```

To see what's happening' lets first take a look at the memory stats and then the memory snapshot using the [memory visualizer](https://pytorch.org/memory_viz).

```
Model is initialized.

        After Model Setup :
        Memory Allocated: 27.02 GB
        Memory Reserved: 27.85 GB
        Peak Memory: 27.83 GB

Tokenizer is initialized from file.
Optimizer is initialized.
Loss is initialized.
Dataset and Sampler are initialized.

| 0/52002 [00:00<?, ?it/s]
        After Model Fwd :
        Memory Allocated: 28.58 GB
        Memory Reserved: 28.66 GB
        Peak Memory: 28.60 GB

        After Model Bwd :
        Memory Allocated: 54.01 GB
        Memory Reserved: 55.03 GB
        Peak Memory: 54.01 GB

        After Optim Zero :
        Memory Allocated: 27.06 GB
        Memory Reserved: 55.03 GB
        Peak Memory: 54.01 GB
```
As expected, the peak memory is ~54GB. Following is the memory snapshot for this run.

<img width="1305" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/47255723/da3042ae-7527-4021-bcf4-7023a5bcd896">

&nbsp;

So how can we improve upon this? First let's take a closer look at mixed precision training.

&nbsp;

## Detour: Mixed Precision Training

There's a common misnomer that mixed precision training (eg: bf16) helps reduce the memory footprint. This is not true because of the following reasons:
- Autocast creates two copies of the model weights in memory: one in half-precision and one in full precision - this increases memory by 1.5x
- Forwsrd activations saved for gradient computation are in half-precision, but the activations are a very small % of the memory (depends on sequence length and batch size among other factors)
- Gradients are computed in half precision but converted to full-precision for the weight updates - no memory savings
- Optimizer states are in full precision - no memory savings

We can enable mixed precision training by adding the following to the config above:
```
...
dtype=bf16
...
```

We check the gradients using pdb and indeed these are in fp32

```
(Pdb) self._model.output.weight.grad.dtype
torch.float32
```
 Let's take a look at the memory statistics:

```
Model is initialized.

        After Model Setup :
        Memory Allocated: 27.02 GB
        Memory Reserved: 27.85 GB
        Peak Memory: 27.83 GB

Tokenizer is initialized from file.
Optimizer is initialized.
Loss is initialized.
Dataset and Sampler are initialized.
                                                                                                                                                                     | 0/52002 [00:00<?, ?it/s]
        After Model Fwd :
        Memory Allocated: 41.32 GB
        Memory Reserved: 41.35 GB
        Peak Memory: 41.33 GB

        After Model Bwd :
        Memory Allocated: 54.01 GB
        Memory Reserved: 61.98 GB
        Peak Memory: 54.01 GB

        After Optim Zero :
        Memory Allocated: 27.06 GB
        Memory Reserved: 61.98 GB
        Peak Memory: 54.01 GB
```

Two observations:
- We have two copies of the model to compute forward resulting in ~41GB (27 + 13.5)
- Gradients are in fp32 - peak memory is the same as full precision training

Let's take a look at the snapshot for this run. Indeed the memory during forward is higher owing to the extra copy of the model weights. These are kept in memory for gradient computation.

<img width="1178" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/47255723/3bf8c08c-6e48-4f16-8b2a-47c6c755867f">

&nbsp;

## Optimization 1: True BF16 Training 

To get the true benefits of ```bf16```, we need "true" half-precision training where the model weights, gradients and optimizer states are all in ```bf16```. There is some evidence that this setup is stable for LLMs. 

The memory breakdown for true bf16 training should include:
```
Model Weights: 2 * num_params = ~13.5GB
Gradients: 2 * num_params = ~13.5GB
Opt State: None (using SGD)
Total: ~27GB

Note: Activations are ignored since the peak memory is after bwd (during opt step) when activations are no longer in memory. These are <1GB anyways.
```

Let's look at the memory stats to see if this is indeed true

```
Model is initialized.

        After Model Setup :
        Memory Allocated: 13.51 GB
        Memory Reserved: 28.14 GB
        Peak Memory: 27.83 GB

Tokenizer is initialized from file.
Optimizer is initialized.
Loss is initialized.
Dataset and Sampler are initialized.
                                                                                                                                                                                   | 0/52002 [00:00<?, ?it/s]
        After Model Fwd :
        Memory Allocated: 14.39 GB
        Memory Reserved: 28.14 GB
        Peak Memory: 27.83 GB

        After Model Bwd :
        Memory Allocated: 27.02 GB
        Memory Reserved: 28.14 GB
        Peak Memory: 27.83 GB

        After Optim Zero :
        Memory Allocated: 13.55 GB
        Memory Reserved: 28.14 GB
        Peak Memory: 27.83 GB
```

This looks good, except that the peak memory is now shifted to model setup! This is because we load the weights in ```fp32``` on device and then convert to ```bf16```. Let's change this load the weights on CPU, convert to ```bf16``` and then load to device. This increases the time it takes to init the model from ```0.5 seconds``` to ```13 seconds```, but it's worth to take this small hit for the additional savings.

```
After Model Init :
        Memory Allocated: 13.51 GB
        Memory Reserved: 13.51 GB
        Peak Memory: 13.51 GB

Model is initialized.

        After Model Setup :
        Memory Allocated: 13.51 GB
        Memory Reserved: 13.51 GB
        Peak Memory: 13.51 GB

Tokenizer is initialized from file.
Optimizer is initialized.
Loss is initialized.
Dataset and Sampler are initialized.
                                                                                                                                                                                  | 0/52002 [00:00<?, ?it/s]
        After Model Fwd :
        Memory Allocated: 14.41 GB
        Memory Reserved: 14.45 GB
        Peak Memory: 14.42 GB

        After Model Bwd :
        Memory Allocated: 27.02 GB
        Memory Reserved: 27.94 GB
        Peak Memory: 27.02 GB

        After Optim Zero :
        Memory Allocated: 13.55 GB
        Memory Reserved: 27.94 GB
        Peak Memory: 27.02 GB
```

The memory savings can be seen in the snapshot as well (compare the y axes)

<img width="1098" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/47255723/83d03d80-c9c6-4df4-94b2-39dbf6c2c5be">

&nbsp;

Now that we've reduced the memory footprint. Time to bring back AdamW and see if we can run the config which was previously OOM-ing. Following is the command used to launch this training:

```
tune --nnodes 1 --nproc_per_node 1 recipes/full_finetune_single_device.py \
--config recipes/configs/alpaca_llama2_full_finetune.yaml \
--override model_checkpoint=/home/kartikayk/cpts/llama2-7b-01242024 \
seed=30 \
tokenizer_checkpoint=/home/kartikayk/cpts/tokenizer.model \
epochs=3 \
batch_size=1 \
gradient_accumulation_steps=1 \
enable_activation_checkpointing=False \
enable_fsdp=False \
max_steps_per_epoch=2 \
epochs=1 \
optimizer=AdamW
```

Before we look at the memory stats, let's compute the expected values:
```
Model Weights: 2 * num_params = ~13.5GB
Gradients: 2 * num_params = ~13.5GB
Opt State: 2 * 2 * num_params = ~27GB
Total: ~54GB (same memory footprint as baseline SGD!)

Note: Activations are ignored since the peak memory is after bwd (during opt step) when activations are no longer in memory. These are <1GB anyways.
```

Now lets look at the memory stats:

```
Model is initialized.

        After Model Setup :
        Memory Allocated: 13.51 GB
        Memory Reserved: 13.51 GB
        Peak Memory: 13.51 GB

Tokenizer is initialized from file.
Optimizer is initialized.
Loss is initialized.
Dataset and Sampler are initialized.

 | 0/52002 [00:00<?, ?it/s]
        After Model Fwd :
        Memory Allocated: 14.41 GB
        Memory Reserved: 14.45 GB
        Peak Memory: 14.42 GB

        After Model Bwd :
        Memory Allocated: 27.02 GB
        Memory Reserved: 27.94 GB
        Peak Memory: 27.02 GB

        After Optim Zero :
        Memory Allocated: 40.50 GB
        Memory Reserved: 68.38 GB
        Peak Memory: 67.45 GB
```

Note: The optimizer state only kicks in after other first call to ```optimizer.step()``` is made (see snapshot below).
 
Most of the numbers match up, but there's an additional 13.5GB which is mysteriously equal to the size of model weights in half precision. Let's take a look at the snapshot to see where this is coming from.

<img width="1050" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/47255723/28600061-ea73-41a3-aa19-46a0ded65c10">

&nbsp;

Digging through the AdamW documentation, the extra memory seems to be related to the foreach flag which is a performance lever enabled by default:

```
foreach (bool, optional) – whether foreach implementation of optimizer is used. 
If unspecified by the user (so foreach is None), we will try to use foreach over the for-loop 
implementation on CUDA, since it is usually significantly more performant. 
Note that the foreach implementation uses ~ sizeof(params) more peak memory than the 
for-loop version due to the intermediates being a tensorlist vs just one tensor. 
If memory is prohibitive, batch fewer parameters through the optimizer at a time or 
switch this flag to False (default: None)
```

Disabling this and things look more in line with our expectation. Namely, peak memory is ~54GB WITH AdamW.

<img width="697" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/47255723/54e8bea3-69c9-491a-948d-68a49c2e4f32">

&nbsp;

## Optimizations 2: 8-Bit Optimizer

Given the above breakdown, one way to reduce the memory footprint of AdamW is by using the 8-bit version. This will reduce the AdamW state by a ~13.5GB (instead of 2 bytes per param, we use 1 byte per param) and the total from ~54GB to ~40.5GB. 

To this, I use the ```AdamW8Bit``` from [BitsAndBytes](https://huggingface.co/docs/bitsandbytes/main/en/optimizers#introduction-8-bit-optimizers) which is a single line code change:

```
optimizer = bnb.optim.AdamW8bit(trainable_params, lr=lr)
```

Let's look at the memory stats to see if this matches up with our expectation:

```
Memory Stats after fwd:
    Memory Allocated: 27.29 GB
    Memory Reserved: 41.07 GB
    Peak Memory: 40.73 GB

1|3|Loss: 1.4059289693832397:   0%|                                                                                                                                              | 2/52002 [00:03<18:31:29,  1.28s/it]

    Memory Stats after bwd:
    Memory Allocated: 40.73 GB
    Memory Reserved: 41.07 GB
    Peak Memory: 40.73 GB

    Memory Stats opt zero:
    Memory Allocated: 27.25 GB
    Memory Reserved: 41.07 GB
    Peak Memory: 40.73 GB
```

Caveat: This introduces a new dependency in the code base. We might have a native PyTorch implementation of 8-bit AdamW, but this version from BnB has been thoroughly tested by the community.

&nbsp;

## Optimization 3: Fusing Optimizer with Backward to remove Gradients

The other optimization we can look at is to get rid of the gradients which take up ~13.5GB of memory. We can do this by fusing the optimizer with the backward so that weight updates happen as the relevant gradient is computed. This can be done using the following code change:

```
optimizer_dict = {p: torch.optim.AdamW([p], lr=lr) for p in self._model.parameters()}

def optimizer_hook(parameter) -> None:
    optimizer_dict[parameter].step()
    optimizer_dict[parameter].zero_grad()

for p in self._model.parameters():
     p.register_post_accumulate_grad_hook(optimizer_hook)
```

The memory stats show that the peak memory is as expected (we don't have optimizer steps anymore):

```
Memory Stats after fwd:
    Memory Allocated: 40.54 GB
    Memory Reserved: 42.74 GB
    Peak Memory: 41.02 GB

1|2|Loss: 1.1041574478149414:   0%|                                                                                                                                              | 1/52002 [00:03<41:08:58,  2.85s/it]
    Memory Stats after bwd:
    Memory Allocated: 40.50 GB
    Memory Reserved: 42.75 GB
    Peak Memory: 41.05 GB
```

Caveat: IIUC, fusing the optimizer with backward makes it impossible to accumulate gradients to simulate larger batch sizes. But this might be worth the ability to run training (see loss curves below).

&nbsp;

## Optimization 4: Combine 1, 2 and 3

By using the 8-bit optimizer and removing the need for preserving gradients, we can further reduce the peak memory to ~27GB. Let's take a look at the memory stats:

```
Memory Stats after fwd:
    Memory Allocated: 27.30 GB
    Memory Reserved: 27.85 GB
    Peak Memory: 27.51 GB

1|2|Loss: 1.1036440134048462:   0%|                                                                                                                                              | 1/52002 [00:03<53:58:40,  3.74s/it]
    Memory Stats after bwd:
    Memory Allocated: 27.25 GB
    Memory Reserved: 27.85 GB
    Peak Memory: 27.55 GB
```

We can run this using the prototype script using the following command:

```
tune --nnodes 1 --nproc_per_node 1 recipes/full_finetune_single_device.py \
--config recipes/configs/alpaca_llama2_full_finetune.yaml \
--override model_checkpoint=/home/kartikayk/cpts/llama2-7b-01242024 \
seed=30 tokenizer_checkpoint=/home/kartikayk/cpts/tokenizer.model \
epochs=3 \
batch_size=1 \
gradient_accumulation_steps=1 \
enable_activation_checkpointing=True \
enable_fsdp=False \
epochs=1 \
optimizer_in_bwd=True \
optimizer=AdamW8Bit \
```

&nbsp;

## Putting it all together

To replicate the loss curves we've seen thus far from lit-gpt and LoRA, i set ```batch_size=8```. Following is the loss curve with the final loss value ~0.44, with a peak memory of ~35GB. With a little more tuning of the hyper-params, I believe we can bring the peak memory down. This will require access to evals to better understand the trajectory of model training.

<img width="1626" alt="Screenshot 2024-02-18 at 9 04 10 AM" src="https://github.com/pytorch-labs/torchtune/assets/47255723/d9da72f2-dd28-4a5b-933b-2cae6c9a288a">

If we replace AdamW8Bit with SGD, we further reduce the peak memory to ~14.4GB. The following logs from WandB show this setting with the loss, peak memory and allocated memory (logged after forward)

<img width="1651" alt="image" src="https://github.com/pytorch-labs/torchtune/assets/47255723/fa5bec29-0946-4e39-a3d2-ccfd04b95d34">















