### PR TITLE
Add details in comment in peft_utils.py

### DIFF
--- a/torchtune/modules/peft/peft_utils.py
+++ b/torchtune/modules/peft/peft_utils.py
@@ -215,7 +215,10 @@ def lora_fsdp_init(module: nn.Module, device: torch.device) -> None:
     # Custom init for RoPE, which has buffers only
     if hasattr(module, "_rope_init"):
         module._rope_init(device=device)
-    # Skip init of modules that already have params on non-meta device
+    # Skip init of modules that already have params on non-meta device. This is
+    # to avoid re-initialization of parameters that have already been explicitly
+    # initialized by the user before wrapping with FSDP. In particular, for LoRA,
+    # LoRA a & b matrices are pre-initialized before wrapping with FSDP.
     if all([not p.is_meta for p in module.parameters()]):
         return
     else:


### PR DESCRIPTION
#### Context
- Clarifies why we're skipping some modules if they already have non-meta parameters during FSDP + meta device init.

#### Changelog
- ...

#### Test plan
- ....
