### PR TITLE
Fix norm_eps value in lora_llama2_7b

### DIFF
--- a/torchtune/models/lora_llama2.py
+++ b/torchtune/models/lora_llama2.py
@@ -48,7 +48,7 @@ def lora_llama2_7b(
         max_seq_len=4096,
         max_batch_size=max_batch_size,
         attn_dropout=0.0,
-        norm_eps=1e-6,
+        norm_eps=1e-5,
         lora_rank=lora_rank,
         lora_alpha=lora_alpha,
         lora_dropout=0.05,


### PR DESCRIPTION
#### Context
- #290 fixed incorrect values of norm_eps throughout Llama2 code. However, #266 was open (but not landed) and so I missed integrating these changes into the `lora_llama2_7b` builder. 

#### Changelog
- Fix the remaining usage of norm_eps=1e-6 in lora_llama2_7b

#### Test plan
- CI
