### PR TITLE
Fix kv cache for bf16 inference

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,6 +137,16 @@ def single_box_init():
 
 
 @contextmanager
+def set_dtype(dtype: torch.dtype) -> Generator[None, None, None]:
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(old_dtype)
+
+
+@contextmanager
 def captured_output() -> Generator[Tuple[TextIO, TextIO], None, None]:
     new_out, new_err = StringIO(), StringIO()
     old_out, old_err = sys.stdout, sys.stderr

--- a/torchtune/modules/kv_cache.py
+++ b/torchtune/modules/kv_cache.py
@@ -19,7 +19,6 @@ class KVCache(nn.Module):
         max_seq_len (int): maximum sequence length model will be run with
         n_kv_heads (int): number of kv heads
         head_dim (int): per-attention head embedding dimension
-        dtype (torch.dtype): datatype of kv-cache entries (default is torch.float32)
     """
 
     def __init__(
@@ -28,16 +27,11 @@ class KVCache(nn.Module):
         max_seq_len: int,
         n_kv_heads: int,
         head_dim: int,
-        dtype: torch.dtype = torch.float32,
     ):
         super().__init__()
         cache_shape = (max_batch_size, max_seq_len, n_kv_heads, head_dim)
-        self.register_buffer(
-            "k_cache", torch.zeros(cache_shape, dtype=dtype), persistent=False
-        )
-        self.register_buffer(
-            "v_cache", torch.zeros(cache_shape, dtype=dtype), persistent=False
-        )
+        self.register_buffer("k_cache", torch.zeros(cache_shape), persistent=False)
+        self.register_buffer("v_cache", torch.zeros(cache_shape), persistent=False)
         self.max_batch_size = max_batch_size
 
     def update(


### PR DESCRIPTION
#### Context
- Our current kv cache is broken for bf16 inference, we need to fix this. See https://github.com/pytorch-labs/torchtune/issues/398 for details

#### Changelog
- Remove `dtype` from kv cache to make kv cache respect whatever dtype is set by user via torch.set_default_dtype (which would be fp32 if user didn't set anything).
- Modify unittests appropriately

#### Test plan
- `pytest tests/torchtune/generation/test_generation.py -v -k test_kv_cache_incremental_decode_parity`
