### PR TITLE
[WIP, not ready for review] Add option to use cached dataset

### DIFF
--- a/recipes/full_finetune.py
+++ b/recipes/full_finetune.py
@@ -143,6 +143,7 @@ class FullFinetuneRecipe(FTRecipeInterface):
         # setup after both of these are initialized
         self._sampler, self._dataloader = self._setup_data(
             dataset=params.dataset,
+            cache_dir=params.cache_dir,
             train_on_input=params.train_on_input,
             shuffle=params.shuffle,
             batch_size=params.batch_size,
@@ -269,7 +270,7 @@ class FullFinetuneRecipe(FTRecipeInterface):
         return loss_fn
 
     def _setup_data(
-        self, dataset: str, shuffle: bool, batch_size: int, train_on_input: bool
+        self, dataset: str, cache_dir: str, shuffle: bool, batch_size: int, train_on_input: bool
     ) -> Tuple[DistributedSampler, DataLoader]:
         """
         All data related setup happens here. Currently this recipe only supports the
@@ -279,6 +280,7 @@ class FullFinetuneRecipe(FTRecipeInterface):
         world_size, rank = utils.get_world_size_and_rank()
         ds = datasets.get_dataset(
             dataset,
+            cache_dir=cache_dir,
             split="train",
             tokenizer=self._tokenizer,
             train_on_input=train_on_input,

--- a/recipes/lora_finetune.py
+++ b/recipes/lora_finetune.py
@@ -273,6 +273,11 @@ class LoRAFinetuneRecipe(FTRecipeInterface):
             base_model_state_dict_keys=base_model_state_dict.keys(),
         )
         model.load_state_dict(base_model_state_dict, strict=False)
+        print(f"RV: loaded state_dict, calling summon_full_params")
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+        with FSDP.summon_full_params(model):
+            print(f"RV: done summoning full params!")
+
         if lora_weights_state_dict:
             model.load_state_dict(lora_weights_state_dict, strict=False)
 

--- a/recipes/params/full_finetune.py
+++ b/recipes/params/full_finetune.py
@@ -27,6 +27,9 @@ class FullFinetuneParams:
         tokenizer_checkpoint (str): Local path to load tokenizer checkpoint from.
         dataset (str): String specifying dataset to use. See ``torchtune.datasets.get_dataset`` for options.
             Currently, only predefined datasets in library are supported.
+        cache_dir (str): Allows using a locally cached dataset by specifying a string indicating the
+            directory the dataset is cached in. If specified and valid, the dataset will be loaded from the
+            local directory as opposed to making network calls to download the dataset.
         shuffle (bool): Whether to shuffle dataset.
         batch_size (int): Batch size to use for training.
         epochs (int): Number of epochs to train for.
@@ -57,6 +60,7 @@ class FullFinetuneParams:
 
     # Dataset and Sampler
     dataset: str = ""
+    cache_dir: str = ""
     train_on_input: bool = True
     shuffle: bool = True
     batch_size: int = 2

--- a/torchtune/datasets/_alpaca.py
+++ b/torchtune/datasets/_alpaca.py
@@ -67,12 +67,17 @@ class AlpacaDataset(Dataset):
 
     def __init__(
         self,
+        cache_dir: str,
         tokenizer: Tokenizer,
         train_on_input: bool = True,
         use_clean: bool = False,
         **kwargs,
     ) -> None:
         dataset_path = "yahma/alpaca-cleaned" if use_clean else "tatsu-lab/alpaca"
+        cache_path = "~/.cache/huggingface/datasets"
+        cache_path = " ~/.cache/huggingface/datasets/tatsu-lab___alpaca/"
+        # import os ; os.environ["HF_HUB_OFFLINE"] = "1"
+        import os ; os.environ["HF_DATASETS_OFFLINE"] = "1"
         self._data = load_dataset(dataset_path, split="train")
         self._tokenizer = tokenizer
         self.train_on_input = train_on_input


### PR DESCRIPTION
#### Context
- ...

#### Changelog
- ...

#### Test plan
- `torchrun --nnodes 1 --nproc_per_node 8 recipes/full_finetune.py --config recipes/configs/alpaca_llama2_full_finetune.yaml --override model_checkpoint=/home/rvarm1/local/dev/assets/llama2-7b-01242024 seed=18 cache_dir=/home/rvarm1/.cache/huggingface/datasets tokenizer_checkpoint=/home/rvarm1/local/dev/assets/tokenizer.model output_dir=/tmp/lora_debug &> out &`
