### PR TITLE
Add dim_multiplier to scale_hidden_dim_for_mlp and expose in llama2 builder

### DIFF
--- a/tests/torchtune/models/test_model_utils.py
+++ b/tests/torchtune/models/test_model_utils.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtune.models.llama2 import scale_hidden_dim_for_mlp
+
+
+def _get_expected_scaled_dim(input_dim, mul_of, dim_multiplier=None):
+    expected = 4 * int(2 * input_dim / 3)
+    if dim_multiplier:
+        expected = int(expected * dim_multiplier)
+    expected = mul_of * ((expected + mul_of - 1) // mul_of)
+    return expected
+
+
+def test_scale_hidden_dim_for_mlp():
+    # Test that the hidden dim is scaled correctly.
+    dim = 256
+    mul_of = 1024
+    dim_multiplier = 1.3
+
+    expected = _get_expected_scaled_dim(dim, mul_of, dim_multiplier)
+    assert scale_hidden_dim_for_mlp(dim, mul_of, dim_multiplier) == expected
+
+    expected_no_multiplier = _get_expected_scaled_dim(dim, mul_of, dim_multiplier=None)
+    assert scale_hidden_dim_for_mlp(dim, mul_of) == expected_no_multiplier

--- a/torchtune/models/llama2/_llama2_builders.py
+++ b/torchtune/models/llama2/_llama2_builders.py
@@ -74,6 +74,7 @@ def llama2(
     attn_dropout: float = 0.0,
     max_batch_size: Optional[int] = None,
     norm_eps: float = 1e-5,
+    mlp_hidden_dim_multiplier: Optional[float] = None,
 ):
     head_dim = embed_dim // num_heads
     num_kv_heads = num_kv_heads if num_kv_heads else num_heads
@@ -102,7 +103,7 @@ def llama2(
         max_seq_len=max_seq_len,
         attn_dropout=attn_dropout,
     )
-    hidden_dim = scale_hidden_dim_for_mlp(embed_dim)
+    hidden_dim = scale_hidden_dim_for_mlp(embed_dim, dim_multiplier=mlp_hidden_dim_multiplier)
     mlp = _llama_mlp(dim=embed_dim, hidden_dim=hidden_dim)
     layer = TransformerDecoderLayer(
         attn=self_attn,

--- a/torchtune/models/llama2/_model_utils.py
+++ b/torchtune/models/llama2/_model_utils.py
@@ -4,13 +4,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Optional
 
-def scale_hidden_dim_for_mlp(dim: int, multiple_of: int = 256) -> int:
+
+def scale_hidden_dim_for_mlp(
+    dim: int, multiple_of: int = 256, dim_multiplier: Optional[float] = None
+) -> int:
     """Scale hidden dimension for MLP to keep number of parameters and computation constant.
 
     Args:
         dim (int): Input dimension.
         multiple_of (int): Round scaled dimension to nearest multiple of `multiple_of` for clean computation.
+        dim_multiplier (Optional[float]): Multiplier for scaling hidden dimension. If ``None``, do not multiply
+            hidden dimension. Default: ``None``. Note that if the result of the multiplication is a floating point,
+            it is rounded down to the nearest integer.
 
     Returns:
         Scaled hidden dimension.
@@ -18,6 +25,8 @@ def scale_hidden_dim_for_mlp(dim: int, multiple_of: int = 256) -> int:
     # Scale hidden dimension by (2/3)4d for SwiGLU to keep number of
     # parameters and computation constant
     hidden_dim = 4 * int(2 * dim / 3)
+    if dim_multiplier is not None:
+        hidden_dim = int(dim_multiplier * hidden_dim)
     # Round hidden dimension to nearest multiple of `multiple_of`
     hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
     return hidden_dim


### PR DESCRIPTION
#### Context
- To support models such as llama 2 70b, we need to expose this as 70b uses a dim multiplier of 1.3, but we don't currently expose this in our llama model builders.

#### Changelog
- Add `dim_multiplier` + impl to scale_hidden_dim_for_mlp
- Expose in `llama2` function.

#### Test plan
- Added appropriate unittests.