### PR TITLE
Fix failing distributed tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import uuid
+
+import pytest
+import torch.distributed.launcher as pet
+
+
+@pytest.fixture(scope="session")
+def get_pet_launch_config():
+    def get_pet_launch_config_fn(nproc: int) -> pet.LaunchConfig:
+        """
+        Initialize pet.LaunchConfig for single-node, multi-rank functions.
+
+        Args:
+            nproc (int): The number of processes to launch.
+
+        Returns:
+            An instance of pet.LaunchConfig for single-node, multi-rank functions.
+
+        Example:
+            >>> from torch.distributed import launcher
+            >>> launch_config = get_pet_launch_config(nproc=8)
+            >>> launcher.elastic_launch(config=launch_config, entrypoint=train)()
+        """
+        return pet.LaunchConfig(
+            min_nodes=1,
+            max_nodes=1,
+            nproc_per_node=nproc,
+            run_id=str(uuid.uuid4()),
+            rdzv_backend="c10d",
+            rdzv_endpoint="localhost:0",
+            max_restarts=0,
+            monitor_interval=1,
+        )
+
+    return get_pet_launch_config_fn

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,14 +8,12 @@ import math
 import os
 import sys
 import unittest
-import uuid
 from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
 from typing import Any, Generator, TextIO, Tuple, Union
 
 import torch
-import torch.distributed.launcher as pet
 from torch import nn
 
 
@@ -92,33 +90,6 @@ def assert_expected(
         atol=atol,
         check_device=check_device,
         msg=f"actual: {actual}, expected: {expected}",
-    )
-
-
-def get_pet_launch_config(nproc: int) -> pet.LaunchConfig:
-    """
-    Initialize pet.LaunchConfig for single-node, multi-rank functions.
-
-    Args:
-        nproc (int): The number of processes to launch.
-
-    Returns:
-        An instance of pet.LaunchConfig for single-node, multi-rank functions.
-
-    Example:
-        >>> from torch.distributed import launcher
-        >>> launch_config = get_pet_launch_config(nproc=8)
-        >>> launcher.elastic_launch(config=launch_config, entrypoint=train)()
-    """
-    return pet.LaunchConfig(
-        min_nodes=1,
-        max_nodes=1,
-        nproc_per_node=nproc,
-        run_id=str(uuid.uuid4()),
-        rdzv_backend="c10d",
-        rdzv_endpoint="localhost:0",
-        max_restarts=0,
-        monitor_interval=1,
     )
 
 

--- a/tests/torchtune/utils/test_checkpoint.py
+++ b/tests/torchtune/utils/test_checkpoint.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from tests.test_utils import get_pet_launch_config, skip_if_cuda_not_available
+from tests.test_utils import skip_if_cuda_not_available
 from torch.distributed import launcher
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torchtune.utils.checkpoint import load_checkpoint, save_checkpoint
@@ -133,6 +133,6 @@ class TestCheckpoint:
         torch.distributed.barrier()
 
     @skip_if_cuda_not_available
-    def test_distributed_save_load(self) -> None:
+    def test_distributed_save_load(self, get_pet_launch_config) -> None:
         lc = get_pet_launch_config(nproc=min(4, torch.cuda.device_count()))
         launcher.elastic_launch(lc, entrypoint=self._test_distributed_save_load)()

--- a/tests/torchtune/utils/test_distributed.py
+++ b/tests/torchtune/utils/test_distributed.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from tests.test_utils import get_pet_launch_config, single_box_init
+from tests.test_utils import single_box_init
 from torch.distributed import launcher
 
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
@@ -58,23 +58,24 @@ class TestDistributed:
 
     def _test_launch_worker(
         self,
+        get_pet_launch_config,
         num_processes: int,
         init_pg_explicit: bool,
     ) -> None:
         lc = get_pet_launch_config(num_processes)
         launcher.elastic_launch(lc, entrypoint=self._test_worker_fn)(init_pg_explicit)
 
-    def test_init_from_env_no_dup(self) -> None:
-        self._test_launch_worker(2, init_pg_explicit=False)
+    def test_init_from_env_no_dup(self, get_pet_launch_config) -> None:
+        self._test_launch_worker(get_pet_launch_config, 2, init_pg_explicit=False)
         # trivial test case to ensure test passes with no exceptions
         assert True
 
-    def test_init_from_env_dup(self) -> None:
-        self._test_launch_worker(2, init_pg_explicit=True)
+    def test_init_from_env_dup(self, get_pet_launch_config) -> None:
+        self._test_launch_worker(get_pet_launch_config, 2, init_pg_explicit=True)
         # trivial test case to ensure test passes with no exceptions
         assert True
 
-    def test_world_size_with_cpu(self) -> None:
+    def test_world_size_with_cpu(self, get_pet_launch_config) -> None:
         desired_world_size = 4
         lc = get_pet_launch_config(desired_world_size)
         launcher.elastic_launch(lc, entrypoint=self._test_world_size_with_cpu_device)(


### PR DESCRIPTION
#### Context
- See #447.. our distributed tests fail when we run more than one in parallel (e.g. `python -m pytest -v tests/torchtune/utils/test_distributed.py` passes but `python -m pytest -v tests/torchtune/utils` fails)

#### Changelog
- I believe this is because we are doing multiple distributed launches in the same test session attached to the same endpoint. So I moved `get_pet_launch_config` from `test_utils.py` to `conftest.py` so that I could make it a session-level fixture. This way we only create it once per test session and do not run into port collisions.

#### Test plan

```
python -m pytest -v tests/torchtune/utils
...
================ 54 passed, 15 warnings in 99.96s (0:01:39) ===============
```
