### PR TITLE
[Easy] update the 'Converting the checkpoint into PyTorch-native' instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ tune download --repo-id meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir
 Now that you have the Llama2 model weights, convert them into a PyTorch-native format supported by TorchTune.
 
 ```
-tune convert_checkpoint --checkpoint-path /tmp/llama2/consolidated.00.pth --output-path /tmp/llama2_native
+tune convert_checkpoint --checkpoint-path /tmp/llama2/consolidated.00.pth --output-path /tmp/llama2_native --model llama2
 ```
 
 &nbsp;


### PR DESCRIPTION
#### Context
The current converting checkpoint command line instruction doesn't work. 
It throws error
``` 
convert_checkpoint.py: error: the following arguments are required: --model
```

#### Changelog

#### Test plan
test
```
tune convert_checkpoint --checkpoint-path /tmp/llama2/consolidated.00.pth --output-path /tmp/llama2_native --model llama2
```
in command line and it converted the model successfully
