### PR TITLE
Add default null max_steps_per_epoch to LoRA config

### DIFF
--- a/recipes/configs/alpaca_llama2_lora_finetune.yaml
+++ b/recipes/configs/alpaca_llama2_lora_finetune.yaml
@@ -42,6 +42,7 @@ loss:
 
 # Training
 epochs: 1
+max_steps_per_epoch: null
 resume_from_checkpoint: False
 
 # Logging


### PR DESCRIPTION
#### Context
- LoRA FT script is broken due to missing config field `max_steps_per_epoch`

#### Changelog
- Set `max_steps_per_epoch` to null in `alpaca_llama2_lora_finetune.yaml`

#### Test plan

```
tune --nnodes 1 --nproc_per_node 2 lora_finetune --config alpaca_llama2_lora_finetune --override model_checkpoint=/data/users/ebs/checkpoints/lora-debug/llama2-7b-01242024 seed=18 tokenizer._component_=torchtune.models.llama2.llama2_tokenizer tokenizer.pat
h=/data/users/ebs/checkpoints/lora-debug/tokenizer.model output_dir=/data/users/ebs/checkpoints/test
...
1|2|Loss: 1.4417723417282104:   0%|                                                                                                     | 1/12940 [00:04<14:21:18,  3.99s/it]
```
