### PR TITLE
[Not for land][RFC] Torchtune pytorch profiler

### DIFF
--- a/recipes/configs/alpaca_llama2_full_finetune.yaml
+++ b/recipes/configs/alpaca_llama2_full_finetune.yaml
@@ -22,22 +22,22 @@ model_checkpoint: /tmp/llama2_native
 
 # Fine-tuning arguments
 batch_size: 2
-epochs: 3
+epochs: 1
 optimizer:
   _component_: torch.optim.SGD
   lr: 2e-5
 loss:
   _component_: torch.nn.CrossEntropyLoss
-max_steps_per_epoch: null
+max_steps_per_epoch: 30
 gradient_accumulation_steps: 1
-log_every_n_steps: null
+log_every_n_steps: 2
 run_generation: null
 resume_from_checkpoint: False
 
 # Distributed
 device: cuda
-dtype: fp32
-enable_fsdp: True
+dtype: bf16
+enable_fsdp: False
 enable_activation_checkpointing: True
 cpu_offload: False
 

--- a/recipes/configs/alpaca_llama2_lora_finetune.yaml
+++ b/recipes/configs/alpaca_llama2_lora_finetune.yaml
@@ -42,7 +42,8 @@ loss:
 
 # Training
 epochs: 1
-max_steps_per_epoch: null
+max_steps_per_epoch: 30
+gradient_accumulation_steps: 1
 resume_from_checkpoint: False
 
 # Logging
@@ -50,10 +51,10 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: 1
+log_every_n_steps: 2
 
 # Environment
 device: cuda
-dtype: fp32
-enable_fsdp: True
+dtype: bf16
+enable_fsdp: False
 enable_activation_checkpointing: True

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -17,7 +17,7 @@ from .distributed import (
 )
 from .logging import get_logger
 from .memory import set_activation_checkpointing
-from .precision import get_autocast, get_dtype, get_gradient_scaler, list_dtypes
+from .precision import get_autocast, get_dtype, get_gradient_scaler, list_dtypes, validate_expected_param_dtype, set_default_dtype
 from .seed import set_seed
 
 __all__ = [

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -113,3 +113,33 @@ def get_autocast(dtype: torch.dtype, device: torch.device) -> ContextManager:
         )
     else:
         return contextlib.nullcontext()
+
+@contextlib.contextmanager
+def set_default_dtype(dtype: torch.dtype) -> None:
+    """
+    Context manager that sets the default dtype. Within
+    the context, default dtype will be as given by ``dtype``
+    argument.
+    Args:
+        dtype (torch.dtype): dtype to set as default.
+    """
+    old_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(old_dtype)
+def validate_expected_param_dtype(model: torch.nn.Module, dtype: torch.dtype) -> None:
+    """
+    Validates that all parameters in the model have the expected dtype.
+    Args:
+        model (torch.nn.Module): Model to validate.
+        dtype (torch.dtype): Expected dtype.
+    Raises:
+        ValueError: If any parameter in the model has a different dtype than `dtype`.
+    """
+    for name, param in model.named_parameters():
+        if param.dtype != dtype:
+            raise ValueError(
+                f"Parameter {name} has dtype {param.dtype}"
+            )


### PR DESCRIPTION
#### Context
Based on the discussed, we plan to add pytorch profiler to torchtun full finetune and lora finetune recipes to compare the delta.

In this PR, I added pytorch profiler in torchtune full finetune. I was able to see the log output file at ./log/torchtune_fft. Then I followed the instruction here https://github.com/pytorch/kineto/blob/main/tb_plugin/README.md to visualize profiling output. But I wasn;t able to see the proper profiling data in TB. please see the attached screenshot 
<img width="1909" alt="Screenshot 2024-03-08 at 11 19 50 AM" src="https://github.com/pytorch-labs/torchtune/assets/29116689/5eddec6f-c754-42ea-925e-4353b95d31b9">


#### Changelog
- ...

#### Test plan
- ....
