### PR TITLE
Fix passing of FSDP arg to LoRA recipe test

### DIFF
--- a/tests/recipes/test_lora_finetune.py
+++ b/tests/recipes/test_lora_finetune.py
@@ -70,10 +70,10 @@ class TestLoRAFinetuneRecipe:
         cmd += ['model.lora_attn_modules=["q_proj", "k_proj", "v_proj", "output_proj"]']
 
         if enable_fsdp:
-            cmd.append("--enable-fsdp")
-            context_manager = contextlib.nullcontext
-        else:
+            cmd.append("enable_fsdp=True")
             context_manager = single_box_init
+        else:
+            context_manager = contextlib.nullcontext
 
         with context_manager():
             monkeypatch.setattr(sys, "argv", cmd)


### PR DESCRIPTION
#### Context
- Our current `test_lora_finetune.py` is not passing the `enable_fsdp` flag to the recipe correctly. It is also using the wrong context manager (swapping null context manager for single box init)

#### Changelog
- Fix the config and swap the context managers back.

#### Test plan

First: add `import pdb; pdb.set_trace()` at the first line of both `test_loss` and `LoRAFinetuneRecipe.__init__`.

Before this change:

```
pytest -v tests/recipes/test_lora_finetune.py -k 'test_loss'
...
tests/recipes/test_lora_finetune.py::TestLoRAFinetuneRecipe::test_loss[False] 
> /data/users/ebs/ebs-torchtune/tests/recipes/test_lora_finetune.py(54)test_loss()
-> ckpt = "lora_small_test_ckpt"
(Pdb) enable_fsdp
False
(Pdb) c
> /data/users/ebs/torchtune/recipes/lora_finetune.py(76)__init__()
-> self._device = utils.get_device(device=cfg.device)
(Pdb) cfg.enable_fsdp
False 
(Pdb) c

tests/recipes/test_lora_finetune.py::TestLoRAFinetuneRecipe::test_loss[True] 
> /data/users/ebs/ebs-torchtune/tests/recipes/test_lora_finetune.py(54)test_loss()
-> ckpt = "lora_small_test_ckpt"
(Pdb) enable_fsdp
True
(Pdb) c
> /data/users/ebs/torchtune/recipes/lora_finetune.py(76)__init__()
-> self._device = utils.get_device(device=cfg.device)
(Pdb) cfg.enable_fsdp
False # THIS LINE IS INCORRECT
```

After this change:
```
pytest -v tests/recipes/test_lora_finetune.py -k 'test_loss'
...
tests/recipes/test_lora_finetune.py::TestLoRAFinetuneRecipe::test_loss[False] 
> /data/users/ebs/ebs-torchtune/tests/recipes/test_lora_finetune.py(54)test_loss()
-> ckpt = "lora_small_test_ckpt"
(Pdb) enable_fsdp
False
(Pdb) c
> /data/users/ebs/torchtune/recipes/lora_finetune.py(76)__init__()
-> self._device = utils.get_device(device=cfg.device)
(Pdb) cfg.enable_fsdp
False 
(Pdb) c

tests/recipes/test_lora_finetune.py::TestLoRAFinetuneRecipe::test_loss[True] 
> /data/users/ebs/ebs-torchtune/tests/recipes/test_lora_finetune.py(54)test_loss()
-> ckpt = "lora_small_test_ckpt"
(Pdb) enable_fsdp
True
(Pdb) c
> /data/users/ebs/torchtune/recipes/lora_finetune.py(76)__init__()
-> self._device = utils.get_device(device=cfg.device)
(Pdb) cfg.enable_fsdp
True # Now it's correct
```


```
pytest -v tests/recipes/test_lora_finetune.py -k 'test_loss'
...
========== 2 passed, 5 warnings in 15.53s ===========
```

