### PR TITLE
Check for bf16 availibility when running with full bf16

### DIFF
--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -115,7 +115,12 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             )
             self._update_recipe_state(lora_ckpt)
 
-        if cfg.full_bf16 and not torch.cuda.is_bf16_supported():
+        # For CUDA devices, check if the HW supports bf16.
+        if (
+            cfg.full_bf16
+            and self._device != torch.device("cpu")
+            and not torch.cuda.is_bf16_supported()
+        ):
             raise RuntimeError("Full bf16 training is not supported on this hardware.")
 
         self._model = self._setup_model(


### PR DESCRIPTION
#### Context
- We mention that we do this in the recipe but actually didn't add this in the previous PR.

#### Changelog
- Adds `torch.cuda.is_bf16_supported` check before setting up model. Is there a better place for this check to live?

#### Test plan
- `tune lora_finetune_single_device --config recipes/configs/alpaca_llama2_lora_finetune_single_device.yaml --override model_checkpoint=/home/rvarm1/local/dev/assets/llama2-7b-01242024 seed=18 tokenizer_checkpoint=/home/rvarm1/local/dev/assets/tokenizer.model output_dir=/tmp/lora_debug device=cuda batch_size=2 enable_activation_checkpointing=False full_bf16=True`
- Patching `torch.cuda.is_bf16_supported` to return False, recipe raises: `RuntimeError: Full bf16 training is not supported on this hardware.`
