### PR TITLE
Fix distributed tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,6 +95,9 @@ def assert_expected(
 
 @contextmanager
 def single_box_init(init_pg: bool = True):
+    env_vars = ["MASTER_ADDR", "MASTER_PORT", "LOCAL_RANK", "RANK", "WORLD_SIZE"]
+    initial_os = {k: os.environ.get(k, None) for k in env_vars}
+    os.environ.get("MASTER_ADDR", None)
     os.environ["MASTER_ADDR"] = "localhost"
     # TODO: Don't hardcode ports as this could cause flakiness if tests execute
     # in parallel.
@@ -113,6 +116,11 @@ def single_box_init(init_pg: bool = True):
     finally:
         if init_pg:
             torch.distributed.destroy_process_group()
+        for k in env_vars:
+            if initial_os.get(k) is None:
+                del os.environ[k]
+            else:
+                os.environ[k] = initial_os[k]
 
 
 @contextmanager

--- a/tests/torchtune/utils/test_distributed.py
+++ b/tests/torchtune/utils/test_distributed.py
@@ -30,6 +30,13 @@ from torchtune.utils.distributed import (
 
 
 class TestDistributed:
+    def test_init_distributed(self) -> None:
+        """Integration test to confirm consistency across device initialization utilities."""
+        distributed = init_distributed()
+        assert (
+            not distributed
+        ), "Should return False as there are no distributed environment variables"
+
     @staticmethod
     def _test_worker_fn(init_pg_explicit: bool) -> None:
         """


### PR DESCRIPTION
#### Context
- On main branch, the command `pytest tests/` currently fails:

```
pytest/tests/
...
FAILED tests/recipes/test_lora_finetune.py::TestLoRAFinalCheckpoints::test_save_and_load_merged_weights[True-True] - omegaconf.errors.ConfigAttributeError: Missing key apply_lora_to_output
FAILED tests/recipes/test_lora_finetune.py::TestLoRAFinalCheckpoints::test_save_and_load_merged_weights[True-False] - omegaconf.errors.ConfigAttributeError: Missing key apply_lora_to_output
FAILED tests/recipes/test_lora_finetune.py::TestLoRAFinalCheckpoints::test_save_and_load_merged_weights[False-True] - ValueError: trying to initialize the default process group twice!
FAILED tests/recipes/test_lora_finetune.py::TestLoRAFinalCheckpoints::test_save_and_load_merged_weights[False-False] - omegaconf.errors.ConfigAttributeError: Missing key apply_lora_to_output
FAILED tests/torchtune/utils/test_distributed.py::TestDistributed::test_init_distributed - RuntimeError: torch.distributed already initialized.
FAILED tests/torchtune/utils/test_distributed.py::TestDistributed::test_default_wrap_fsdp - ValueError: trying to initialize the default process group twice!
FAILED tests/torchtune/utils/test_distributed.py::TestDistributed::test_wrap_fsdp_wrapping - ValueError: trying to initialize the default process group twice!
FAILED tests/torchtune/utils/test_distributed.py::TestDistributed::test_wrap_fsdp_custom_policy - ValueError: trying to initialize the default process group twice!
FAILED tests/torchtune/utils/test_distributed.py::TestLoRAFSDP::test_lora_fsdp_wrap - ValueError: trying to initialize the default process group twice!
=================================== 9 failed, 178 passed, 11 warnings in 146.21s (0:02:26) ===================================
```

Note that this does not fail if we run e.g. `pytest tests/recipes`. It also does not fail if we run `pytest tests/torchtune`. In fact, a minimal command to trigger the failure is given by running `pytest tests/recipes/test_lora_finetune.py tests/torchtune/utils/distributed.py`. Why do these two tests trigger the failure? Well, 

(a) `test_lora_finetune.py` uses [single_box_init](https://github.com/pytorch-labs/torchtune/blob/f20049417d938d4de4b25b31cf7a8212cb5ecaf0/tests/test_utils.py#L97-L115), which sets a bunch of environment variables. 
(b) The `test_init_distributed` test case in `test_distributed.py` calls `init_distributed`, which checks if `is_distributed()` is true. `is_distributed()` is just a [check on all those environment variables](https://github.com/pytorch-labs/torchtune/blob/f20049417d938d4de4b25b31cf7a8212cb5ecaf0/torchtune/utils/distributed.py#L45-L55) that were set in (a), so it returns True. This causes the process group to be initialized [here](https://github.com/pytorch-labs/torchtune/blob/f20049417d938d4de4b25b31cf7a8212cb5ecaf0/torchtune/utils/distributed.py#L93). But this test doesn't expect that, since the expected value is False. So by initializing the process group here, we are breaking the contract with _all_ the other tests in this file, which all either initialize the process group themselves explicitly ([e.g.](https://github.com/pytorch-labs/torchtune/blob/f20049417d938d4de4b25b31cf7a8212cb5ecaf0/tests/torchtune/utils/test_distributed.py#L46)), or use single_box_init themselve ([e.g.](https://github.com/pytorch-labs/torchtune/blob/f20049417d938d4de4b25b31cf7a8212cb5ecaf0/tests/torchtune/utils/test_distributed.py#L92)).

How to fix it? Actually at first I just deleted `test_init_distributed`, which also works. But I would propose that any good context manager should leave things as they were before it was invoked, and currently `single_box_init` is not doing that. So..

#### Changelog
- Add logic to `single_box_init` to restore any environment variables modified by the context manager to their previous state on exit.
- Also clean up a couple more LoRA output proj bugs that snuck in due to landing the weight merge PR after the LoRA output proj PR (sorry..)

#### Test plan


```
pytest tests/
...
======= 186 passed, 25 warnings in 176.89s (0:02:56) ==========
```
