### PR TITLE
[Eazy][Fix] Update the lora recipes configs model checkpoint path

### DIFF
--- a/recipes/configs/alpaca_llama2_lora_finetune_distributed.yaml
+++ b/recipes/configs/alpaca_llama2_lora_finetune_distributed.yaml
@@ -12,7 +12,7 @@ model:
   lora_rank: 8
   lora_alpha: 16
 
-model_checkpoint: /tmp/llama2_native
+model_checkpoint: /tmp/llama2/llama2_native.pt
 lora_checkpoint: null
 
 # Tokenizer

--- a/recipes/configs/alpaca_llama2_lora_finetune_single_device.yaml
+++ b/recipes/configs/alpaca_llama2_lora_finetune_single_device.yaml
@@ -12,7 +12,7 @@ model:
   lora_rank: 8
   lora_alpha: 16
 
-model_checkpoint: /tmp/llama2_native
+model_checkpoint: /tmp/llama2/llama2_native.pt
 lora_checkpoint: null
 
 # Tokenizer


### PR DESCRIPTION
#### Context
- Currently, lora recipes configs model_checkpoint path isn't consistent with the converting checkpoint output path in https://github.com/pytorch/torchtune?tab=readme-ov-file#converting-the-checkpoint-into-pytorch-native-for-lora and will cause kicking off training failure. 

#### Changelog
- Update the paths to make it easier for user to kick off training

#### Test plan
- tune --nnodes 1 --nproc_per_node 1 lora_finetune_single_device --config alpaca_llama2_lora_finetune_single_device 
- tune --nnodes 1 --nproc_per_node 1 lora_finetune_distributed --config alpaca_llama2_lora_finetune_distributed and kick off training successfully  


