### PR TITLE
Update paths from pytorch-labs to pytorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-[![Unit Test](https://github.com/pytorch-labs/torchtune/actions/workflows/unit_test.yaml/badge.svg?branch=main)](https://github.com/pytorch-labs/torchtune/actions/workflows/unit_test.yaml)
-![Recipe Integration Test](https://github.com/pytorch-labs/torchtune/actions/workflows/recipe_test.yaml/badge.svg)
+[![Unit Test](https://github.com/pytorch/torchtune/actions/workflows/unit_test.yaml/badge.svg?branch=main)](https://github.com/pytorch/torchtune/actions/workflows/unit_test.yaml)
+![Recipe Integration Test](https://github.com/pytorch/torchtune/actions/workflows/recipe_test.yaml/badge.svg)
 [![](https://dcbadge.vercel.app/api/server/4Xsdn8Rr9Q?style=flat)](https://discord.gg/4Xsdn8Rr9Q)
 
 # TorchTune (alpha release)
@@ -38,11 +38,11 @@ experience different peak memory utilization based on changes made in configurat
 
 | HW Resources | Finetuning Method |  Config | Model Size | Peak Memory per GPU
 |--------------|-------------------|---------|------------|---------------------|
-| 2 x RTX 4090 |     LoRA          | [lora_finetune](https://github.com/pytorch-labs/torchtune/blob/main/recipes/configs/alpaca_llama2_lora_finetune.yaml)    |    7B      |    18 GB *           |
-| 1 x A6000    |     LoRA          | [lora_finetune](https://github.com/pytorch-labs/torchtune/blob/main/recipes/configs/alpaca_llama2_lora_finetune.yaml)    |    7B      |    29.5 GB *           |
-| 4 x T4       |     LoRA          | [lora_finetune](https://github.com/pytorch-labs/torchtune/blob/main/recipes/configs/alpaca_llama2_lora_finetune.yaml)    |    7B      |    12 GB *           |
-| 2 x A100 80G |   Full finetune   | [full_finetune](https://github.com/pytorch-labs/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml)    |    7B      |    62 GB             |
-| 8 x A6000    |   Full finetune   | [full_finetune](https://github.com/pytorch-labs/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml)    |    7B      |    42 GB *             |
+| 2 x RTX 4090 |     LoRA          | [lora_finetune](https://github.com/pytorch/torchtune/blob/main/recipes/configs/alpaca_llama2_lora_finetune.yaml)    |    7B      |    18 GB *           |
+| 1 x A6000    |     LoRA          | [lora_finetune](https://github.com/pytorch/torchtune/blob/main/recipes/configs/alpaca_llama2_lora_finetune.yaml)    |    7B      |    29.5 GB *           |
+| 4 x T4       |     LoRA          | [lora_finetune](https://github.com/pytorch/torchtune/blob/main/recipes/configs/alpaca_llama2_lora_finetune.yaml)    |    7B      |    12 GB *           |
+| 2 x A100 80G |   Full finetune   | [full_finetune](https://github.com/pytorch/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml)    |    7B      |    62 GB             |
+| 8 x A6000    |   Full finetune   | [full_finetune](https://github.com/pytorch/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml)    |    7B      |    42 GB *             |
 
 
 NOTE: * indicates an estimated metric based on experiments conducted on A100 GPUs with GPU memory artificially limited using [torch.cuda.set_per_process_memory_fraction API](https://pytorch.org/docs/stable/generated/torch.cuda.set_per_process_memory_fraction.html). Peak memory per GPU is as reported by `nvidia-smi` monitored over a couple hundred training iterations. Please file an issue if you are not able to reproduce these results when running TorchTune on certain hardware.
@@ -58,7 +58,7 @@ Currently, `torchtune` must be built via cloning the repository and installing a
 NOTE: TorchTune is currently only tested with the latest stable PyTorch release, which is currently [2.2](https://pytorch.org/get-started/locally/).
 
 ```
-git clone https://github.com/pytorch-labs/torchtune.git
+git clone https://github.com/pytorch/torchtune.git
 cd torchtune
 pip install -e .
 ```
@@ -116,7 +116,7 @@ tune convert_checkpoint --checkpoint-path /tmp/llama2/consolidated.00.pth \
 
 #### Running recipes
 
-TorchTune contains recipes for [full finetuning](https://github.com/pytorch-labs/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/full_finetune.py), [LoRA finetuning](https://github.com/pytorch-labs/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/lora_finetune.py), and [generation](https://github.com/pytorch-labs/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/alpaca_generate.py).
+TorchTune contains recipes for [full finetuning](https://github.com/pytorch/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/full_finetune.py), [LoRA finetuning](https://github.com/pytorch/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/lora_finetune.py), and [generation](https://github.com/pytorch/torchtune/blob/e802c057d17773f65cf80721807086724e4fa7db/recipes/alpaca_generate.py).
 
 Full-finetuning runs without the need for any model conversion. To run a full finetune on two devices on the Alpaca dataset using FSDP:
 
@@ -126,7 +126,7 @@ full_finetune \
 --config alpaca_llama2_full_finetune
 ```
 
-The argument passed to `--nproc_per_node` can be varied depending on how many GPUs you have. A full finetune can be memory-intensive, so make sure you are running on enough devices. See [this table](https://github.com/pytorch-labs/torchtune/blob/main/README.md#finetuning-resource-requirements) for resource requirements on common hardware setups.
+The argument passed to `--nproc_per_node` can be varied depending on how many GPUs you have. A full finetune can be memory-intensive, so make sure you are running on enough devices. See [this table](https://github.com/pytorch/torchtune/blob/main/README.md#finetuning-resource-requirements) for resource requirements on common hardware setups.
 
 Similarly, you can finetune with LoRA on the Alpaca dataset on two devices via the following. Remember to convert your
 model with `train_type` set to `lora`

--- a/docs/source/examples/finetune_llm.rst
+++ b/docs/source/examples/finetune_llm.rst
@@ -21,7 +21,7 @@ This recipe supports:
 
 * :ref:`Activation Checkpointing<ac_label>`
 
-This guide will walk you through the different aspects of the `recipe <https://github.com/pytorch-labs/torchtune/blob/main/recipes/full_finetune.py>`_.
+This guide will walk you through the different aspects of the `recipe <https://github.com/pytorch/torchtune/blob/main/recipes/full_finetune.py>`_.
 
 
 An example config for training the Llama 7B model using the Alpaca dataset looks something like this:
@@ -101,7 +101,7 @@ from Stanford. The following parameters are related to the data:
 Model
 -----
 
-In this example, we use the `Llama 7B model <https://github.com/pytorch-labs/torchtune/blob/main/torchtune/models/llama2.py>`_.
+In this example, we use the `Llama 7B model <https://github.com/pytorch/torchtune/blob/main/torchtune/models/llama2.py>`_.
 The following parameters are related to the model:
 
 .. code-block:: python

--- a/docs/source/examples/lora_finetune.rst
+++ b/docs/source/examples/lora_finetune.rst
@@ -247,7 +247,7 @@ Once we've loaded the base model weights, we also want to set only LoRA paramete
 LoRA finetuning recipe in TorchTune
 -----------------------------------
 
-Finally, we can put it all together and finetune a model using TorchTune's `LoRA recipe <https://github.com/pytorch-labs/torchtune/blob/48626d19d2108f92c749411fbd5f0ff140023a25/recipes/lora_finetune.py>`_.
+Finally, we can put it all together and finetune a model using TorchTune's `LoRA recipe <https://github.com/pytorch/torchtune/blob/48626d19d2108f92c749411fbd5f0ff140023a25/recipes/lora_finetune.py>`_.
 Make sure that you have first downloaded the Llama2 weights and tokenizer by following :ref:`these instructions<download_llama_label>`.
 You can then run the following command to perform a LoRA finetune of Llama2-7B using the Alpaca dataset with two GPUs (each having VRAM of at least 23GB):
 
@@ -263,7 +263,7 @@ You can then run the following command to perform a LoRA finetune of Llama2-7B u
 
 .. note::
     You can modify the value of :code:`nproc_per_node` depending on (a) the number of GPUs you have available,
-    and (b) the memory constraints of your hardware. See `this table <https://github.com/pytorch-labs/torchtune/tree/main?tab=readme-ov-file#finetuning-resource-requirements>`_
+    and (b) the memory constraints of your hardware. See `this table <https://github.com/pytorch/torchtune/tree/main?tab=readme-ov-file#finetuning-resource-requirements>`_
     for peak memory of LoRA finetuning in a couple of common hardware setups.
 
 The preceding command will run a LoRA finetune with TorchTune's factory settings, but we may want to experiment a bit.

--- a/docs/source/examples/recipe_deepdive.rst
+++ b/docs/source/examples/recipe_deepdive.rst
@@ -42,8 +42,8 @@ Each recipe consists of three components:
 - **Recipe Class**, core logic needed for training, exposed to users through a set of APIs
 
 In the following sections, we'll take a closer look at each of these components. For a complete working example, refer to the
-`full finetuning recipe <https://github.com/pytorch-labs/torchtune/blob/main/recipes/full_finetune.py>`_ in TorchTune and the associated
-`config <https://github.com/pytorch-labs/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml>`_.
+`full finetuning recipe <https://github.com/pytorch/torchtune/blob/main/recipes/full_finetune.py>`_ in TorchTune and the associated
+`config <https://github.com/pytorch/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml>`_.
 
 
 What Recipes are not?

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -8,7 +8,7 @@ There is currently only one way to download TorchTune, which is locally.
 
 .. code-block:: bash
 
-    git clone https://github.com/pytorch-labs/torchtune.git
+    git clone https://github.com/pytorch/torchtune.git
     cd torchtune
     pip install -e .
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -6,8 +6,8 @@
 
 Recipes are the primary entry points for TorchTune users. These can be thought of as end-to-end pipelines for training and optionally evaluating LLMs. Each recipe consists of three components:
 
-- **Configurable parameters**, specified through yaml configs [example](https://github.com/pytorch-labs/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml), command-line overrides and dataclasses
-- **Recipe class**, core logic needed for training, exposed to users through a set of APIs [interface](https://github.com/pytorch-labs/torchtune/blob/main/recipes/interfaces.py)
+- **Configurable parameters**, specified through yaml configs [example](https://github.com/pytorch/torchtune/blob/main/recipes/configs/alpaca_llama2_full_finetune.yaml), command-line overrides and dataclasses
+- **Recipe class**, core logic needed for training, exposed to users through a set of APIs [interface](https://github.com/pytorch/torchtune/blob/main/recipes/interfaces.py)
 - **Recipe script**, puts everything together including parsing and validating configs, setting up the environment, and correctly using the recipe class
 
 &nbsp;

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     description="Package for finetuning LLMs using native PyTorch",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    url="https://github.com/pytorch-labs/torchtune",
+    url="https://github.com/pytorch/torchtune",
     extras_require={"dev": read_requirements("dev-requirements.txt")},
 )

--- a/tests/recipes/test_lora_finetune.py
+++ b/tests/recipes/test_lora_finetune.py
@@ -73,7 +73,7 @@ class TestLoRAFinetuneRecipe:
             ckpt_dir = ckpt_path.parent
             # TODO (rohan-varma): setting CUDA_VISIBLE_DEVICES to ignore all GPUs
             # on machine to simulate current CI environment that does not have GPUs.
-            # Will consolidate as part of addressing https://github.com/pytorch-labs/torchtune/issues/473
+            # Will consolidate as part of addressing https://github.com/pytorch/torchtune/issues/473
             monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
             cmd = f"""
             tune {recipe_name}
@@ -236,7 +236,7 @@ class TestLoRAFinetuneRecipe:
         ckpt_dir = ckpt_path.parent
         # TODO (rohan-varma): setting CUDA_VISIBLE_DEVICES to ignore all GPUs
         # on machine to simulate current CI environment that does not have GPUs.
-        # Will consolidate as part of addressing https://github.com/pytorch-labs/torchtune/issues/473
+        # Will consolidate as part of addressing https://github.com/pytorch/torchtune/issues/473
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
         cmd = f"""
         tune {recipe_name}

--- a/tests/torchtune/models/llama2/scripts/compare_lora_attention.py
+++ b/tests/torchtune/models/llama2/scripts/compare_lora_attention.py
@@ -61,7 +61,7 @@ def compare_lora_attention(
     attn_dropout = 0.0
     # Reference implementation: wrap our native causal self-attention with PEFT LoRAConfig
     # Copy-pasted from llama2.py
-    # https://github.com/pytorch-labs/torchtune/blob/e983194629d7f093257225dafb7cbc4e46505cc8/torchtune/models/llama2.py#L88-L114
+    # https://github.com/pytorch/torchtune/blob/e983194629d7f093257225dafb7cbc4e46505cc8/torchtune/models/llama2.py#L88-L114
     head_dim = embed_dim // num_heads
     num_kv_heads = num_kv_heads if num_kv_heads else num_heads
     kv_cache = (

--- a/torchtune/_cli/tune.py
+++ b/torchtune/_cli/tune.py
@@ -29,9 +29,9 @@ does with the following additional functionalities:
 .. note:: ``tune`` is a python
           `console script <https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts>`_
           to the main module
-          `scripts.cli_utils.tune <https://github.com/pytorch-labs/torchtune/blob/main/scripts/cli_utils/tune>`_
+          `scripts.cli_utils.tune <https://github.com/pytorch/torchtune/blob/main/scripts/cli_utils/tune>`_
           declared in the ``scripts`` configuration in
-          `setup.py <https://github.com/pytorch-labs/torchtune/blob/main/setup.py>`_.
+          `setup.py <https://github.com/pytorch/torchtune/blob/main/setup.py>`_.
           It is equivalent to invoking ``python -m scripts.cli_utils.tune``.
 """
 import argparse


### PR DESCRIPTION
Updated the doc pages, setup.py url and all references for repo move from pytorch-labs to pytorch

Test Plan: 
Changes for setup.py (rest are all doc changes). 
Installed from branch on different machine and verified tune with FT recipe is working fine on new machine




