### PR TITLE
Optimize training speed by moving loss.item() into log_n_steps block

### DIFF
--- a/recipes/full_finetune.py
+++ b/recipes/full_finetune.py
@@ -372,9 +372,8 @@ class FullFinetuneRecipe(FTRecipeInterface):
 
                 # Note: We're always logging the loss before normalizing it
                 # Check if this is the norm or not
-                pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
-
                 if self.total_training_steps % self._log_every_n_steps == 0:
+                    pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
                     self._metric_logger.log_dict(
                         {
                             "loss": loss.item(),

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -432,12 +432,12 @@ class LoRAFinetuneDistributedRecipe(FTRecipeInterface):
                     logits = logits.transpose(1, 2)
                     # Compute loss
                     loss = self._loss_fn(logits, labels)
-                pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
 
                 if (
                     self.total_training_steps % self._log_every_n_steps == 0
                     and self._is_rank_zero
                 ):
+                    pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
                     self._metric_logger.log_dict(
                         {
                             "loss": loss.item(),

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -391,9 +391,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
 
-                pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
-
                 if self.total_training_steps % self._log_every_n_steps == 0:
+                    pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
                     self._metric_logger.log_dict(
                         {
                             "loss": loss.item(),


### PR DESCRIPTION
#### Context
Based on the pytorch profiling tracing
<img width="1530" alt="Screenshot 2024-03-18 at 4 05 34 PM" src="https://github.com/pytorch/torchtune/assets/29116689/bfb766d9-470d-4278-837f-c0fb6e24d2c7">
@rohan-varma found that it takes 40 - 50 ms for cudaStreamSynchronize operation to sync the loss value to CPU for every step. 

#### Changelog
To optimize training speed, we move the loss.item() operation into log_every_n_steps block to avoid cudaStreamSynchronize in every step

#### Test plan
We applied the changes on fft, lora single device and lore distributed. In the below comparison, we focus on lora single device. 

command line to kick off training: `tune --nnodes 1 --nproc_per_node 1 lora_finetune_single_device --config alpaca_llama2_lora_finetune_single_device`

yaml config 
```
# Config for LoRAFinetuneRecipeSingleDevice in lora_finetune_single_device.py
#
# To launch, run the following command from root:
#    tune lora_finetune_single_device --config alpaca_llama2_lora_finetune_single_device model_checkpoint=<your_checkpoint_dir> ...

# Model Arguments
model:
  _component_: torchtune.models.llama2.lora_llama2_7b
  lora_attn_modules: ['q_proj', 'v_proj']
  apply_lora_to_mlp: False
  apply_lora_to_output: False
  lora_rank: 8
  lora_alpha: 16

checkpointer:
  _component_: torchtune.utils.FullModelMetaCheckpointer
  checkpoint_dir: /tmp/llama2/
  checkpoint_files: [consolidated.00.pth]
  adapter_checkpoint: null
  recipe_checkpoint: null
  output_dir: /tmp/llama2/
  model_type: LLAMA2
resume_from_checkpoint: False

# Tokenizer
tokenizer:
  _component_: torchtune.models.llama2.llama2_tokenizer
  path: /tmp/llama2/tokenizer.model

# Dataset and Sampler
dataset:
  _component_: torchtune.datasets.AlpacaDataset
  train_on_input: True
  use_clean: True
seed: null
shuffle: True
batch_size: 2

# Optimizer and Scheduler
optimizer:
  _component_: torch.optim.AdamW
  weight_decay: 0.01
  lr: 3e-4
lr_scheduler:
  _component_: torchtune.modules.get_cosine_schedule_with_warmup
  num_warmup_steps: 100

loss:
  _component_: torch.nn.CrossEntropyLoss

# Training
epochs: 1
max_steps_per_epoch: 1000

# Logging
output_dir: /tmp/lora_finetune_output
metric_logger:
  _component_: torchtune.utils.metric_logging.DiskLogger
  log_dir: ${output_dir}
log_every_n_steps: 10

# Environment
device: cuda
full_bf16: True
enable_activation_checkpointing: False
```

before the change training time for 1000 steps 224s 
after the change training time for 100 steps 220s 

before the change tracing
<img width="1598" alt="Screenshot 2024-03-18 at 4 14 33 PM" src="https://github.com/pytorch/torchtune/assets/29116689/74ba7c5a-760c-4b85-a5ab-b659cbacb94c">
after the change tracing
<img width="1571" alt="Screenshot 2024-03-18 at 4 15 12 PM" src="https://github.com/pytorch/torchtune/assets/29116689/2a0a6604-e358-4864-8c5d-0c5a2b4f29b1">


#### Discussion Item 
- Seems the impact of this changes is over estimated. Theoretically, we reduce num of loss.item() operations from 1000 to 100 by training 1000 steps, it should save us 40ms * 900 = 36s but in reality, it saves us 4s. The hypothesis is pytorch tracing has performance overhead and makes cudaStreamSynchronize takes longer than actual
