### PR TITLE
Solve the duplicate loss.item() call caused by PR conflict

### DIFF
--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -492,8 +492,6 @@ class LoRAFinetuneDistributedRecipe(FTRecipeInterface):
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
 
-                pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
-
                 if (
                     self.total_training_steps % self._log_every_n_steps == 0
                     and self._is_rank_zero


### PR DESCRIPTION
#### Context
There is a conflict between https://github.com/pytorch/torchtune/pull/514 and https://github.com/pytorch/torchtune/pull/522 and cause pbar to get loss get called twice. 

#### Changelog
Remove the duplicated loss.item() call

#### Test plan
tune --nnodes 1 --nproc_per_node 1 lora_finetune_distributed --config alpaca_llama2_lora_finetune_distributed

