### PR TITLE
Add missing test for `_get_template`

### DIFF
--- a/tests/torchtune/datasets/test_instruct_dataset.py
+++ b/tests/torchtune/datasets/test_instruct_dataset.py
@@ -6,8 +6,11 @@
 
 from unittest import mock
 
-from torchtune.datasets import InstructDataset
+import pytest
+from torchtune.data import AlpacaInstructTemplate
 from torchtune.datasets._common import CROSS_ENTROPY_IGNORE_IDX
+
+from torchtune.datasets._instruct import _get_template, InstructDataset
 
 
 class DummyTokenizer:
@@ -97,3 +100,34 @@ class TestInstructDataset:
             prompt, label = dataset[i]
             assert prompt == self.expected_tokenized_prompts[i]
             assert label == expected_labels[i]
+
+
+def test_get_template():
+    # Test valid template class
+    template = _get_template("AlpacaInstructTemplate")
+    assert isinstance(template, AlpacaInstructTemplate)
+
+    # Test invalid template class
+    with pytest.raises(
+        ValueError,
+        match="Must be a PromptTemplate class or a string with placeholders.",
+    ):
+        _ = _get_template("InvalidTemplate")
+
+    # Test valid template strings
+    s = [
+        "Instruction: {instruction}\nInput: {input}",
+        "Instruction: {instruction}",
+        "{a}",
+    ]
+    for t in s:
+        assert _get_template(t) == t
+
+    # Test invalid template strings
+    s = ["hello", "{}", "a}{b"]
+    for t in s:
+        with pytest.raises(
+            ValueError,
+            match="Must be a PromptTemplate class or a string with placeholders.",
+        ):
+            _ = _get_template(t)

--- a/torchtune/datasets/_instruct.py
+++ b/torchtune/datasets/_instruct.py
@@ -5,10 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import re
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from datasets import load_dataset
 from torch.utils.data import Dataset
+from torchtune.config._errors import InstantiationError
 from torchtune.config._utils import _get_component_from_path
 
 from torchtune.data import PromptTemplate


### PR DESCRIPTION
## Context
Got too excited checking in #520 that I forgot to add a test for `_get_template`. And adding it revealed some bugs. Oops.

## Test plan
`pytest tests/torchtune/datasets/test_instruct_dataset.py`
