### PR TITLE
Improve config parsing errors

### DIFF
--- a/tests/torchtune/config/test_utils.py
+++ b/tests/torchtune/config/test_utils.py
@@ -95,3 +95,15 @@ class TestUtils:
         ), f"b == {conf.b._component_}, not 2 as set in the config."
         assert conf.b.c == 5, f"b.c == {conf.b.c}, not 5 as set in overrides."
         assert mock_load.call_count == 3
+
+        yaml_args, cli_args = parser.parse_known_args(
+            [
+                "--config",
+                "test.yaml",
+                "b",  # Test invalid override
+            ]
+        )
+        with pytest.raises(
+            ValueError, match="Command-line overrides must be in the form of key=value"
+        ):
+            _ = _merge_yaml_and_cli_args(yaml_args, cli_args)

--- a/tests/torchtune/utils/test_argparse.py
+++ b/tests/torchtune/utils/test_argparse.py
@@ -41,3 +41,8 @@ class TestArgParse:
         assert (
             cli_kwargs.c == 4
         ), f"c == {cli_kwargs.c} not 4 as set in the command args."
+
+        with pytest.raises(ValueError, match="Additional flag arguments not supported"):
+            _ = parser.parse_known_args(
+                ["--config", "test.yaml", "--b", "3"],
+            )

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -122,12 +122,20 @@ def _merge_yaml_and_cli_args(yaml_args: Namespace, cli_args: List[str]) -> DictC
 
     Returns:
         DictConfig: OmegaConf DictConfig containing merged args
+
+    Raises:
+        ValueError: If a cli override is not in the form of key=value
     """
     # Convert Namespace to simple dict
     yaml_kwargs = vars(yaml_args)
     cli_dotlist = []
     for arg in cli_args:
-        k, v = arg.split("=")
+        try:
+            k, v = arg.split("=")
+        except ValueError:
+            raise ValueError(
+                f"Command-line overrides must be in the form of key=value, got {arg}"
+            ) from None
         # If a cli arg overrides a yaml arg with a _component_ field, update the
         # key string to reflect this
         if k in yaml_kwargs and _has_component(yaml_kwargs[k]):

--- a/torchtune/utils/argparse.py
+++ b/torchtune/utils/argparse.py
@@ -44,11 +44,19 @@ class TuneArgumentParser(argparse.ArgumentParser):
 
         https://docs.python.org/3/library/argparse.html#the-parse-args-method
         """
-        namespace, _ = super().parse_known_args(*args, **kwargs)
-        if namespace.config is not None:
-            config = OmegaConf.load(namespace.config)
-            assert "config" not in config, "Cannot use 'config' within a config file"
-            self.set_defaults(**config)
+        namespace, unknown_args = super().parse_known_args(*args, **kwargs)
+
+        unknown_flag_args = [arg for arg in unknown_args if arg.startswith("--")]
+        if unknown_flag_args:
+            raise ValueError(
+                f"Additional flag arguments not supported: {unknown_flag_args}. Please use --config or key=value overrides"
+            )
+
+        config = OmegaConf.load(namespace.config)
+        assert "config" not in config, "Cannot use 'config' within a config file"
+        self.set_defaults(**config)
+
         namespace, unknown_args = super().parse_known_args(*args, **kwargs)
         del namespace.config
+
         return namespace, unknown_args


### PR DESCRIPTION
## Context
- More descriptive error message when overrides are now in the form `key=value`
- Prevent users from entering additional `--` flag arguments and silently failing

## Test plan
Buffed up existing unit tests
