### PR TITLE
Distributed Recipe Cleanups

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import gc
 import sys
 import time
 

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -237,8 +237,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         if self._dtype == torch.bfloat16:
             model = model.to(torch.bfloat16)
 
-
-
         # Wrap the model with FSDP. This will ensure that the model is sharded
         # across all available GPUs.
         model = FSDP(

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -397,8 +397,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         ``max_steps_per_epoch``.
         """
         # clean up before training begins
-        gc.collect()
-        torch.cuda.empty_cache()
+        utils.cleanup_before_training()
 
         _, rank = utils.get_world_size_and_rank()
 

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -311,8 +311,12 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         The core training loop. Supports training on subsets of the dataset using the
         ``max_steps_per_epoch``.
         """
+
+        utils.cleanup_before_training()
+
         # zero out the gradients before starting training
         self._optimizer.zero_grad()
+
         # self.epochs_run should be non-zero when we're resuming from a checkpoint
         for curr_epoch in range(self.epochs_run, self.total_epochs):
             # Update the sampler to ensure data is correctly shuffled across epochs

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -311,9 +311,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         The core training loop. Supports training on subsets of the dataset using the
         ``max_steps_per_epoch``.
         """
-
-        utils.cleanup_before_training()
-
         # zero out the gradients before starting training
         self._optimizer.zero_grad()
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import gc
 import sys
 import time
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -480,10 +480,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         The core training loop.
         """
         # clean up before training begins
-        gc.collect()
-        torch.cuda.empty_cache()
-        torch.cuda.reset_peak_memory_stats()
-
+        utils.cleanup_before_training()
 
         _, rank = utils.get_world_size_and_rank()
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -102,7 +102,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # logging attributes
         self._output_dir = cfg.output_dir
         self._log_every_n_steps = cfg.log_every_n_steps if cfg.log_every_n_steps else 1
-        self._log_peak_memory_every_n_steps = 10
+        self._log_peak_memory_every_n_steps = 100
         # training attributes
         self._enable_activation_checkpointing = cfg.enable_activation_checkpointing
 

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .argparse import TuneArgumentParser
 from ._checkpointing import (  # noqa
     FullModelHFCheckpointer,
     FullModelMetaCheckpointer,
@@ -22,6 +21,7 @@ from ._distributed import (  # noqa
     validate_no_params_on_meta_device,
     wrap_fsdp,
 )
+from .argparse import TuneArgumentParser
 from .checkpoint import (  # noqa
     save_checkpoint,
     transform_opt_state_dict,
@@ -39,10 +39,10 @@ from .constants import (  # noqa
     TOTAL_EPOCHS_KEY,
 )
 from .logging import get_logger
-from .memory import (   # noqa
+from .memory import (  # noqa
+    cleanup_before_training,
     memory_stats_log,
     set_activation_checkpointing,
-    cleanup_before_training,
 )
 from .precision import (
     get_autocast,

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .argparse import TuneArgumentParser
 from ._checkpointing import (  # noqa
     FullModelHFCheckpointer,
     FullModelMetaCheckpointer,
@@ -21,7 +22,6 @@ from ._distributed import (  # noqa
     validate_no_params_on_meta_device,
     wrap_fsdp,
 )
-from .argparse import TuneArgumentParser
 from .checkpoint import (  # noqa
     save_checkpoint,
     transform_opt_state_dict,
@@ -39,7 +39,11 @@ from .constants import (  # noqa
     TOTAL_EPOCHS_KEY,
 )
 from .logging import get_logger
-from .memory import memory_stats_log, set_activation_checkpointing  # noqa
+from .memory import (   # noqa
+    memory_stats_log,
+    set_activation_checkpointing,
+    cleanup_before_training,
+)
 from .precision import (
     get_autocast,
     get_dtype,

--- a/torchtune/utils/memory.py
+++ b/torchtune/utils/memory.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import gc
+
 from typing import Optional, Set
 
 import torch
@@ -27,6 +29,12 @@ def set_activation_checkpointing(
     """
     wrap_policy = ModuleWrapPolicy(auto_wrap_policy or set())
     apply_activation_checkpointing(model, auto_wrap_policy=wrap_policy, **kwargs)
+
+
+def cleanup_before_training() -> None:
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
 
 
 def memory_stats_log(


### PR DESCRIPTION
#### Context

Our distributed recipes (especially LoRA) see some skew in the memory stats during training. This is mainly due to stragglers which need to be cleaned up before training begins. Adding this here.

Comparisons with LoRA distributed Recipe:

```
tune --nnodes 1 --nproc_per_node 4 recipes/lora_finetune_distributed.py \
--config recipes/configs/lora_finetune_distributed.yaml \
epochs=2 enable_activation_checkpointing=False

tune --nnodes 1 --nproc_per_node 4 recipes/lora_finetune_distributed.py \
--config recipes/configs/lora_finetune_distributed.yaml \
epochs=2 enable_activation_checkpointing=True
```

Baseline without AC

<img width="439" alt="Screenshot 2024-03-22 at 1 15 30 PM" src="https://github.com/pytorch/torchtune/assets/47255723/fcf00782-1d36-4525-850a-d47c5d3b93a6">

Baseline with AC
<img width="426" alt="Screenshot 2024-03-22 at 1 13 55 PM" src="https://github.com/pytorch/torchtune/assets/47255723/95903626-7f3e-4956-bdf8-5f5c8d934ba9">

This PR without AC

<img width="451" alt="Screenshot 2024-03-22 at 1 07 29 PM" src="https://github.com/pytorch/torchtune/assets/47255723/62eb76b8-65e3-4c30-b79b-6240ac11df86">


This PR with AC

<img width="393" alt="Screenshot 2024-03-22 at 1 10 34 PM" src="https://github.com/pytorch/torchtune/assets/47255723/c06f4f53-67d0-4463-bddf-a09d3e5ae884">


#### Changelog
-  Add the cleanup utility
- Sync before training begins
- Move validation for LoRA state dict to before loading the state dict (unrelated change, but putting in here)

#### Test plan
- Unit Tests

```
pytest tests/torchtune
```

- Recipe Tests

```
pytest tests/recipes
```
