### PR TITLE
[Not for land][Debug] Implement chunked loss to see if it can speed up training

### DIFF
--- a/recipes/configs/lora_finetune_single_device.yaml
+++ b/recipes/configs/lora_finetune_single_device.yaml
@@ -52,7 +52,7 @@ loss:
 
 # Training
 epochs: 1
-max_steps_per_epoch: null
+max_steps_per_epoch: 30
 gradient_accumulation_steps: 1
 
 # Logging
@@ -60,9 +60,9 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: 1
+log_every_n_steps: 2
 
 # Environment
 device: cuda
 dtype: bf16
-enable_activation_checkpointing: True
+enable_activation_checkpointing: False


### PR DESCRIPTION
#### Context
We noticed that torchtune takes significant longer softmax time than lit-gpt 
<img width="968" alt="Screenshot 2024-03-22 at 5 40 17 PM" src="https://github.com/pytorch/torchtune/assets/29116689/f3900887-696d-43a6-b14e-732c2f8a7db0">
We noticed that lit-gpt is using chunked loss https://github.com/Lightning-AI/litgpt/blob/main/litgpt/utils.py#L240-L249

We dirty implemented chunked loss in torchtune to see if we can reduce the softmax time 

#### Changelog
Implemented chunked loss in lora single device finetune 

#### Discussion Item 
It seems that chunked loss doesn't help softmax speed
<img width="572" alt="Screenshot 2024-03-22 at 5 44 13 PM" src="https://github.com/pytorch/torchtune/assets/29116689/c74f8212-7c0a-49fb-98d2-1e840885cb8b">
