### PR TITLE
[RFC] Default pytest run mode to unit tests only

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -36,6 +36,6 @@ jobs:
           python -m pip install torch
           python -m pip install -e ".[dev]"
       - name: Run unit tests with coverage
-        run: pytest tests --without-integration --without-slow-integration --cov=. --cov-report=xml --durations=20 -vv
+        run: pytest tests --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ check-return-types = 'False'
 exclude = 'tests/torchtune/models/llama2/scripts/'
 
 [tool.pytest.ini_options]
-addopts = ["--showlocals", "--import-mode=importlib"]
+addopts = ["--showlocals", "--import-mode=importlib", "--without-integration", "--without-slow-integration"]
 # --showlocals will show local variables in tracebacks
 # --import-model=importlib ensures pytest doesn't append the repo root to sys.path,
 # causing our tests to bypass legitimate import errors
+# --without-integration and --without-slow-integration: default to running unit tests only


### PR DESCRIPTION
**Note:** this is a copy of #569 due to some issues with S3 credentials in CI on a PR created from a fork.

It was pointed out by @kartikayk that the current UX for our testing is a bit clunky. E.g. executing a single unit test without downloading from S3 necessitates running `pytest tests/path/to/my_unit_test.py --without-integration --without-slow-integration`. This is a bit annoying, especially given this is a very common way to test individual changes.

This PR makes the default mode for our test runs to be unit-test only. This means that `pytest tests` will now run **only** unit tests, and will not run recipe tests or regression tests. It will also not download any artifacts for those tests.

My hope is that this is more intuitive given that most people are only running unit tests. One gotcha is that e.g. `pytest tests/recipes` and `pytest tests/regression_tests` will now be essentially a no-op, so we will need to instead specify e.g. `pytest tests -m integration_test` or `pytest tests -m slow_integration_test` instead. Assuming this isn't too much cognitive load, I claim this change should be a net positive.

### Test plan

Run a bunch of different commands and check (a) which assets (if any) are expected, and (b) which tests runs.

**All unit tests**
Should run only unit tests, so no artifacts are needed.
```
pytest tests
(no expected artifacts)
...
187 passed, 19 skipped, 5 warnings in 136.89s (0:02:16)
```

**tests/recipes unit tests only**
Runs all unit tests under `tests/recipes`. Since only unit tests are run, no artifacts are needed.
```
pytest tests/recipes
(no expected artifacts)
...
1 passed, 11 skipped, 1 warning in 2.11s (since recipe tests are skipped by default)
```

**tests/recipes, recipe tests only**
Runs all recipe tests under `tests/recipes`. Fetches tokenizer and small model checkpoints for recipe tests.
```
pytest tests/recipes -m integration_test
Expected artifacts for test run are:
small-ckpt-01242024
small-ckpt-tune-03082024.pt
small-ckpt-meta-03082024.pt
small-ckpt-hf-03082024.pt
...
11 passed, 1 deselected, 3 warnings in 125.10s (0:02:05)
```


**Single file, unit tests only**
Runs unit tests from a single file. No artifacts are needed.
```
pytest tests/torchtune/modules/peft/test_peft_utils.py 
(no expected artifacts)
...
19 passed, 1 warning in 0.12s
```

**Single (unit test) file, regression tests only**
(Not an intended usage) This command runs only regression tests from a single file containing only unit tests.
As a result, the full 7B model and tokenizer are fetched, but no tests actually run.
```
pytest tests/torchtune/modules/peft/test_peft_utils.py -m slow_integration_test 
Expected artifacts for this test run are:
Expected artifacts for test run are:
llama2-7b-torchtune.pt
tokenizer.model
...
19 deselected, 1 warning in 0.02s (none run because the file contains no regression tests)
```

**Single (unit test) file, with regression tests**
(Also not an intended usage) By using `--with-slow-integration-test` instead of `-m slow-integration-test`,
this test will run unit tests + regression tests instead of just regression tests (as in the last command). 
Again the full 7B model and tokenizer will be downloaded, but in this case all the unit tests do run.
```
pytest tests/torchtune/modules/peft/test_peft_utils.py --with-slow-integration-test 
Expected artifacts for this test run are:
...
19 passed, 1 warning in 0.12s (unit tests run by default)
```

**Recipe tests only with -k flag**
Finally, this command runs recipe tests only using a `-k` filter.
This will fetch recipe test models and tokenizers and run only recipe tests matching the wildcard string.
```
pytest tests -m integration_test -k 'test_training_state_on_resume'
Expected artifacts for test run are:
small-ckpt-01242024
small-ckpt-tune-03082024.pt
small-ckpt-meta-03082024.pt
small-ckpt-hf-03082024.pt
...
3 passed, 203 deselected, 1 warning in 55.25s
```

CI should be green as well