### PR TITLE
Fix QLoRA recipe, add CI

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -71,7 +71,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
     def __init__(self, cfg: DictConfig) -> None:
 
         self._device = utils.get_device(device=cfg.device)
-        self._dtype = utils.get_dtype(dtype=cfg.dtype)
+        self._dtype = utils.get_dtype(cfg.dtype, device=self._device)
 
         if self._dtype == torch.float16:
             raise ValueError(

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -61,7 +61,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
     def __init__(self, cfg: DictConfig) -> None:
         self._device = utils.get_device(device=cfg.device)
-        self._dtype = utils.get_dtype(dtype=cfg.dtype)
+        self._dtype = utils.get_dtype(cfg.dtype, device=self._device)
         # Disable for fp16, as we haven't validated "full" fp16 with this recipe, nor
         # enabled necessary features such as gradient scaling.
         if self._dtype == torch.float16:

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -73,7 +73,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
     def __init__(self, cfg: DictConfig) -> None:
         self._device = utils.get_device(device=cfg.device)
-        self._dtype = utils.get_dtype(dtype=cfg.dtype)
+        self._dtype = utils.get_dtype(cfg.dtype, device=self._device)
 
         if self._dtype == torch.float16:
             raise ValueError(

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -68,7 +68,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         self._device = utils.get_device(device=cfg.device)
         # Reduced precision logic
-        self._dtype = utils.get_dtype(cfg.dtype)
+        self._dtype = utils.get_dtype(cfg.dtype, device=self._device)
         # fp16 precision is explicitly disabled as it is not supported in this
         # recipe (for example, no gradient scaling).
         if self._dtype == torch.float16:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ tqdm
 omegaconf
 
 # Quantization
-torchao-nightly
+torchao-nightly==2024.3.13

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -57,7 +57,7 @@ class TestLoRAFinetuneSingleDeviceRecipe:
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
 
-        prefix = f"qlora" if run_qlora else "lora"
+        prefix = "qlora" if run_qlora else "lora"
         cmd = f"""
         tune lora_finetune_single_device
             --config {prefix}_finetune_single_device \

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -79,9 +79,11 @@ class TestLoRAFinetuneSingleDeviceRecipe:
         )
 
         # TODO (rohan-varma): QLoRA only supported with bf16 for now
-        cmd = cmd + self._get_test_config_overrides(
-            dtype_str="bf16" if run_qlora else "fp32"
-        ) + model_config
+        cmd = (
+            cmd
+            + self._get_test_config_overrides(dtype_str="bf16" if run_qlora else "fp32")
+            + model_config
+        )
         monkeypatch.setattr(sys, "argv", cmd)
         with pytest.raises(SystemExit):
             runpy.run_path(TUNE_PATH, run_name="__main__")

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -45,7 +45,7 @@ class TestLoRAFinetuneSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, run_qlora: bool = False):
         if run_qlora:
-            return [10.5056, 10.5575, 10.5179, 10.4897]
+            return [10.5057, 10.5575, 10.5179, 10.4898]
         else:
             return [10.5074, 10.5614, 10.5205, 10.4918]
 

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -76,7 +76,6 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             lora_alpha=16,
         )
 
-        # TODO (rohan-varma): QLoRA only supported with bf16 for now
         cmd = cmd + self._get_test_config_overrides(dtype_str="fp32") + model_config
         monkeypatch.setattr(sys, "argv", cmd)
         with pytest.raises(SystemExit):

--- a/tests/torchtune/models/test_lora_llama2.py
+++ b/tests/torchtune/models/test_lora_llama2.py
@@ -181,7 +181,6 @@ class TestLoRALlama2:
         assert not unexpected
         assert all(["lora" in key for key in missing])
 
-    @pytest.mark.skip(reason="broken by ao nightly")
     def test_lora_linear_quantize_base(self):
         model = self.get_lora_llama2(
             lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
@@ -196,7 +195,6 @@ class TestLoRALlama2:
             if isinstance(module, LoRALinear):
                 assert module._quantize_base
 
-    @pytest.mark.skip(reason="broken by ao nightly")
     def test_qlora_llama2_parity(self, inputs):
         with utils.set_default_dtype(torch.bfloat16):
             model_ref = self.get_lora_llama2(
@@ -224,7 +222,6 @@ class TestLoRALlama2:
         output = qlora(inputs)
         torch.testing.assert_close(ref_output, output)
 
-    @pytest.mark.skip(reason="broken by ao nightly")
     def test_qlora_llama2_state_dict(self):
         with utils.set_default_dtype(torch.bfloat16):
             model_ref = self.get_lora_llama2(
@@ -258,7 +255,6 @@ class TestLoRALlama2:
             for v in qlora_sd.values():
                 assert v.dtype == torch.bfloat16
 
-    @pytest.mark.skip(reason="broken by ao nightly")
     def test_qlora_llama2_merged_state_dict(self):
         with utils.set_default_dtype(torch.bfloat16):
             qlora = self.get_lora_llama2(

--- a/tests/torchtune/modules/peft/test_lora.py
+++ b/tests/torchtune/modules/peft/test_lora.py
@@ -97,7 +97,6 @@ class TestLoRALinear:
         assert actual.shape == (BSZ, SEQ_LEN, out_dim)
         torch.testing.assert_close(actual.mean(), expected, atol=1e-4, rtol=1e-6)
 
-    @pytest.mark.skip(reason="broken by ao nightly")
     def test_lora_weight_nf4_when_quantized(self, qlora_linear):
         assert isinstance(qlora_linear.weight, NF4Tensor)
 

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -55,6 +55,8 @@ def list_dtypes() -> List[str]:
 
 
 def verify_bf16_support():
+    if not torch.cuda.is_available():
+        return True # bf16 is supported on CPU
     return (
         torch.cuda.is_available()
         and torch.version.cuda
@@ -89,7 +91,6 @@ def get_dtype(dtype: Optional[str] = None) -> torch.dtype:
         raise ValueError(
             f"Dtype {torch_dtype} must be one of {', '.join(list_dtypes())} for finetuning."
         )
-
     if torch_dtype == torch.bfloat16 and not verify_bf16_support():
         log.info("BF16 not supported on this hardware. Setting dtype to float32")
         torch_dtype = torch.float32

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -77,9 +77,8 @@ def get_dtype(
         dtype (Optional[str]): The precision dtype. Default: ``None``, in which we default to torch.float32
         device (Optional[torch.device]): Device in use for training. Only CUDA and CPU
             devices are supported. If a CUDA device is passed in, additional checking is done
-            to ensure that the device supports the requested precision. Default: ``None``, in which
-            case the device given by `torch.get_default_device()` is used.
-
+            to ensure that the device supports the requested precision. Default: ``None``, in which case
+            a CUDA device is assumed.
     Raises:
         ValueError: if precision isn't supported by the precision utils
 
@@ -101,7 +100,8 @@ def get_dtype(
             f"Dtype {torch_dtype} must be one of {', '.join(list_dtypes())} for finetuning."
         )
 
-    device = device or torch.get_default_device()
+    # TODO (rohan-varma): prefer to use get_default_device() here to figure out whether user is training on
+    # CPU or GPU, but it is not supported in versions of torch we test.
     if (
         torch_dtype == torch.bfloat16
         and device != torch.device("cpu")

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -56,7 +56,7 @@ def list_dtypes() -> List[str]:
 
 def verify_bf16_support():
     if not torch.cuda.is_available():
-        return True # bf16 is supported on CPU
+        return True  # bf16 is supported on CPU
     return (
         torch.cuda.is_available()
         and torch.version.cuda

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -159,4 +159,4 @@ def validate_expected_param_dtype(model: torch.nn.Module, dtype: torch.dtype) ->
     """
     for name, param in model.named_parameters():
         if param.dtype != dtype:
-            raise ValueError(f"Parameter {name} has dtype {param.dtype}")
+            raise ValueError(f"Parameter {name} has dtype {param.dtype}, but expected {dtype}")


### PR DESCRIPTION
#### Context
- As reported by https://github.com/pytorch/torchtune/issues/570 and by @ebsmothers, QLoRA recently broke due to torchao nightly update. In this PR, I pin torchao-nightly to the last known working version which contains all features we need, re-enable the unittests, and add a recipe test for QLoRA.

#### Changelog
- See above
- Also a couple of changes to `get_precision`. In particular, we accept a `device` argument which is mostly used for bf16 support checking. bf16 can run on CPU (there might be some unsupported ops versus CUDA in general), so I don't think we should run in fp32 for CPU if bf16 is specified.
- Basically, previously if bf16 was specified, but the GPU did not support, we'd return torch.float32, even if the user was training on CPUs. Now, if the GPU does not support but the user is using CPU, we return bf16.

#### Test plan
- Unit:  pytest tests/recipes/test_lora_finetune_single_device.py -v -k test_loss
- Fresh install, verify expected ao nightly. Run QLoRA: `tune lora_finetune_single_device --config recipes/configs/qlora_finetune_single_device.yaml`

#### Follow up
- We need to establish a process for regularly upgrading deps for libraries which we use nightlies for. The simplest thing to do is what I've done now - pin the version and bump it whenever a new feature/bugfix we need is released. Though if there's a large gap in time between these, the upgrade process could be time consuming and cumbersome to resolve all issues. I could see a process where we upgrade ~weekly to avoid this and more regularly deal with the issues. Unfortunately since we're using nightlies of a library that doesn't provide BC guarantee at the moment, its tricky to think of a more robust upgrade process.
