### PR TITLE
WIP Exclude tests/ from being packaged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,6 @@ exclude = 'tests/torchtune/models/llama2/scripts/'
 [tool.pytest.ini_options]
 addopts = ["--showlocals", "--import-mode=prepend", "--without-integration", "--without-slow-integration"]
 # --showlocals will show local variables in tracebacks
-# --import-mode=importlib ensures pytest doesn't append the repo root to sys.path,
-# causing our tests to bypass legitimate import errors
+# --import-mode=prepend will add the root (the parent dir of torchtune/, tests/, recipes/)
+# to `sys.path` when invoking pytest, allowing us to treat `tests` as a package within the tests.
 # --without-integration and --without-slow-integration: default to running unit tests only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ check-return-types = 'False'
 exclude = 'tests/torchtune/models/llama2/scripts/'
 
 [tool.pytest.ini_options]
-addopts = ["--showlocals", "--import-mode=prepend", "--without-integration", "--without-slow-integration"]
-pythonpath = 'tests'
+addopts = ["--showlocals", "--import-mode=importlib", "--without-integration", "--without-slow-integration"]
 # --showlocals will show local variables in tracebacks
-# --import-model=importlib ensures pytest doesn't append the repo root to sys.path,
+# --import-mode=importlib ensures pytest doesn't append the repo root to sys.path,
 # causing our tests to bypass legitimate import errors
 # --without-integration and --without-slow-integration: default to running unit tests only
+pythonpath = 'tests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ check-return-types = 'False'
 exclude = 'tests/torchtune/models/llama2/scripts/'
 
 [tool.pytest.ini_options]
-addopts = ["--showlocals", "--import-mode=importlib", "--without-integration", "--without-slow-integration"]
+addopts = ["--showlocals", "--import-mode=prepend", "--without-integration", "--without-slow-integration"]
 # --showlocals will show local variables in tracebacks
 # --import-mode=importlib ensures pytest doesn't append the repo root to sys.path,
 # causing our tests to bypass legitimate import errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,3 @@ addopts = ["--showlocals", "--import-mode=importlib", "--without-integration", "
 # --import-mode=importlib ensures pytest doesn't append the repo root to sys.path,
 # causing our tests to bypass legitimate import errors
 # --without-integration and --without-slow-integration: default to running unit tests only
-pythonpath = 'tests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ check-return-types = 'False'
 exclude = 'tests/torchtune/models/llama2/scripts/'
 
 [tool.pytest.ini_options]
-addopts = ["--showlocals", "--import-mode=importlib", "--without-integration", "--without-slow-integration"]
+addopts = ["--showlocals", "--import-mode=prepend", "--without-integration", "--without-slow-integration"]
+pythonpath = 'tests'
 # --showlocals will show local variables in tracebacks
 # --import-model=importlib ensures pytest doesn't append the repo root to sys.path,
 # causing our tests to bypass legitimate import errors

--- a/recipes/__init__.py
+++ b/recipes/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 raise ModuleNotFoundError("No module named 'recipes'")

--- a/recipes/__init__.py
+++ b/recipes/__init__.py
@@ -1,0 +1,1 @@
+raise ModuleNotFoundError("No module named 'recipes'")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read_requirements(file):
 setup(
     name="torchtune",
     version="0.0.1",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     python_requires=">=3.8",
     install_requires=read_requirements("requirements.txt"),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read_requirements(file):
 setup(
     name="torchtune",
     version="0.0.1",
-    packages=find_packages(exclude=["tests", "tests.*"]),
+    packages=find_packages(exclude=["tests", "tests.*", "recipes", "recipes.*"]),
     python_requires=">=3.8",
     install_requires=read_requirements("requirements.txt"),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read_requirements(file):
 setup(
     name="torchtune",
     version="0.0.1",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.8",
     install_requires=read_requirements("requirements.txt"),
     entry_points={

--- a/tests/test_import_recipes.py
+++ b/tests/test_import_recipes.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def test_import_receipes():
+    with pytest.raises(ModuleNotFoundError, match="No module named 'recipes'"):
+        import recipes

--- a/tests/test_import_recipes.py
+++ b/tests/test_import_recipes.py
@@ -3,4 +3,4 @@ import pytest
 
 def test_import_receipes():
     with pytest.raises(ModuleNotFoundError, match="No module named 'recipes'"):
-        import recipes
+        import recipes  # noqa

--- a/tests/test_import_recipes.py
+++ b/tests/test_import_recipes.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import pytest
 
 


### PR DESCRIPTION
Summary:

- We need to exclude tests from being packaged, i.e. we need `find_packages(exclude=["tests", "tests.*"]))`
- This causes the tests to not be importable anymore. That's a good thing. But the entire test setup relies on this assumption. So we need to make tests importable again (this is different from packaging them!!!!!!)
- To make tests importable again one solution is to go back to the `prepend` mode of pytest which will add the root dir to `sys.path`. `tests` are in this root dir, so they're importable again.
- Unfortunately, it's not just the tests which are importable now: `recipes` also are. And we want to avoid `recipes` to be importable from the tests because otherwise we might be missing bugs. So I explicitly added `recipes/__init__.py` which raises an error if you try to do anything with it.