### PR TITLE
Update torchao to latest working nightly, QLoRA fixes

### DIFF
--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -157,7 +157,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
         model.load_state_dict(model_state_dict)
 
         # Validate model was loaded in with the expected dtype.
-        utils.validate_expected_param_dtype(model, dtype=self._dtype)
+        utils.validate_expected_param_dtype(model.named_parameters(), dtype=self._dtype)
         logger.info(f"Model is initialized with precision {self._dtype}.")
         return model
 

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -211,7 +211,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         model.load_state_dict(model_state_dict)
 
         # Validate model was loaded in with the expected dtype.
-        utils.validate_expected_param_dtype(model, dtype=self._dtype)
+        utils.validate_expected_param_dtype(model.named_parameters(), dtype=self._dtype)
         log.info(f"Model is initialized with precision {self._dtype}.")
         log.info(
             utils.memory_stats_log(

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -23,7 +23,6 @@ from torchtune.modules.peft.peft_utils import (
     set_trainable_params,
     validate_state_dict_for_lora,
 )
-
 from torchtune.recipe_interfaces import FTRecipeInterface
 from tqdm import tqdm
 
@@ -245,8 +244,14 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         if lora_weights_state_dict:
             model.load_state_dict(lora_weights_state_dict, strict=False)
 
-        # Validate model was loaded in with the expected dtype.
-        utils.validate_expected_param_dtype(model, dtype=self._dtype)
+        # Validate model was loaded in with the expected dtype, allowing for separate
+        # dtypes for base and adapter params.
+        # Validate model adapter params were loaded in with the expected dtype
+        # TODO (rohan-varma): Further validation to ensure the appropriate base params
+        # are NF4 vs bf16 based on the quantization config.
+        utils.validate_expected_param_dtype(
+            self.adapter_params.items(), dtype=self._dtype
+        )
 
         log.info(f"Model is initialized with precision {self._dtype}.")
         log.info(

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -244,8 +244,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         if lora_weights_state_dict:
             model.load_state_dict(lora_weights_state_dict, strict=False)
 
-        # Validate model was loaded in with the expected dtype, allowing for separate
-        # dtypes for base and adapter params.
         # Validate model adapter params were loaded in with the expected dtype
         # TODO (rohan-varma): Further validation to ensure the appropriate base params
         # are NF4 vs bf16 based on the quantization config.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ tqdm
 omegaconf
 
 # Quantization
-torchao-nightly==2024.3.13
+torchao-nightly==2024.3.25

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,7 +69,7 @@ def fixed_init_model(
     min_val: Union[float, int] = 0.0,
     max_val: Union[float, int] = 1.0,
     nonlinear: bool = False,
-    dtype: Optional[torch.dtype] = None
+    dtype: Optional[torch.dtype] = None,
 ):
     """
     This utility initializes all parameters of a model deterministically using the

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,6 +69,7 @@ def fixed_init_model(
     min_val: Union[float, int] = 0.0,
     max_val: Union[float, int] = 1.0,
     nonlinear: bool = False,
+    dtype: Optional[torch.dtype] = None
 ):
     """
     This utility initializes all parameters of a model deterministically using the
@@ -81,7 +82,7 @@ def fixed_init_model(
                 min_val=min_val,
                 max_val=max_val,
                 nonlinear=nonlinear,
-                dtype=param.dtype,
+                dtype=param.dtype if dtype is None else dtype,
             )
         )
 

--- a/tests/torchtune/models/test_lora_llama2.py
+++ b/tests/torchtune/models/test_lora_llama2.py
@@ -222,14 +222,14 @@ class TestLoRALlama2:
                 embed_dim=512,
                 run_fixed_init=False,
             )
-            qlora_sd = qlora.state_dict()
-            model_ref.load_state_dict(qlora_sd)
-            # Forward pass of model_ref and qlora should be the same, as QLoRA linear layers should use
-            # a special linear operator that runs the compute in bf16, but only saves the 4 bit tensors
-            # for backward.
-            ref_output = model_ref(inputs)
-            output = qlora(inputs)
-            torch.testing.assert_close(ref_output, output)
+        qlora_sd = qlora.state_dict()
+        model_ref.load_state_dict(qlora_sd)
+        # Forward pass of model_ref and qlora should be the same, as QLoRA linear layers should use
+        # a special linear operator that runs the compute in bf16, but only saves the 4 bit tensors
+        # for backward.
+        ref_output = model_ref(inputs)
+        output = qlora(inputs)
+        torch.testing.assert_close(ref_output, output)
 
     def test_qlora_llama2_state_dict(self):
         with utils.set_default_dtype(torch.bfloat16):
@@ -276,7 +276,7 @@ class TestLoRALlama2:
                 quantize_base=True,
                 embed_dim=512,
                 run_fixed_init=False,
-                reset_norm=False # to ensure norm.scale key exists
+                reset_norm=False,  # to ensure norm.scale key exists
             )
 
         qlora_sd = qlora.state_dict()

--- a/tests/torchtune/models/test_lora_llama2.py
+++ b/tests/torchtune/models/test_lora_llama2.py
@@ -90,6 +90,7 @@ class TestLoRALlama2:
         reset_norm=True,
         quantize_base=False,
         embed_dim=EMBED_DIM,
+        run_fixed_init=True,
     ):
         num_layers = 3
         model = lora_llama2(
@@ -109,17 +110,22 @@ class TestLoRALlama2:
         # To make final outputs less trivial
         if reset_norm:
             model.norm = nn.Identity()
-        fixed_init_model(model)
+
+        # Some tests don't rely on fixed_init, NF4Tensor does not have op
+        # coverage to cover ops done in fixed_init (i.e. arange). So only
+        # run fixed_init if needed.
+        if run_fixed_init:
+            fixed_init_model(model)
         return model
 
-    def get_ref_llama2(self, vocab_size):
+    def get_ref_llama2(self, vocab_size, embed_dim=EMBED_DIM):
         num_layers = 3
         model = llama2(
             vocab_size=vocab_size,
             num_layers=num_layers,
             num_heads=NUM_HEADS,
             num_kv_heads=NUM_KV_HEADS,
-            embed_dim=EMBED_DIM,
+            embed_dim=embed_dim,
             max_seq_len=MAX_SEQ_LEN,
         )
         return model
@@ -190,6 +196,7 @@ class TestLoRALlama2:
             vocab_size=50,
             quantize_base=True,
             embed_dim=512,
+            run_fixed_init=False,
         )
         for module in model.modules():
             if isinstance(module, LoRALinear):
@@ -204,6 +211,7 @@ class TestLoRALlama2:
                 vocab_size=50,
                 quantize_base=False,
                 embed_dim=512,
+                run_fixed_init=False,
             )
             qlora = self.get_lora_llama2(
                 lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
@@ -212,15 +220,16 @@ class TestLoRALlama2:
                 vocab_size=50,
                 quantize_base=True,
                 embed_dim=512,
+                run_fixed_init=False,
             )
-        qlora_sd = qlora.state_dict()
-        model_ref.load_state_dict(qlora_sd)
-        # Forward pass of model_ref and qlora should be the same, as QLoRA linear layers should use
-        # a special linear operator that runs the compute in bf16, but only saves the 4 bit tensors
-        # for backward.
-        ref_output = model_ref(inputs)
-        output = qlora(inputs)
-        torch.testing.assert_close(ref_output, output)
+            qlora_sd = qlora.state_dict()
+            model_ref.load_state_dict(qlora_sd)
+            # Forward pass of model_ref and qlora should be the same, as QLoRA linear layers should use
+            # a special linear operator that runs the compute in bf16, but only saves the 4 bit tensors
+            # for backward.
+            ref_output = model_ref(inputs)
+            output = qlora(inputs)
+            torch.testing.assert_close(ref_output, output)
 
     def test_qlora_llama2_state_dict(self):
         with utils.set_default_dtype(torch.bfloat16):
@@ -231,6 +240,7 @@ class TestLoRALlama2:
                 vocab_size=50,
                 quantize_base=False,
                 embed_dim=512,
+                run_fixed_init=False,
             )
             bf16_sd = model_ref.state_dict()
             for v in bf16_sd.values():
@@ -244,6 +254,7 @@ class TestLoRALlama2:
                 vocab_size=50,
                 quantize_base=True,
                 embed_dim=512,
+                run_fixed_init=False,
             )
             qlora.load_state_dict(bf16_sd)
             # LoRALinear base weights should be nf4 still
@@ -264,6 +275,8 @@ class TestLoRALlama2:
                 vocab_size=50,
                 quantize_base=True,
                 embed_dim=512,
+                run_fixed_init=False,
+                reset_norm=False # to ensure norm.scale key exists
             )
 
         qlora_sd = qlora.state_dict()
@@ -276,4 +289,6 @@ class TestLoRALlama2:
 
         # Ensure checkpoint can be loaded into non-LoRA model
         with utils.set_default_dtype(torch.bfloat16):
-            llama2 = self.get_ref_llama2(vocab_size=50)
+            llama2 = self.get_ref_llama2(vocab_size=50, embed_dim=512)
+
+        llama2.load_state_dict(merged_ckpt)

--- a/tests/torchtune/modules/peft/test_lora.py
+++ b/tests/torchtune/modules/peft/test_lora.py
@@ -71,6 +71,7 @@ class TestLoRALinear:
                 use_bias=False,
                 quantize_base=True,
             )
+            fixed_init_model(qlora_linear, dtype=torch.bfloat16)
             return qlora_linear
 
     @torch.no_grad()

--- a/tests/torchtune/modules/peft/test_lora.py
+++ b/tests/torchtune/modules/peft/test_lora.py
@@ -71,7 +71,6 @@ class TestLoRALinear:
                 use_bias=False,
                 quantize_base=True,
             )
-            fixed_init_model(qlora_linear)
             return qlora_linear
 
     @torch.no_grad()

--- a/tests/torchtune/utils/test_precision.py
+++ b/tests/torchtune/utils/test_precision.py
@@ -100,4 +100,4 @@ class TestPrecisionUtils:
         """
         m = torch.nn.Linear(10, 10)
         with pytest.raises(ValueError, match=f"has dtype {next(m.parameters()).dtype}"):
-            validate_expected_param_dtype(m, dtype=torch.float16)
+            validate_expected_param_dtype(m.named_parameters(), dtype=torch.float16)

--- a/torchtune/modules/peft/peft_utils.py
+++ b/torchtune/modules/peft/peft_utils.py
@@ -33,7 +33,7 @@ class AdapterModule(Protocol):
 
 
 @functools.lru_cache()
-def get_adapter_params(model: nn.Module) -> Dict[str, Any]:
+def get_adapter_params(model: nn.Module) -> Dict[str, nn.Parameter]:
     """
     Return the subset of parameters from a model that correspond to an adapter.
     Assumes that any adapter class has defined the
@@ -43,7 +43,7 @@ def get_adapter_params(model: nn.Module) -> Dict[str, Any]:
         model (nn.Module): Instance of model class containing some adapter params.
 
     Returns:
-        Dict[str, Any]: the subset of model's state dict containing
+        Dict[str, nn.Parameter]: the subset of model's state dict containing
         only adapter parameters.
 
     """

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -178,7 +178,7 @@ def validate_expected_param_dtype(
     Validates that all input parameters have the expected dtype.
 
     Args:
-        named_params (Iterable[str, nn.Parameter]): Iterable of named parameters.
+        named_params (Iterable[Tuple[str, nn.Parameter]]): Iterable of named parameters.
         dtype (torch.dtype): Expected dtype.
 
     Raises:

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -5,9 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 import contextlib
-from typing import ContextManager, Dict, Generator, List, Optional, Union
+from typing import (
+    ContextManager,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import torch
+import torch.nn as nn
 from pkg_resources import packaging
 
 from torch.cuda.amp import GradScaler
@@ -161,18 +171,20 @@ def set_default_dtype(dtype: torch.dtype) -> Generator[None, None, None]:
         torch.set_default_dtype(old_dtype)
 
 
-def validate_expected_param_dtype(model: torch.nn.Module, dtype: torch.dtype) -> None:
+def validate_expected_param_dtype(
+    named_params: Iterable[Tuple[str, nn.Parameter]], dtype: torch.dtype
+) -> None:
     """
-    Validates that all parameters in the model have the expected dtype.
+    Validates that all input parameters have the expected dtype.
 
     Args:
-        model (torch.nn.Module): Model to validate.
+        named_params (Iterable[str, nn.Parameter]): Iterable of named parameters.
         dtype (torch.dtype): Expected dtype.
 
     Raises:
-        ValueError: If any parameter in the model has a different dtype than `dtype`.
+        ValueError: If any parameter has a different dtype than `dtype`.
     """
-    for name, param in model.named_parameters():
+    for name, param in named_params:
         if param.dtype != dtype:
             raise ValueError(
                 f"Parameter {name} has dtype {param.dtype}, but expected {dtype}"


### PR DESCRIPTION
#### Context
- Note: This PR should be a one-off (maybe n-off, for small n) to get us to a working state with a relatively recent version of torchao to bring in required changes for upcoming features. We should work towards an automated mechanism such as a bot to automatically upgrade packages when new ones are available and auto-run the appropriate CI tests.
- Upgrades torchao to 3/25 nightly, which contains features needed to run QLoRA in fp32
- Make appropriate changes to tests / recipes.
- In particular, get rid of torch.arange calls for QLoRA in tests. These are in `fixed_init_model`, but fixed init is not needed for the current QLoRA tests we are running.
- Limit bf16 validation to only adapter params. This is admittedly incomplete and we need to validate base model params are nf4 or bf16 based on quantization config. I'd like to punt this to a future PR as it requires more thought on how to get the param names we expect to be nf4, and I'd like to prioritze landing this ASAP.

#### Changelog
- See above

#### Test plan
- `pytest tests/torchtune/models/test_lora_llama2.py`
- `tune lora_finetune_single_device --config llama2/7B_qlora_single_device`
