### PR TITLE
Mistral configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The library currently supports the following models and fine-tuning methods.
 |-----------------------------------------------|-----------|-----------------------------------------------------------|
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 7B        | Full Finetuning [[single device](recipes/configs/llama2/7B_full_single_device.yaml),  [distributed](recipes/configs/llama2/7B_full.yaml)] LoRA [[single device](recipes/configs/llama2/7B_lora_single_device.yaml),  [distributed](recipes/configs/llama2/7B_lora.yaml)] QLoRA [single device](recipes/configs/llama2/7B_qlora_single_device.yaml) |
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 13B       | [Full Finetuning](recipes/configs/llama2/13B_full.yaml), [LoRA](recipes/configs/llama2/13B_lora.yaml)
-| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | Full Finetuning and LoRA are WIP and will be added soon
+| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | [Full Finetuning](recipes/configs/mistral/7B_full.yaml), [LoRA](recipes/configs/mistral/7B_lora.yaml)
 
 
 &nbsp;

--- a/recipes/configs/mistral/7B_full.yaml
+++ b/recipes/configs/mistral/7B_full.yaml
@@ -4,7 +4,7 @@
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.mistral.mistral_tokenizer
-  path: /data/users/kartikayk/cpts/Mistral-7B-v0.1/tokenizer.model
+  path: /tmp/Mistral-7B-v0.1/tokenizer.model
 
 # Dataset
 dataset:
@@ -19,18 +19,18 @@ model:
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir: /data/users/kartikayk/cpts/Mistral-7B-v0.1
+  checkpoint_dir: /tmp/Mistral-7B-v0.1/
   checkpoint_files: [
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin
   ]
   recipe_checkpoint: null
-  output_dir: /data/users/kartikayk/cpts/Mistral-7B-v0.1
-  model_type: LLAMA2
+  output_dir: /tmp/Mistral-7B-v0.1/
+  model_type: MISTRAL
 resume_from_checkpoint: False
 
 # Fine-tuning arguments
-batch_size: 32
+batch_size: 2
 epochs: 3
 optimizer:
   _component_: torch.optim.AdamW
@@ -57,5 +57,5 @@ dtype: bf16
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-output_dir: /tmp/alpaca-llama2-finetune
+output_dir: /tmp/Mistral-7B-v0.1/
 log_every_n_steps: null

--- a/recipes/configs/mistral/7B_full.yaml
+++ b/recipes/configs/mistral/7B_full.yaml
@@ -1,5 +1,9 @@
-# This config is currently a WIP. Use it with caution
-
+# This config uses hyperparameters based on small set of experiments and information
+# available on various forums. These are not meant to replicate the numbers
+# from the paper
+#
+# Run this config on 4 GPUs using the following:
+# tune --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full
 
 # Tokenizer
 tokenizer:

--- a/recipes/configs/mistral/7B_full.yaml
+++ b/recipes/configs/mistral/7B_full.yaml
@@ -19,7 +19,7 @@ model:
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir: /tmp/Mistral-7B-v0.1/
+  checkpoint_dir: /tmp/Mistral-7B-v0.1
   checkpoint_files: [
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -4,7 +4,7 @@
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.mistral.mistral_tokenizer
-  path: /data/users/kartikayk/cpts/Mistral-7B-v0.1/tokenizer.model
+  path: /tmp/Mistral-7B-v0.1/tokenizer.model
 
 # Dataset
 dataset:
@@ -24,22 +24,22 @@ model:
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir: /data/users/kartikayk/cpts/Mistral-7B-v0.1
+  checkpoint_dir: /tmp/Mistral-7B-v0.1
   checkpoint_files: [
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin
   ]
   recipe_checkpoint: null
-  output_dir: /data/users/kartikayk/cpts/Mistral-7B-v0.1
-  model_type: LLAMA2
+  output_dir: /tmp/Mistral-7B-v0.1
+  model_type: MISTRAL
 resume_from_checkpoint: False
 
 # Fine-tuning arguments
-batch_size: 32
+batch_size: 4
 epochs: 3
 optimizer:
   _component_: torch.optim.AdamW
-  lr: 2e-4
+  lr: 2e-5
 lr_scheduler:
   _component_: torchtune.modules.get_cosine_schedule_with_warmup
   num_warmup_steps: 100
@@ -65,5 +65,5 @@ dtype: bf16
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-output_dir: /tmp/alpaca-llama2-finetune
+output_dir: /tmp/Mistral-7B-v0.1
 log_every_n_steps: null

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -1,4 +1,9 @@
-# This config is currently a WIP. Use it with caution
+# This config uses hyperparameters based on small set of experiments and information
+# available on various forums. These are not meant to replicate the numbers
+# from the paper
+#
+# Run this config on 4 GPUs using the following:
+# tune --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config mistral/7B_lora
 
 
 # Tokenizer
@@ -16,7 +21,7 @@ shuffle: True
 # Model Arguments
 model:
   _component_: torchtune.models.mistral.lora_mistral_7b
-  lora_attn_modules: ['q_proj', 'v_proj', 'k_proj']
+  lora_attn_modules: ['q_proj', 'k_proj', 'v_proj']
   apply_lora_to_mlp: True
   apply_lora_to_output: True
   lora_rank: 64
@@ -34,26 +39,25 @@ checkpointer:
   model_type: MISTRAL
 resume_from_checkpoint: False
 
-# Fine-tuning arguments
-batch_size: 4
-epochs: 3
 optimizer:
   _component_: torch.optim.AdamW
   lr: 2e-5
+
 lr_scheduler:
   _component_: torchtune.modules.get_cosine_schedule_with_warmup
   num_warmup_steps: 100
+
 loss:
   _component_: torch.nn.CrossEntropyLoss
+
+# Fine-tuning arguments
+batch_size: 4
+epochs: 3
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1
 
-
 # Training env
 device: cuda
-
-# Distributed
-cpu_offload: False
 
 # Memory management
 enable_activation_checkpointing: True

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -15,7 +15,12 @@ shuffle: True
 
 # Model Arguments
 model:
-  _component_: torchtune.models.mistral.mistral_7b
+  _component_: torchtune.models.mistral.lora_mistral_7b
+  lora_attn_modules: ['q_proj', 'v_proj', 'k_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: True
+  lora_rank: 64
+  lora_alpha: 16
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
@@ -34,7 +39,10 @@ batch_size: 32
 epochs: 3
 optimizer:
   _component_: torch.optim.AdamW
-  lr: 5e-6
+  lr: 2e-4
+lr_scheduler:
+  _component_: torchtune.modules.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
 loss:
   _component_: torch.nn.CrossEntropyLoss
 max_steps_per_epoch: null

--- a/torchtune/models/mistral/__init__.py
+++ b/torchtune/models/mistral/__init__.py
@@ -4,5 +4,5 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._component_builders import mistral, lora_mistral  # noqa
+from ._component_builders import lora_mistral, mistral  # noqa
 from ._model_builders import lora_mistral_7b, mistral_7b, mistral_tokenizer  # noqa

--- a/torchtune/models/mistral/__init__.py
+++ b/torchtune/models/mistral/__init__.py
@@ -5,4 +5,4 @@
 # LICENSE file in the root directory of this source tree.
 
 from ._component_builders import mistral  # noqa
-from ._model_builders import mistral_7b, mistral_tokenizer  # noqa
+from ._model_builders import mistral_7b, mistral_tokenizer, lora_mistral_7b  # noqa

--- a/torchtune/models/mistral/__init__.py
+++ b/torchtune/models/mistral/__init__.py
@@ -4,5 +4,5 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._component_builders import mistral  # noqa
+from ._component_builders import mistral, lora_mistral  # noqa
 from ._model_builders import lora_mistral_7b, mistral_7b, mistral_tokenizer  # noqa

--- a/torchtune/models/mistral/__init__.py
+++ b/torchtune/models/mistral/__init__.py
@@ -5,4 +5,4 @@
 # LICENSE file in the root directory of this source tree.
 
 from ._component_builders import mistral  # noqa
-from ._model_builders import mistral_7b, mistral_tokenizer, lora_mistral_7b  # noqa
+from ._model_builders import lora_mistral_7b, mistral_7b, mistral_tokenizer  # noqa

--- a/torchtune/models/mistral/_component_builders.py
+++ b/torchtune/models/mistral/_component_builders.py
@@ -19,6 +19,8 @@ from torchtune.modules import (
     TransformerDecoderLayer,
 )
 
+from torchtune.modules.peft import LORA_ATTN_MODULES, LoRALinear
+
 """
 Component builders for the Mistral 7B models and popular variants such as LoRA.
 
@@ -63,11 +65,11 @@ def mistral(
             `None`, in which case this is the same as MHA
         embed_dim (int): embedding dimension for self-attention
         intermediate_dim (int): intermediate dimension for MLP
-            this is computed using :func:`~torchtune.modules.scale_hidden_dim_for_mlp`
+        max_seq_len (int): maximum sequence length the model will be run with,
         attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
             Default: 0.0
-        max_batch_size (Optional[int]): maximum batch size to be passed to :func:`~torchtune.modules.KVCache`
-        norm_eps (float): epsilon in RMS norms.
+        norm_eps (float): epsilon in RMS norms
+        rope_base (int): base for the rotary positional embeddings. Default: 10_000
 
     Returns:
         TransformerDecoder: Instantiation of mistral model.
@@ -115,3 +117,254 @@ def mistral_mlp(dim: int, hidden_dim: int) -> FeedForward:
     down_proj = nn.Linear(hidden_dim, dim, bias=False)
     up_proj = nn.Linear(dim, hidden_dim, bias=False)
     return FeedForward(gate_proj=gate_proj, down_proj=down_proj, up_proj=up_proj)
+
+
+def lora_mistral(
+    lora_attn_modules: List[LORA_ATTN_MODULES],
+    apply_lora_to_mlp: bool = False,
+    apply_lora_to_output: bool = False,
+    *,
+    # mistral args
+    vocab_size: int,
+    num_layers: int,
+    num_heads: int,
+    num_kv_heads: int,
+    embed_dim: int,
+    max_seq_len: int,
+    intermediate_dim: int,
+    attn_dropout: float = 0.0,
+    norm_eps: float = 1e-5,
+    rope_base: int = 10_000,
+    # LoRA args
+    lora_rank: int,
+    lora_alpha: float,
+    lora_dropout: float = 0.0,
+) -> TransformerDecoder:
+    """
+    Return a version of Mistral (an instance of :func:`~torchtune.modules.TransformerDecoder`)
+    with LoRA applied to some of the linear layers in its self-attention modules.
+
+    Args:
+        lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers
+            LoRA should be applied to in each self-attention block. Options are
+            ``{"q_proj", "k_proj", "v_proj", "output_proj"}``.
+        apply_lora_to_mlp (bool): whether to apply LoRA to the MLP in each transformer layer.
+            Default: False
+        apply_lora_to_output (bool): whether to apply LoRA to the model's final output projection.
+            Default: False
+        vocab_size (int): number of tokens in vocabulary.
+        num_layers (int): number of layers in the transformer decoder.
+        num_heads (int): number of query heads. For MHA this is also the
+            number of heads for key and value
+        num_kv_heads (int): number of key and value heads. If specified,
+            user should ensure `num_heads` % `num_kv_heads` == 0. Default value is
+            `None`, in which case this is the same as MHA
+        embed_dim (int): embedding dimension for self-attention
+        max_seq_len (int): maximum sequence length the model will be run with
+        intermediate_dim (int): intermediate dimension for MLP.
+        attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
+            Default: 0.0
+        norm_eps (float): epsilon in RMS norms.
+        rope_base (int): base for the rotary positional embeddings. Default: 10_000
+        lora_rank (int): rank of each low-rank approximation
+        lora_alpha (float): scaling factor for the low-rank approximation
+        lora_dropout (float): LoRA dropout probability. Default: 0.0
+
+    Returns:
+        TransformerDecoder: Instantiation of Mistral model with LoRA applied to
+        a subset of the attention projections in each layer.
+
+    """
+
+    self_attn = lora_mistral_self_attention(
+        lora_modules=lora_attn_modules,
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        max_seq_len=max_seq_len,
+        attn_dropout=attn_dropout,
+        rope_base=rope_base,
+        lora_rank=lora_rank,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+    )
+
+    if apply_lora_to_mlp:
+        mlp = lora_mistral_mlp(
+            dim=embed_dim,
+            hidden_dim=intermediate_dim,
+            lora_rank=lora_rank,
+            lora_alpha=lora_alpha,
+        )
+    else:
+        mlp = mistral_mlp(dim=embed_dim, hidden_dim=intermediate_dim)
+
+    layer = TransformerDecoderLayer(
+        attn=self_attn,
+        mlp=mlp,
+        sa_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
+        mlp_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
+    )
+
+    tok_embeddings = nn.Embedding(vocab_size, embed_dim)
+
+    # TODO: quantize_base is not applied to final output_proj currently.
+    output_proj = (
+        LoRALinear(embed_dim, vocab_size, rank=lora_rank, alpha=lora_alpha)
+        if apply_lora_to_output
+        else nn.Linear(embed_dim, vocab_size, bias=False)
+    )
+    model = TransformerDecoder(
+        tok_embeddings=tok_embeddings,
+        layer=layer,
+        num_layers=num_layers,
+        norm=RMSNorm(embed_dim, eps=norm_eps),
+        output=output_proj,
+    )
+
+    return model
+
+
+def lora_mistral_self_attention(
+    lora_modules: List[LORA_ATTN_MODULES],
+    *,
+    # CausalSelfAttention args
+    embed_dim: int,
+    num_heads: int,
+    num_kv_heads: int,
+    max_seq_len: int,
+    attn_dropout: float = 0.0,
+    rope_base: int = 10_000,
+    # LoRA args
+    lora_rank: int,
+    lora_alpha: float,
+    lora_dropout: float = 0.0,
+) -> CausalSelfAttention:
+    """
+    Return an instance of :func:`~torchtune.modules.CausalSelfAttention` with LoRA
+    applied to a subset of its linear layers
+
+    Args:
+        lora_modules (List[LORA_ATTN_MODULES]): list of which linear layers
+            LoRA should be applied to. Options are ``{"q_proj", "k_proj", "v_proj",
+            "output_proj"}``.
+        embed_dim (int): embedding dimension for self-attention
+        num_heads (int): number of query heads. For MHA this is also the
+            number of heads for key and value
+        num_kv_heads (int): number of key and value heads. If specified,
+            user should ensure `num_heads` % `num_kv_heads` == 0. Default value is
+            `None`, in which case this is the same as MHA
+        max_seq_len (int): maximum sequence length the model will be run with
+        attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
+            Default: 0.0
+        rope_base (int): base for the rotary positional embeddings. Default: 10_000
+        lora_rank (int): rank of each low-rank approximation
+        lora_alpha (float): scaling factor for the low-rank approximation
+        lora_dropout (float): LoRA dropout probability. Default: 0.0
+
+    Returns:
+        CausalSelfAttention: instantiation of self-attention module with LoRA
+        applied to a subset of Q, K, V, output projections.
+
+    Raises:
+        ValueError: If lora_modules arg is an empty list
+    """
+    if not lora_modules:
+        raise ValueError(
+            f"Must pass one or more of {LORA_ATTN_MODULES} as lora_modules"
+        )
+
+    head_dim = embed_dim // num_heads
+    num_kv_heads = num_kv_heads if num_kv_heads else num_heads
+
+    q_proj = (
+        LoRALinear(
+            embed_dim,
+            num_heads * head_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+        )
+        if "q_proj" in lora_modules
+        else nn.Linear(embed_dim, num_heads * head_dim, bias=False)
+    )
+    k_proj = (
+        LoRALinear(
+            embed_dim,
+            num_kv_heads * head_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+        )
+        if "k_proj" in lora_modules
+        else nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+    )
+    v_proj = (
+        LoRALinear(
+            embed_dim,
+            num_kv_heads * head_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+        )
+        if "v_proj" in lora_modules
+        else nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+    )
+    output_proj = (
+        LoRALinear(
+            embed_dim,
+            embed_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+        )
+        if "output_proj" in lora_modules
+        else nn.Linear(embed_dim, embed_dim, bias=False)
+    )
+    rope = RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
+    self_attn = CausalSelfAttention(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        q_proj=q_proj,
+        k_proj=k_proj,
+        v_proj=v_proj,
+        output_proj=output_proj,
+        pos_embeddings=rope,
+        max_seq_len=max_seq_len,
+        attn_dropout=attn_dropout,
+    )
+    return self_attn
+
+
+def lora_mistral_mlp(
+    *,
+    dim: int,
+    hidden_dim: int,
+    lora_rank: int,
+    lora_alpha: float,
+    lora_dropout: float = 0.0,
+) -> FeedForward:
+    gate_proj = LoRALinear(
+        in_dim=dim,
+        out_dim=hidden_dim,
+        rank=lora_rank,
+        alpha=lora_alpha,
+        dropout=lora_dropout,
+    )
+    down_proj = LoRALinear(
+        in_dim=hidden_dim,
+        out_dim=dim,
+        rank=lora_rank,
+        alpha=lora_alpha,
+        dropout=lora_dropout,
+    )
+    up_proj = LoRALinear(
+        in_dim=dim,
+        out_dim=hidden_dim,
+        rank=lora_rank,
+        alpha=lora_alpha,
+        dropout=lora_dropout,
+    )
+    return FeedForward(
+        gate_proj=gate_proj,
+        down_proj=down_proj,
+        up_proj=up_proj,
+    )

--- a/torchtune/models/mistral/_component_builders.py
+++ b/torchtune/models/mistral/_component_builders.py
@@ -208,7 +208,6 @@ def lora_mistral(
 
     tok_embeddings = nn.Embedding(vocab_size, embed_dim)
 
-    # TODO: quantize_base is not applied to final output_proj currently.
     output_proj = (
         LoRALinear(embed_dim, vocab_size, rank=lora_rank, alpha=lora_alpha)
         if apply_lora_to_output

--- a/torchtune/models/mistral/_model_builders.py
+++ b/torchtune/models/mistral/_model_builders.py
@@ -8,9 +8,10 @@ from functools import partial
 
 from torch import nn
 
-from torchtune.models.mistral._component_builders import mistral
+from torchtune.models.mistral._component_builders import mistral, lora_mistral
 
 from torchtune.modules import Tokenizer, TransformerDecoder
+from torchtune.modules.peft import LORA_ATTN_MODULES
 
 
 """
@@ -46,3 +47,52 @@ def mistral_tokenizer(path: str) -> Tokenizer:
     # Original tokenizer has no pad_id, which causes indexing errors when batch training
     tokenizer.pad_id = 0
     return tokenizer
+
+
+def lora_mistral_7b(
+    lora_attn_modules: List[LORA_ATTN_MODULES],
+    apply_lora_to_mlp: bool = False,
+    apply_lora_to_output: bool = False,
+    lora_rank: int = 8,
+    lora_alpha: float = 16,
+) -> TransformerDecoder:
+    """
+    Builder for creating a Llama2 7B model with LoRA enabled.
+
+    The Llama2 defaults are the same as in :func:`~torchtune.models.llama2.llama2_7b`,
+    while LoRA default params are based on
+    https://github.com/tloen/alpaca-lora/blob/8bb8579e403dc78e37fe81ffbb253c413007323f/finetune.py#L41-L43.
+
+    Args:
+        lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers
+            LoRA should be applied to in each self-attention block. Options are
+            ``{"q_proj", "k_proj", "v_proj", "output_proj"}``.
+        apply_lora_to_mlp (bool): whether to apply LoRA to the MLP in each transformer layer.
+            Default: False
+        apply_lora_to_output (bool): whether to apply LoRA to the model's final output projection.
+            Default: False
+        lora_rank (int): rank of each low-rank approximation
+        lora_alpha (float): scaling factor for the low-rank approximation
+        max_batch_size (Optional[int]): Maximum batch size to be passed to KVCache.
+
+    Returns:
+        TransformerDecoder: Instantiation of Llama2 7B model with LoRA applied
+    """
+    return lora_mistral(
+        lora_attn_modules=lora_attn_modules,
+        apply_lora_to_mlp=apply_lora_to_mlp,
+        apply_lora_to_output=apply_lora_to_output,
+        vocab_size=32_000,
+        num_layers=32,
+        num_heads=32,
+        num_kv_heads=8,
+        embed_dim=4096,
+        intermediate_dim=14336,
+        max_seq_len=32768,
+        attn_dropout=0.0,
+        norm_eps=1e-5,
+        rope_base=10_000,
+        lora_rank=lora_rank,
+        lora_alpha=lora_alpha,
+        lora_dropout=0.05,
+    )

--- a/torchtune/models/mistral/_model_builders.py
+++ b/torchtune/models/mistral/_model_builders.py
@@ -57,11 +57,7 @@ def lora_mistral_7b(
     lora_alpha: float = 16,
 ) -> TransformerDecoder:
     """
-    Builder for creating a Llama2 7B model with LoRA enabled.
-
-    The Llama2 defaults are the same as in :func:`~torchtune.models.llama2.llama2_7b`,
-    while LoRA default params are based on
-    https://github.com/tloen/alpaca-lora/blob/8bb8579e403dc78e37fe81ffbb253c413007323f/finetune.py#L41-L43.
+    Builder for creating a Mistral 7B model with LoRA enabled.
 
     Args:
         lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers
@@ -76,7 +72,7 @@ def lora_mistral_7b(
         max_batch_size (Optional[int]): Maximum batch size to be passed to KVCache.
 
     Returns:
-        TransformerDecoder: Instantiation of Llama2 7B model with LoRA applied
+        TransformerDecoder: Instantiation of Mistral 7B model with LoRA applied
     """
     return lora_mistral(
         lora_attn_modules=lora_attn_modules,


### PR DESCRIPTION
## Context

#571 added support for Mistral 7B. In this PR, I add configs for Mistral7B full finetuning and lora. These can be further improved, but have decent results OOTB.

Full finetune:
```
 tune --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
--config mistral/7B_full \
metric_logger=torchtune.utils.metric_logging.WandBLogger \
metric_logger.project=test
```

Loss Curve:

<img width="531" alt="Screenshot 2024-03-25 at 9 00 57 AM" src="https://github.com/pytorch/torchtune/assets/47255723/92f9e3dc-c991-432e-94e4-e0ec3f6c9b2d">

Eval on ```truthfulqa_mc2```

<img width="1076" alt="Screenshot 2024-03-25 at 9 01 08 AM" src="https://github.com/pytorch/torchtune/assets/47255723/7eae5d34-5ce2-41f4-9cc2-704c510d1a86">


LoRA: 
```
tune --nnodes 1 --nproc_per_node 4 lora_finetune_distributed \
--config mistral/7B_lora  \
metric_logger=torchtune.utils.metric_logging.WandBLogger \
metric_logger.project=test
```

Loss Curve:

<img width="526" alt="image" src="https://github.com/pytorch/torchtune/assets/47255723/e75365a7-12b3-4698-b944-476cd128e5ff">

Eval on ```truthfulqa_mc2```

<img width="1250" alt="Screenshot 2024-03-26 at 7 11 15 AM" src="https://github.com/pytorch/torchtune/assets/47255723/53efc353-2219-4e55-979f-a9ff1a8c9588">


## FAQ

How did you come up with these configs?

Getting training to stabilize took some work. This model seems to need a smaller LR than the Llama2 7B/13B models and for LoRA, I needed to ramp up rank and alpha a bit. I don't claim this to be novel work though. I just did a bunch of snooping around on localllama [[example](https://www.reddit.com/r/LocalLLaMA/comments/1amjzjw/mistral_finetuning_loss_increases_crazy/)] and some other forums and blogs to come up with a config with reasonable results.


## Changelog
- Adding component and model builders for LoRA with Mistral 7B
- Add configs for LoRA and Full finetuning for Mistral 7B

## Test plan
- Tests

```
pytest tests
```

- E2E Runs - see above
