### PR TITLE
Move doc-preview to a separate job

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   build_docs:
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.11']

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -59,9 +59,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: gh-pages
-          persist-credentials: false
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -47,6 +47,30 @@ jobs:
         run: |
           cd docs
           make html
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Built-Docs
+          path: docs/build/html/
+
+  doc-preview:
+    runs-on: [self-hosted, linux.2xlarge]
+    needs: build_docs
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          persist-credentials: false
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Built-Docs
+          path: docs
+      - name: Add no-index tag
+        run: |
+          cd docs
+          find . -name "*.html" -print0 | xargs -0 sed -i '/<head>/a \ \ <meta name="robots" content="noindex">';
       - name: Upload docs preview
         uses: seemethere/upload-artifact-s3@v5
         if: ${{ github.event_name == 'pull_request' }}
@@ -56,10 +80,6 @@ jobs:
           if-no-files-found: error
           path: docs/build/html/
           s3-prefix: pytorch/torchtune/${{ github.event.pull_request.number }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Built-Docs
-          path: docs/build/html/
 
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -66,8 +66,7 @@ jobs:
           path: docs
       - name: Add no-index tag
         run: |
-          cd docs
-          find . -name "*.html" -print0 | xargs -0 sed -i '/<head>/a \ \ <meta name="robots" content="noindex">';
+          find docs -name "*.html" -print0 | xargs -0 sed -i '/<head>/a \ \ <meta name="robots" content="noindex">';
       - name: Upload docs preview
         uses: seemethere/upload-artifact-s3@v5
         if: ${{ github.event_name == 'pull_request' }}
@@ -75,7 +74,7 @@ jobs:
           retention-days: 14
           s3-bucket: doc-previews
           if-no-files-found: error
-          path: docs/build/html/
+          path: docs
           s3-prefix: pytorch/torchtune/${{ github.event.pull_request.number }}
 
   upload:


### PR DESCRIPTION
#### Context
The doc-build job needs to run on ubuntu-latest but the upload-preview needs to run on a self-hosted worker to be able to upload to S3. Therefore, moving doc-preview step to a separate job so that it can run on a self-hosted worker independently of other jobs. 
