### PR TITLE
Prevent `tests/` from being packaged.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ check-return-types = 'False'
 exclude = 'tests/torchtune/models/llama2/scripts/'
 
 [tool.pytest.ini_options]
-addopts = ["--showlocals", "--import-mode=importlib", "--without-integration", "--without-slow-integration"]
+addopts = ["--showlocals", "--import-mode=prepend", "--without-integration", "--without-slow-integration"]
 # --showlocals will show local variables in tracebacks
-# --import-model=importlib ensures pytest doesn't append the repo root to sys.path,
-# causing our tests to bypass legitimate import errors
+# --import-mode=prepend will add the root (the parent dir of torchtune/, tests/, recipes/)
+# to `sys.path` when invoking pytest, allowing us to treat `tests` as a package within the tests.
 # --without-integration and --without-slow-integration: default to running unit tests only

--- a/recipes/__init__.py
+++ b/recipes/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file mainly exists because we want to ensure that `recipes` aren't
+# importable *from the tests*.
+# We're using the `prepend` pytest import mode which adds the root dir (i.e. the
+# parent of torchtune/, tests/, recipes/) to the pythonpath during pytest
+# sessions
+# (https://docs.pytest.org/en/7.1.x/explanation/pythonpath.html#import-modes).
+# This has the positive effect that the `tests` folder becomes importable when
+# testing (we need that, considering how tests are currently set up) but ALSO
+# has the negative effect of making the `recipes/` importable when testing.
+# Since we don't want the tests to to incorrectly assume that recipes are
+# importable, we have to explicitly raise an error here.
+
+# TODO: Add proper link to pytorch.org/torchtune/... when the docs are live.
+raise ModuleNotFoundError(
+    "The TorchTune recipes folder isn't a package and you should not import anything from there. "
+    "Refer to our docs for detailed instructions on how to use the recipes!"
+    "This file only exists for testing reasons."
+)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read_requirements(file):
 setup(
     name="torchtune",
     version="0.0.1",
-    packages=find_packages(exclude=["tests", "tests.*"]),
+    packages=find_packages(exclude=["tests", "tests.*", "recipes"]),
     python_requires=">=3.8",
     install_requires=read_requirements("requirements.txt"),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read_requirements(file):
 setup(
     name="torchtune",
     version="0.0.1",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.8",
     install_requires=read_requirements("requirements.txt"),
     entry_points={

--- a/tests/test_import_recipes.py
+++ b/tests/test_import_recipes.py
@@ -8,5 +8,5 @@ import pytest
 
 
 def test_import_receipes():
-    with pytest.raises(ModuleNotFoundError, match="No module named 'recipes'"):
+    with pytest.raises(ModuleNotFoundError, match="recipes folder isn't a package"):
         import recipes  # noqa

--- a/tests/test_import_recipes.py
+++ b/tests/test_import_recipes.py
@@ -7,6 +7,6 @@
 import pytest
 
 
-def test_import_receipes():
+def test_import_recipes():
     with pytest.raises(ModuleNotFoundError, match="recipes folder isn't a package"):
         import recipes  # noqa

--- a/tests/test_import_recipes.py
+++ b/tests/test_import_recipes.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+
+def test_import_receipes():
+    with pytest.raises(ModuleNotFoundError, match="No module named 'recipes'"):
+        import recipes  # noqa


### PR DESCRIPTION
If you `pip install torchtune` right now, you end up installing the `torchtune` package (great!) and you also end up installing our `tests` package (ouch!)

```bash
(env) ➜  ~ pip install torchtune
(env) ➜  ~ python -c "import tests; print(tests)"
<module 'tests' from '/home/nicolashug/.miniconda3/envs/wtf/lib/python3.10/site-packages/tests/__init__.py'>
(env) ➜  ~ ls /home/nicolashug/.miniconda3/envs/wtf/lib/python3.10/site-packages/tests/
common.py  conftest.py  __init__.py  __pycache__  recipes  test_utils.py  torchtune
```

**This PR fixes that by making sure that the torchtune wheels won't be packaging the `tests/` folder.**


The fix for that is simply 64bafdad8eb3e53046aeffd0552ab85870ba8385.

# BUT

Our tests setup is currently relying on the assumption that `tests` is a package: we keep doing stuff like `from test.X import Y`. And if we were to just do 64bafdad8eb3e53046aeffd0552ab85870ba8385, the `tests` package isn't installed anymore, so the entire test suite fails with import errors.

So we need a way for `tests/` to become importable when we run tests. The easy way to do that is to use the `prepend` mode of pytest 650f98428078751f90d99407373e5d9449a83ab1. https://docs.pytest.org/en/7.1.x/explanation/pythonpath.html. This mode will add the root of the package (i.e. the parent of `torchtune/`, `tests/`, `recipes/`) to the Pythonpath when running the tests. So the `tests` folder is magically importable again when running the tests.

# BUT

`tests` are importable when running the tests now, and that's great, but so are the `recipes`!! and that's bad, we don't want our tests to rely on that assumption. So I added a test in 625cfd8ccc57ea41e7e7229f462dcaac1ec74efa that ensure the `recipes` folder isn't importable from the tests (that test fails in 625cfd8ccc57ea41e7e7229f462dcaac1ec74efa).

To make that test pass, i.e. to make the `recipes` folder impossible to import from the tests, I had to explicitly create `recipes/__init__.py` and raise a loud error in there 457ef58552dce32cfa9b65feb4fd7d7c286b0dbe

# BUT

Now that `recipes` has an `__init__.py` file, it gets interpreted by `find_packages()` as a package. So we have to explicitly exclude it as well from `find_packages()` aa8063825809795019de1d6022f4190bc16323b4


# Wow that dummy `__init__.py` file is horrible

Yes

# BUT

Python packaging is an absolute mess. It should be simpler than this but it's not. There are probably many different ways to solve the original problem addressed in this PR, and also probably many different ways to address the sub-problems. This is the solutions I ended-up with after 1.5 days of efforts on this.

If you would like to tackle this problem and fix it with a cleaner solution, I'm happy to provide support and reviews. In the meantime, and considering our release deadline, this should do.


# Appendix

## How do I even check that `tests` and `recipes` are properly excluded from being packaged?

1. Build the wheel. From any env:

```bash
$ rm -rf build dist torchtune.egg-info && python setup.py bdist_wheel
```

(If you want to be thorough, also check source distribution by running the same procedure with `python setup.py sdist`)

2. unzip the wheel 
```bash
$ cd dist 
$ unzip torchtune-0.0.1-py3-none-any.whl 
```

3. make sure `tests` and `recipes` aren't part of that. You should only see:

```bash
$ ls
torchtune  torchtune-0.0.1.dist-info  torchtune-0.0.1-py3-none-any.whl
```

## BEFORE YOU PUSH ANY RELEASE TO PYPI

1. Pull me in
2. Do all the steps above and then install the wheel FROM A CLEAN ENVIRONMENT

```bash
$ pip install  path_to_torchtune/dist/torchtune-0.0.1-py3-none-any.whl
```

3. make sure all the tests run fine from there. Try random stuff.
4. Push the wheel to pypi/test, install it from a fresh env, rerun all the tests
5. Push the wheel to pypi and pray.