### PR TITLE
[RFC][fix test] missing .item() in frozen nf4 test

### DIFF
--- a/tests/torchtune/modules/low_precision/test_nf4_linear.py
+++ b/tests/torchtune/modules/low_precision/test_nf4_linear.py
@@ -126,4 +126,4 @@ class TestNF4Linear:
 
         err_bnb = (out_bnb - out_ref).sum().abs().max()
         err_native = (out_nf4 - out_ref).sum().abs().max()
-        assert err_native.item() <= err_bnb
+        assert err_native.item() <= err_bnb.item()


### PR DESCRIPTION
#### Context
- as titled. missing .item()
- but there is another thing. I found the error from frozen-nf4 is larger than the one from bnb-linear

<img width="1037" alt="Screenshot 2024-03-28 at 2 28 58 PM" src="https://github.com/pytorch/torchtune/assets/62768671/a42737a4-fe21-4489-b8bd-6123b179bbb4">


#### Changelog
- updated nf4 test

#### Test plan
- pytest tests/torchtune/modules/low_precision/test_nf4_linear.py
