### PR TITLE
[Fix] Update the tune command to kick off training in yaml files

### DIFF
--- a/recipes/configs/llama2/13B_full.yaml
+++ b/recipes/configs/llama2/13B_full.yaml
@@ -8,7 +8,7 @@
 #   --output-dir /tmp/llama2-13b-hf
 #
 # To launch on 4 devices, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
+#   tune run --nproc_per_node 4 full_finetune_distributed \
 #   --config llama2/13B_full \
 #
 # You can add specific overrides through the command line. For example

--- a/recipes/configs/llama2/13B_lora.yaml
+++ b/recipes/configs/llama2/13B_lora.yaml
@@ -8,7 +8,7 @@
 #   --output-dir /tmp/llama2-13b-hf
 #
 # To launch on 4 devices, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 4 lora_finetune_distributed \
+#   tune run --nproc_per_node 4 lora_finetune_distributed \
 #   --config llama2/13B_lora \
 #
 # You can add specific overrides through the command line. For example

--- a/recipes/configs/llama2/7B_full.yaml
+++ b/recipes/configs/llama2/7B_full.yaml
@@ -8,7 +8,7 @@
 #   --output-dir /tmp/llama2
 #
 # To launch on 4 devices, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
+#   tune run --nproc_per_node 4 full_finetune_distributed \
 #   --config llama2/7B_full \
 #
 # You can add specific overrides through the command line. For example

--- a/recipes/configs/llama2/7B_full_single_device.yaml
+++ b/recipes/configs/llama2/7B_full_single_device.yaml
@@ -8,7 +8,7 @@
 #   --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 1 full_finetune_single_device \
+#   tune run full_finetune_single_device \
 #   --config llama2/7B_full_single_device \
 #
 # You can add specific overrides through the command line. For example

--- a/recipes/configs/llama2/7B_full_single_device_low_memory.yaml
+++ b/recipes/configs/llama2/7B_full_single_device_low_memory.yaml
@@ -8,7 +8,7 @@
 #   --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 1 full_finetune_single_device \
+#   tune run full_finetune_single_device \
 #   --config llama2/7B_full_single_device_low_memory \
 #
 # You can add specific overrides through the command line. For example

--- a/recipes/configs/llama2/7B_lora.yaml
+++ b/recipes/configs/llama2/7B_lora.yaml
@@ -8,7 +8,7 @@
 #   --output-dir /tmp/llama2
 #
 # To launch on 4 devices, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 4 lora_finetune_distributed \
+#   tune run --nproc_per_node 4 lora_finetune_distributed \
 #   --config llama2/7B_lora \
 #
 # You can add specific overrides through the command line. For example

--- a/recipes/configs/llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_single_device.yaml
@@ -8,7 +8,7 @@
 #   --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 1 lora_finetune_single_device \
+#   tune run lora_finetune_single_device \
 #   --config llama2/7B_lora_single_device \
 #
 # You can add specific overrides through the command line. For example

--- a/recipes/configs/llama2/7B_qlora_single_device.yaml
+++ b/recipes/configs/llama2/7B_qlora_single_device.yaml
@@ -8,8 +8,8 @@
 #   --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune --nnodes 1 --nproc_per_node 1 lora_finetune_single_device \
-#   --config 7B_qlora_single_device \
+#   tune run lora_finetune_single_device \
+#   --config llama2\7B_qlora_single_device \
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training

--- a/recipes/configs/mistral/7B_full.yaml
+++ b/recipes/configs/mistral/7B_full.yaml
@@ -3,7 +3,7 @@
 # from the paper
 #
 # Run this config on 4 GPUs using the following:
-# tune --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full
+# tune run --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full
 
 # Tokenizer
 tokenizer:

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -3,7 +3,7 @@
 # from the paper
 #
 # Run this config on 4 GPUs using the following:
-# tune --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config mistral/7B_lora
+# tune run --nproc_per_node 4 lora_finetune_distributed --config mistral/7B_lora
 
 
 # Tokenizer


### PR DESCRIPTION
#### Context
https://github.com/pytorch/torchtune/pull/586 updated the command to kick off training with tune run. Update the command line in yamls files to compatible with that

#### Changelog
Update tune command line recipe yaml files

#### Test plan
 tune run full_finetune_single_device \
--config llama2/7B_full_single_device_low_memory

tune run full_finetune_single_device \
--config llama2/7B_full_single_device_low_memory 

tune run --nproc_per_node 4 full_finetune_distributed \
--config llama2/7B_full 

tune run lora_finetune_single_device \
--config llama2/7B_lora_single_device 

 tune run --nproc_per_node 4 lora_finetune_distributed \
--config llama2/7B_lora 

tune run lora_finetune_single_device \
--config llama2/7B_qlora_single_device

tune run --nproc_per_node 4 full_finetune_distributed \
--config llama2/13B_full 

tune run --nproc_per_node 4 lora_finetune_distributed \
--config llama2/13B_lora 

tune run --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full

tune run --nproc_per_node 4 lora_finetune_distributed --config mistral/7B_lora

