### PR TITLE
Adding quantization support in torchtune

### DIFF
--- a/recipes/configs/eleuther_eval.yaml
+++ b/recipes/configs/eleuther_eval.yaml
@@ -28,3 +28,6 @@ seed: 217
 tasks: ["truthfulqa_mc2"]
 limit: null
 max_seq_length: 4096
+
+# Quantization specific args
+quantizer: null

--- a/recipes/configs/generate.yaml
+++ b/recipes/configs/generate.yaml
@@ -29,3 +29,5 @@ prompt: "Hello, my name is"
 max_new_tokens: 300
 temperature: 0.8
 top_k: 300
+
+quantizer: null

--- a/recipes/configs/quantize.yaml
+++ b/recipes/configs/quantize.yaml
@@ -1,0 +1,52 @@
+# Config for QuantizationRecipe in quantize.py
+#
+# To launch, run the following command from root torchtune directory:
+#    tune quantize --config quantize
+#
+# Supported quantization modes are:
+#      8w:
+#        torchtune.utils.quantization.Int8WeightOnlyQuantizer
+#        int8 weight only per axis group quantization
+#
+#      4w:
+#        torchtune.utils.quantization.Int4WeightOnlyQuantizer
+#        int4 weight only per axis group quantization
+#        Args:
+#          `groupsize` (int): a parameter of int4 weight only quantization,
+#           it refers to the size of quantization groups which get independent quantization parameters
+#           e.g. 32, 64, 128, 256, smaller numbers means more fine grained and higher accuracy
+#
+#      4w-gptq:
+#        torchtune.utils.quantization.Int4WeightOnlyGPTQQuantizer
+#        int4 weight only per axis group quantization with GPTQ
+#        Args:
+#           `groupsize`: see description in `4w`
+#           `blocksize`: GPTQ is applied to a 'block' of columns at a time,
+#            larger blocks trade off memory for perf, recommended to be a constant
+#            multiple of groupsize.
+#            `percdamp`: GPTQ stablization hyperparameter, recommended to be .01
+#
+#        future note: blocksize and percdamp should not have to be 'known' by users by default.
+#        Similar to momentum constant in MovingAverageObserver, it can be tuned,
+#        but 99% of users don't need to pay attention to it. blocksize should probably be set at
+#        max(`groupsize`, 128) and percdamp at .01
+
+#
+# Model arguments
+model:
+  _component_: torchtune.models.llama2.llama2_7b
+
+checkpointer:
+  _component_: torchtune.utils.FullModelMetaCheckpointer
+  checkpoint_dir: /tmp/llama2/
+  checkpoint_files: [meta_model_0.pt]
+  output_dir: /tmp/llama2/
+  model_type: LLAMA2
+
+device: cuda
+dtype: bf16
+seed: 1234
+
+quantizer:
+  _component_: torchtune.utils.quantization.Int4WeightOnlyQuantizer
+  groupsize: 256

--- a/recipes/quantize.py
+++ b/recipes/quantize.py
@@ -1,0 +1,92 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import sys
+import time
+from typing import Any, Dict
+
+import torch
+from omegaconf import DictConfig
+
+from torch import nn
+
+from torchtune import config, utils
+
+logger = utils.get_logger("DEBUG")
+
+
+class QuantizationRecipe:
+    """
+    Recipe for quantizing a Transformer-based LLM.
+    Uses quantizer classes from torchao to quantize a model.
+    Please refer to `receipes/configs/quantize.yaml` for supported quantizers and how to use them.
+    """
+
+    def __init__(self, cfg: DictConfig) -> None:
+        self._device = utils.get_device(device=cfg.device)
+        self._dtype = utils.get_dtype(dtype=cfg.dtype)
+        self._quantizer = config.instantiate(cfg.quantizer)
+        self._quantization_mode = utils.get_quantizer_mode(self._quantizer)
+        utils.set_seed(seed=cfg.seed)
+
+    def load_checkpoint(self, checkpointer_cfg: DictConfig) -> Dict[str, Any]:
+        self._checkpointer = config.instantiate(checkpointer_cfg)
+        checkpoint_dict = self._checkpointer.load_checkpoint()
+        return checkpoint_dict
+
+    def setup(self, cfg: DictConfig) -> None:
+        ckpt_dict = self.load_checkpoint(cfg.checkpointer)
+        self._model = self._setup_model(
+            model_cfg=cfg.model,
+            model_state_dict=ckpt_dict[utils.MODEL_KEY],
+        )
+
+    def _setup_model(
+        self,
+        model_cfg: DictConfig,
+        model_state_dict: Dict[str, Any],
+    ) -> nn.Module:
+        with utils.set_default_dtype(self._dtype), self._device:
+            model = config.instantiate(model_cfg)
+
+        model.load_state_dict(model_state_dict, assign=True)
+
+        # Validate model was loaded in with the expected dtype.
+        utils.validate_expected_param_dtype(model.named_parameters(), dtype=self._dtype)
+        logger.info(f"Model is initialized with precision {self._dtype}.")
+        return model
+
+    @torch.no_grad()
+    def quantize(self, cfg: DictConfig):
+        t0 = time.perf_counter()
+        self._model = self._quantizer.quantize(self._model)
+        t = time.perf_counter() - t0
+        logger.info(f"Time for quantization: {t:.02f} sec")
+        logger.info(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
+
+    def save_checkpoint(self, cfg: DictConfig):
+        ckpt_dict = self._model.state_dict()
+        file_name = cfg.checkpointer.checkpoint_files[0].split(".")[0]
+        quantized_file_name = (
+            cfg.checkpointer.output_dir
+            + file_name
+            + "."
+            + self._quantization_mode
+            + ".pt"
+        )
+        torch.save(ckpt_dict, quantized_file_name)
+        logger.info(f"Saved quantized model to {quantized_file_name}")
+
+
+@config.parse
+def main(cfg: DictConfig) -> None:
+    recipe = QuantizationRecipe(cfg=cfg)
+    recipe.setup(cfg=cfg)
+    recipe.quantize(cfg=cfg)
+    recipe.save_checkpoint(cfg=cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ tqdm
 omegaconf
 
 # Quantization
-torchao-nightly==2024.3.29
+torchao==0.1

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -105,6 +105,14 @@ _ALL_RECIPES = [
         ],
         supports_distributed=True,
     ),
+    Recipe(
+        name="quantize",
+        file_path="quantize.py",
+        configs=[
+            Config(name="quantize", file_path="quantize.yaml"),
+        ],
+        supports_distributed=False,
+    ),
 ]
 
 

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -53,6 +53,7 @@ from .precision import (
     set_default_dtype,
     validate_expected_param_dtype,
 )
+from .quantization import get_quantizer_mode
 from .seed import set_seed
 
 __all__ = [
@@ -82,4 +83,5 @@ __all__ = [
     "create_optim_in_bwd_wrapper",
     "register_optim_in_bwd_hooks",
     "profiler",
+    "get_quantizer_mode",
 ]

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, Optional
+
+import torch
+from torchao.quantization.quant_api import (
+    apply_weight_only_int8_quant,
+    Int4WeightOnlyGPTQQuantizer,
+    Int4WeightOnlyQuantizer,
+    Quantizer,
+)
+
+__all__ = [
+    "Int4WeightOnlyQuantizer",
+    "Int4WeightOnlyGPTQQuantizer",
+    "Int8WeightOnlyQuantizer",
+    "get_quantizer_mode",
+]
+
+
+class Int8WeightOnlyQuantizer(Quantizer):
+    def quantize(
+        self, model: torch.nn.Module, *args: Any, **kwargs: Any
+    ) -> torch.nn.Module:
+        apply_weight_only_int8_quant(model)
+        return model
+
+
+_quantizer_to_mode = {
+    Int4WeightOnlyQuantizer: "4w",
+    Int8WeightOnlyQuantizer: "8w",
+    Int4WeightOnlyGPTQQuantizer: "4w-gptq",
+}
+
+
+def get_quantizer_mode(quantizer: Optional[Callable]) -> Optional[str]:
+    """Given a quantizer object, returns a string that specifies the type of quantization e.g.
+    4w, which means int4 weight only quantization.
+    If the quantizer is not recognized as a known quantizer, we'll return None
+    """
+    return _quantizer_to_mode.get(type(quantizer), None)


### PR DESCRIPTION
Summary:
Allows user to specify quantization_mode in generating model in full_finetune_single_device.py and inference with the quantized model in generate.py

Test Plan:
tested locally

may need changes to corresponding yaml files, see README.md for more info
```
tune run full_finetune_single_device --config llama2/7B_full_single_device max_steps_per_epoch=4 epochs=1
tune run quantize --config quantize
tune run generate --config quant_generate
tune run eleuther_eval --config eleuther_eval
```

Results of generate for int4 weight only quantized model:
```
$ tune run generate --config quant_generate                                                                                                         
2024-04-04:19:23:15,756 INFO     [_parse.py:52] Running main with parameters {'model': {'_component_': 'torchtune.models.llama2.llama2_7b'}, 'checkpointer': {'_component_': 'torchtune.utils.FullModelTorchTuneCheckpointer', 'checkpoint_dir': '/tmp/llama2/', 'checkpoint_files': ['meta_model_0.4w.pt'], 'output_dir': '/tmp/llama2/', 'model_type': 'LLAMA2'}, 'device': 'cuda', 'dtype': 'bf16', 'seed': 1234, 'quantizer': {'_compone
nt_': 'torchtune.utils.quantization.Int4WeightOnlyQuantizer', 'groupsize': 256}, 'tokenizer': {'_component_': 'torchtune.models.llama2.llama2_tokenizer', 'path': '/tmp/llama2/tokenizer.model'}, 'prompt': 'Hello, my
 name is', 'max_new_tokens': 300, 'temperature': 0.8, 'top_k': 300}
2024-04-04:19:23:16,140 DEBUG    [seed.py:59] Setting manual seed to local seed 1234. Local seed is seed + rank = 1234 + 0
linear: layers.0.attn.q_proj, in=4096, out=4096
linear: layers.0.attn.k_proj, in=4096, out=4096
linear: layers.0.attn.v_proj, in=4096, out=4096
linear: layers.0.attn.output_proj, in=4096, out=4096
linear: layers.0.mlp.w1, in=4096, out=11008
linear: layers.0.mlp.w2, in=11008, out=4096
…
linear: output, in=4096, out=32000
2024-04-04:19:23:26,511 INFO     [generate.py:68] Model is initialized with precision torch.bfloat16.
2024-04-04:19:23:39,668 INFO     [generate.py:92] Hello, my name is Alicia, I’m a 47-year-old married woman whose husband is older than me. myself. I don’t have children and I’m not expecting any. If you are already 18 years old, and you plan to have a baby with me! I’m an artist and I like to be creative (especially with jewelry and beading). I’m a little clumsy and I don’t know how to drive, but I’m good at doing girly things, lol.
I like to have fun in private, so I’m looking for a guy who likes to have sex and is funny.
I am for private relationships and I understand the importance of loyalty, so I expect the same from you!
I’m here to have fun, so let’s meet and know each other and let’s see if we’ll get along!
British, Europe
Art, Cinema, History, Reading, Shopping, Sleeping
Chillin, Comedy, Conversation, Going out, Intelligence, Movies, Partying
Clothes, Creative, Goal Oriented, Intellectual, Money
2024-04-04:19:23:39,669 INFO     [generate.py:96] Time for inference: 12.82 sec total, 20.44 tokens/sec
2024-04-04:19:23:39,669 INFO     [generate.py:99] Memory used: 17.85 GB
```

Results of eval for int4 weight only quantized model:
```
$ tune run eleuther_eval --config eleuther_eval
2024-04-04:19:26:20,675 INFO     [_parse.py:52] Running recipe_main with parameters {'model': {'_component_': 'torchtune.models.llama2.llama2_7b'}, 'checkpointer': {'_component_': 'torchtune.utils.FullModelTorchTun
eCheckpointer', 'checkpoint_dir': '/tmp/llama2/', 'checkpoint_files': ['meta_model_0.4w.pt'], 'output_dir': '/tmp/llama2/', 'model_type': 'LLAMA2'}, 'tokenizer': {'_component_': 'torchtune.models.llama2.llama2_toke
nizer', 'path': '/tmp/llama2/tokenizer.model'}, 'device': 'cuda', 'dtype': 'bf16', 'seed': 217, 'tasks': ['wikitext'], 'limit': None, 'max_seq_length': 4096, 'quantizer': {'_component_': 'torchtune.utils.quantizati
on.Int4WeightOnlyQuantizer', 'groupsize': 256}}
2024-04-04:19:26:21,029 DEBUG    [seed.py:59] Setting manual seed to local seed 217. Local seed is seed + rank = 217 + 0
linear: layers.0.attn.q_proj, in=4096, out=4096
linear: layers.0.attn.k_proj, in=4096, out=4096
linear: layers.0.attn.v_proj, in=4096, out=4096
linear: layers.0.attn.output_proj, in=4096, out=4096
linear: layers.0.mlp.w1, in=4096, out=11008
linear: layers.0.mlp.w2, in=11008, out=4096
...
linear: output, in=4096, out=32000
2024-04-04:19:26:27,681 INFO     [eleuther_eval.py:167] Model is initialized with precision torch.bfloat16.
2024-04-04:19:26:27,699 INFO     [eleuther_eval.py:151] Tokenizer is initialized from file.
2024-04-04:19:26:28,036 INFO     [huggingface.py:162] Using device 'cuda:0'
q2024-04-04:19:26:35,919 WARNING  [task.py:763] [Task: wikitext] metric word_perplexity is defined, but aggregation is not. using default aggregation=weighted_perplexity
2024-04-04:19:26:35,919 WARNING  [task.py:775] [Task: wikitext] metric word_perplexity is defined, but higher_is_better is not. using default higher_is_better=False
2024-04-04:19:26:35,919 WARNING  [task.py:763] [Task: wikitext] metric byte_perplexity is defined, but aggregation is not. using default aggregation=weighted_perplexity
2024-04-04:19:26:35,919 WARNING  [task.py:775] [Task: wikitext] metric byte_perplexity is defined, but higher_is_better is not. using default higher_is_better=False
2024-04-04:19:26:35,919 WARNING  [task.py:763] [Task: wikitext] metric bits_per_byte is defined, but aggregation is not. using default aggregation=bits_per_byte
2024-04-04:19:26:35,919 WARNING  [task.py:775] [Task: wikitext] metric bits_per_byte is defined, but higher_is_better is not. using default higher_is_better=False
2024-04-04:19:26:37,607 INFO     [eleuther_eval.py:188] Running evaluation on ['wikitext'] tasks.
2024-04-04:19:26:37,610 INFO     [task.py:395] Building contexts for wikitext on rank 0...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 62/62 [00:00<00:00, 487.84it/s]
2024-04-04:19:26:37,743 INFO     [evaluator.py:362] Running loglikelihood_rolling requests
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 62/62 [04:53<00:00,  4.73s/it]
2024-04-04:19:31:31,458 INFO     [eleuther_eval.py:195] Eval completed in 303.43 seconds.
2024-04-04:19:31:31,458 INFO     [eleuther_eval.py:197] wikitext: {'word_perplexity,none': 9.615681846101303, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.5269407647819768, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.610644096180032, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
```

Reviewers:

Subscribers:

Tasks:

Tags:
