### PR TITLE
Add string to InstructTemplate, ChatFormat getters

### DIFF
--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -8,10 +8,14 @@ from unittest import mock
 
 import pytest
 from torchtune.config._utils import (
+    _get_chat_format,
     _get_component_from_path,
+    _get_instruct_template,
     _merge_yaml_and_cli_args,
+    _try_get_component,
     InstantiationError,
 )
+from torchtune.data import AlpacaInstructTemplate, Llama2ChatFormat
 from torchtune.utils.argparse import TuneRecipeArgumentParser
 
 _CONFIG = {
@@ -107,3 +111,31 @@ class TestUtils:
             ValueError, match="Command-line overrides must be in the form of key=value"
         ):
             _ = _merge_yaml_and_cli_args(yaml_args, cli_args)
+
+    def test_try_get_component(self):
+        # Test a valid classname
+        template = _try_get_component(
+            module_path="torchtune.data._instruct_templates",
+            component_name="AlpacaInstructTemplate",
+            class_type="InstructTemplate",
+        )
+        assert template == AlpacaInstructTemplate
+
+        # Test an invalid class
+        with pytest.raises(
+            ValueError,
+            match="Invalid InstructTemplate class",
+        ):
+            _ = _try_get_component(
+                module_path="torchtune.data._instruct_templates",
+                component_name="InvalidTemplate",
+                class_type="InstructTemplate",
+            )
+
+    def test_get_instruct_template(self):
+        assert (
+            _get_instruct_template("AlpacaInstructTemplate") == AlpacaInstructTemplate
+        )
+
+    def test_get_chat_format(self):
+        assert _get_chat_format("Llama2ChatFormat") == Llama2ChatFormat

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Union
 from omegaconf import DictConfig, OmegaConf
 
 from torchtune.config._errors import InstantiationError
+from torchtune.data import ChatFormat, InstructTemplate
 
 
 def _has_component(node: Union[Dict[str, Any], DictConfig]) -> bool:
@@ -148,3 +149,54 @@ def _merge_yaml_and_cli_args(yaml_args: Namespace, cli_args: List[str]) -> DictC
 
     # CLI takes precedence over yaml args
     return OmegaConf.merge(yaml_conf, cli_conf)
+
+
+def _try_get_component(module_path: str, component_name: str, class_type: str) -> Any:
+    """
+    Try-except wrapper around `_get_component_from_path`, used to quickly retrieve
+    a class from a name string with better error handling.
+
+    Args:
+        module_path (str): path string of the file the class resides in
+        component_name (str): name of the class
+        class_type (str): type of the class, only used for more descriptive error message
+
+
+    Returns:
+        Any: the class
+
+    Raises:
+        ValueError: if the string is not a valid class
+    """
+    try:
+        return _get_component_from_path(module_path + "." + component_name)
+    except InstantiationError:
+        raise ValueError(f"Invalid {class_type} class: '{component_name}'") from None
+
+
+def _get_instruct_template(template: str) -> InstructTemplate:
+    """
+    Get the instruct template class from the template string.
+
+    Args:
+        template (str): class name of template, or string with placeholders
+
+    Returns:
+        InstructTemplate: the prompt template class or the same verified string
+    """
+    return _try_get_component(
+        "torchtune.data._instruct_templates", template, "InstructTemplate"
+    )
+
+
+def _get_chat_format(chat_format: str) -> ChatFormat:
+    """
+    Get the chat format class from a string.
+
+    Args:
+        chat_format (str): class name of the ChatFormat
+
+    Returns:
+        ChatFormat: the chat format class
+    """
+    return _try_get_component("torchtune.data._chat_formats", chat_format, "ChatFormat")

--- a/torchtune/datasets/_chat.py
+++ b/torchtune/datasets/_chat.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from datasets import load_dataset
 from torch.utils.data import Dataset
+from torchtune.config._utils import _get_chat_format
 from torchtune.data import ChatFormat, Message, sharegpt_to_llama2_messages
 from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
 from torchtune.modules import Tokenizer
@@ -91,8 +92,8 @@ class ChatDataset(Dataset):
 def chat_dataset(
     tokenizer: Tokenizer,
     source: str,
-    conversation_format: str,
-    chat_format: ChatFormat,
+    conversation_style: str,
+    chat_format: str,
     max_seq_len: int,
     train_on_input: bool = False,
     **load_dataset_kwargs: Dict[str, Any],
@@ -106,9 +107,9 @@ def chat_dataset(
         tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
         source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`
             (https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path)
-        conversation_format (str): string specifying expected format of conversations in the dataset
-            for automatic conversion to the llama format. Supported formats are: "sharegpt"
-        chat_format (ChatFormat): Template class used to format the chat.
+        conversation_style (str): string specifying expected style of conversations in the dataset
+            for automatic conversion to the llama style. Supported styles are: "sharegpt"
+        chat_format (str): name of ChatFormat class used to format the messages.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to `load_dataset`.
@@ -119,16 +120,16 @@ def chat_dataset(
     Raises:
         ValueError: if the conversation format is not supported
     """
-    if conversation_format == "sharegpt":
+    if conversation_style == "sharegpt":
         convert_to_messages = sharegpt_to_llama2_messages
     else:
-        raise ValueError(f"Unsupported conversation format: {conversation_format}")
+        raise ValueError(f"Unsupported conversation style: {conversation_style}")
 
     return ChatDataset(
         tokenizer=tokenizer,
         source=source,
         convert_to_messages=convert_to_messages,
-        chat_format=chat_format,
+        chat_format=_get_chat_format(chat_format),
         max_seq_len=max_seq_len,
         train_on_input=train_on_input,
         **load_dataset_kwargs,

--- a/torchtune/datasets/_instruct.py
+++ b/torchtune/datasets/_instruct.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 import numpy as np
 from datasets import load_dataset
 from torch.utils.data import Dataset
+from torchtune.config._utils import _get_instruct_template
 
 from torchtune.data import InstructTemplate, Message
 
@@ -104,7 +105,7 @@ class InstructDataset(Dataset):
 def instruct_dataset(
     tokenizer: Tokenizer,
     source: str,
-    template: InstructTemplate,
+    template: str,
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
     max_seq_len: Optional[int] = None,
@@ -119,7 +120,7 @@ def instruct_dataset(
         tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
         source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`
             (https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path)
-        template (InstructTemplate): class used to format the prompt. If the placeholder variable
+        template (str): class used to format the prompt. If the placeholder variable
             names in the template do not match the column/key names in the dataset, use `column_map` to map them.
         column_map (Optional[Dict[str, str]]): a mapping from the expected placeholder names in the template
             to the column/key names in the sample. If None, assume these are identical.
@@ -135,7 +136,7 @@ def instruct_dataset(
     return InstructDataset(
         tokenizer=tokenizer,
         source=source,
-        template=template,
+        template=_get_instruct_template(template),
         column_map=column_map,
         train_on_input=train_on_input,
         max_seq_len=max_seq_len,


### PR DESCRIPTION
## Context
The builders `chat_dataset` and `instruct_dataset` need an easy way to specify from the config which `InstructTemplate` / `ChatFormat` to use without requiring using a nested component. Here, we add utility functions to do this easily using existing config utils. Addresses part of #637.

## Test plan
`pytest tests/torchtune/config/test_config_utils.py`
