### PR TITLE
Add weights_only flag to torchtune checkpointer

### DIFF
--- a/torchtune/utils/_checkpointing/_checkpointer.py
+++ b/torchtune/utils/_checkpointing/_checkpointer.py
@@ -148,7 +148,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 )
             self._recipe_checkpoint = get_path(self._checkpoint_dir, recipe_checkpoint)
 
-    def load_checkpoint(self) -> Dict[str, Any]:
+    def load_checkpoint(self, weights_only: bool = True) -> Dict[str, Any]:
         """
         Load TorchTune checkpoint from file. Currently only loading from a single file is supported.
 
@@ -162,9 +162,18 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 "optimizer": ...,
                 ...
             }
+
+        Args:
+            weights_only (bool): flag passed down to torch.load. We expose this, because quantized models
+                cannot be loaded with weights_only=True
+
+        Returns:
+            Dict[str, Any]: state_dict from the input checkpoint
         """
         state_dict: Dict[str:Any] = {}
-        state_dict[utils.MODEL_KEY] = safe_torch_load(self._checkpoint_path)
+        state_dict[utils.MODEL_KEY] = safe_torch_load(
+            self._checkpoint_path, weights_only=weights_only
+        )
 
         if self._adapter_checkpoint:
             adapter_state_dict = safe_torch_load(self._adapter_checkpoint)

--- a/torchtune/utils/_checkpointing/_checkpointer_utils.py
+++ b/torchtune/utils/_checkpointing/_checkpointer_utils.py
@@ -47,7 +47,7 @@ def get_path(input_dir: Path, filename: str, missing_ok: bool = False) -> Path:
     return file_path
 
 
-def safe_torch_load(checkpoint_path: Path) -> Dict[str, Any]:
+def safe_torch_load(checkpoint_path: Path, weights_only: bool = True) -> Dict[str, Any]:
     """
     Utility to load a checkpoint file in a safe manner.
     """
@@ -55,7 +55,10 @@ def safe_torch_load(checkpoint_path: Path) -> Dict[str, Any]:
         # convert the path into a string since pathlib Path and mmap don't work
         # well together
         state_dict = torch.load(
-            str(checkpoint_path), map_location="cpu", mmap=True, weights_only=True
+            str(checkpoint_path),
+            map_location="cpu",
+            mmap=True,
+            weights_only=weights_only,
         )
     except Exception as e:
         raise ValueError(f"Unable to load checkpoint from {checkpoint_path}. ") from e


### PR DESCRIPTION
#### Context
- For loading checkpoints associated with quantized models, we need to expose the weights_only flag in the high level load_checkpoint API. Doing so in this PR.

#### Changelog
- Modified safe_torch_download and load_checkpoint to take a bool which is set to True by default

#### Test plan
- Added a unit test

```
pytest tests/torchtune/utils/test_checkpointer.py
```

<img width="1045" alt="image" src="https://github.com/pytorch/torchtune/assets/47255723/9de6546c-cbd7-4129-925f-7ffa54ffa79d">

