### PR TITLE
grad accum in LoRA distributed recipe

### DIFF
--- a/recipes/configs/llama2/7B_lora.yaml
+++ b/recipes/configs/llama2/7B_lora.yaml
@@ -70,6 +70,7 @@ loss:
 # Training
 epochs: 1
 max_steps_per_epoch: null
+gradient_accumulation_steps: 1
 
 # Logging
 output_dir: /tmp/lora_finetune_output

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -378,17 +378,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 intermediate_checkpoint=(epoch + 1 < self.total_epochs),
             )
 
-    def _should_update_weights(self, current_iteration: int) -> bool:
-        """
-        Determines whether the weights should be updated on the current iteration or not.
-        True is returned either if we've accumulated gradients for enough steps or if this
-        is the last step in the epoch.
-        """
-        should_update_weights = (
-            current_iteration + 1
-        ) % self._gradient_accumulation_steps == 0
-        return should_update_weights
-
     def train(self) -> None:
         """
         The core training loop. Supports training on subsets of the dataset using the
@@ -450,7 +439,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 loss = loss / self._gradient_accumulation_steps
                 loss.backward()
 
-                if self._should_update_weights(idx):
+                if (idx + 1) % self._gradient_accumulation_steps == 0:
                     self._optimizer.step()
                     self._optimizer.zero_grad(set_to_none=True)
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -472,17 +472,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 intermediate_checkpoint=intermediate_checkpoint,
             )
 
-    def _should_update_weights(self, current_iteration: int) -> bool:
-        """
-        Determines whether the weights should be updated on the current iteration or not.
-        True is returned either if we've accumulated gradients for enough steps or if this
-        is the last step in the epoch.
-        """
-        should_update_weights = (
-            current_iteration + 1
-        ) % self._gradient_accumulation_steps == 0
-        return should_update_weights
-
     def train(self) -> None:
         """
         The core training loop.
@@ -541,7 +530,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 loss = loss / self._gradient_accumulation_steps
                 loss.backward()
 
-                if self._should_update_weights(idx):
+                if (idx + 1) % self._gradient_accumulation_steps == 0:
                     self._optimizer.step()
                     self._optimizer.zero_grad(set_to_none=True)
                     self._lr_scheduler.step()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -370,16 +370,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             intermediate_checkpoint=(epoch + 1 < self.total_epochs),
         )
 
-    def _should_update_weights(self, current_iteration: int) -> bool:
-        """
-        Determines whether the weights should be updated on the current iteration or not.
-        True is returned either if we've accumulated gradients for enough steps.
-        """
-        should_update_weights = (
-            current_iteration + 1
-        ) % self._gradient_accumulation_steps == 0
-        return should_update_weights
-
     def train(self) -> None:
         """
         The core training loop.
@@ -422,7 +412,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     )
                 loss = loss / self._gradient_accumulation_steps
                 loss.backward()
-                if self._should_update_weights(idx):
+                if (idx + 1) % self._gradient_accumulation_steps == 0:
                     self._optimizer.step()
                     self._optimizer.zero_grad(set_to_none=True)
                     self._lr_scheduler.step()


### PR DESCRIPTION
#### Context
- We have it in all our other finetune recipes, might as well add it to this one too

Implemented following the approach in `full_finetune_distributed.py`

Run without grad accumulation
```
CUDA_VISIBLE_DEVICES=5,6 tune run --nproc_per_node 2 --rdzv-backend=c10d --rdzv-endpoint=localhost:20000 lora_finetune_distributed --config llama2/7B_lora checkpointer=torchtune.utils.FullModelTorchTuneCheckpointer checkpointer.checkpoint_dir=/data/users/ebs/checkpoints checkpointer.checkpoint_files=['llama2-7b-torchtune.pt'] checkpointer.output_dir=/data/users/ebs/checkpoints/new_tokenizer tokenizer.path=/data/users/ebs/checkpoints/lora-debug/tokenizer.model max_steps_per_epoch=20 metric_logger=torchtune.utils.metric_logging.WandBLogger metric_logger.project=testing
...
1|20|Loss: 1.3451744318008423:   0%|▎            
```

Can see from wandb that there are 20 iterations logged

Run with grad accumulation
```
CUDA_VISIBLE_DEVICES=5,6 tune run --nproc_per_node 2 --rdzv-backend=c10d --rdzv-endpoint=localhost:20000 lora_finetune_distributed --config llama2/7B_lora checkpointer=torchtune.utils.FullModelTorchTuneCheckpointer checkpointer.checkpoint_dir=/data/users/ebs/checkpoints checkpointer.checkpoint_files=['llama2-7b-torchtune.pt'] checkpointer.output_dir=/data/users/ebs/checkpoints/new_tokenizer tokenizer.path=/data/users/ebs/checkpoints/lora-debug/tokenizer.model max_steps_per_epoch=20 gradient_accumulation_steps=2 metric_logger=torchtune.utils.metric_logging.WandBLogger metric_logger.project=testing

...
1|40|Loss: 1.5071550607681274:   0%|▌ 
```
Since tqdm logs iteration number, not step number, we can see that both cases run for the expected number of iterations.
