### PR TITLE
Add ``include_package_data`` to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pytorch/torchtune",
     extras_require={"dev": read_requirements("dev-requirements.txt")},
+    include_package_data=True,
 )


### PR DESCRIPTION
Investigation of built wheels on nightly revealed that package data did not seem to be included in the wheel, but rather just in the source distribution. 

I believe it is because we did not have `include_package_data=True` in our setuptools. See here: https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#controlling-files-in-the-distribution. 

