### PR TITLE
[Easy] Move loss sync for full finetune single device recipe

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -368,10 +368,11 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 logits = logits.transpose(1, 2)
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
+
                 # Note: We're always logging the loss before normalizing it
                 # Check if this is the norm or not
-                pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
                 if self.total_training_steps % self._log_every_n_steps == 0:
+                    pbar.set_description(f"{curr_epoch+1}|{idx+1}|Loss: {loss.item()}")
                     self._metric_logger.log_dict(
                         {
                             "loss": loss.item(),

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -368,7 +368,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 logits = logits.transpose(1, 2)
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
-
                 # Note: We're always logging the loss before normalizing it
                 # Check if this is the norm or not
                 if self.total_training_steps % self._log_every_n_steps == 0:


### PR DESCRIPTION
#### Context
- We moved loss sync into log every n steps block in https://github.com/pytorch/torchtune/pull/522 to improve the training speed. Somehow it was moved outside log every n steps block due to some recently changes. Move it back to improve the training speed and be consistent with other recipes

#### Changelog
- Move loss.item() into log_every_n_steps block for single device full finetune recipe

#### Test plan
- tune run full_finetune_single_device --config llama2/7B_full_single_device 
