### PR TITLE
Add trigger for building Linux wheels

### DIFF
--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -63,14 +63,14 @@ jobs:
           repository: pytorch/test-infra
           ref: main
           path: test-infra
-      - uses: pytorch/test-infra/.github/actions/set-channel
+      - uses: pytorch/test-infra/.github/actions/set-channel/action.yml@main
       - name: Set PYTORCH_VERSION
         if: ${{ env.CHANNEL == 'test' }}
         run: |
           # When building RC, set the version to be the current candidate version,
           # otherwise, leave it alone so nightly will pick up the latest
           echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
-      - uses: pytorch/test-infra/.github/actions/setup-binary-builds
+      - uses: pytorch/test-infra/.github/actions/setup-binary-builds/action.yml@main
         env:
           PLATFORM: ${{ env.ARCH == 'aarch64'  && 'linux-aarch64' || ''}}
         with:
@@ -139,7 +139,7 @@ jobs:
 
   upload:
     needs: build
-    uses: pytorch/test-infra/.github/workflows/_binary_upload.yml
+    uses: pytorch/test-infra/.github/workflows/_binary_upload.yml@main
     if: always()
     with:
       repository: pytorch.torchtune

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -142,7 +142,7 @@ jobs:
     if: always()
     with:
       repository: pytorch/torchtune
-      ref: ""
+      ref: pkg-for-wheel
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.build.needs.generate-matrix.outputs.matrix }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       package-type: $PACKAGE_TYPE
       os: linux
-      test-infra-repository: ${{ TEST_INFRA_REPOSITORY }}
+      test-infra-repository: ${{ env.TEST_INFRA_REPOSITORY }}
       test-infra-ref: $TEST_INFRA_REF
       with-cuda: disable
       with-rocm: disable

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -1,8 +1,4 @@
-# Heavy inspiration taken from:
-# https://github.com/pytorch/test-infra/blob/main/.github/workflows/build_wheels_linux.yml
-
 name: Build Linux Wheels
-
 
 on:
   pull_request:
@@ -12,164 +8,39 @@ on:
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
-        # Release candidate tags look like: v1.11.0-rc1
-        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
-
 
 permissions:
   id-token: write
   contents: read
 
-
 jobs:
-  setup-variables:
-    runs-on: ubuntu-latest
-    outputs:
-      TEST_INFRA_REPOSITORY: pytorch/test-infra
-      TEST_INFRA_REF: main
-      REPOSITORY: pytorch/torchtune
-      REF: pkg-for-wheel
-      PACKAGE_NAME: torchtune
-      PACKAGE_TYPE: wheel
-      ARCH: x86_64
-      SMOKE_TEST_SCRIPT: ""
-    steps:
-      - run: echo "Exposing env vars to all jobs"
   generate-matrix:
-    needs:
-      - setup-variables
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
-      package-type: ${{ needs.setup-variables.outputs.PACKAGE_TYPE }}
+      package-type: wheel
       os: linux
-      test-infra-repository: ${{ needs.setup-variables.outputs.TEST_INFRA_REPOSITORY }}
-      test-infra-ref: ${{ needs.setup-variables.outputs.TEST_INFRA_REF }}
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       with-cuda: disable
       with-rocm: disable
   build:
-    needs:
-      - setup-variables
-      - generate-matrix
+    needs: generate-matrix
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    env:
-      PYTHON_VERSION: ${{ matrix.python_version }}
-      CU_VERSION: ${{ matrix.desired_cuda }}
-      UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
-    name: ${{ matrix.build_name }}
-    runs-on: ${{ matrix.validation_runner }}
-    container:
-      image: ${{ matrix.container_image }}
-      options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
-    # If a build is taking longer than 60 minutes on these runners we need
-    # to have a conversation
-    timeout-minutes: 120
-    steps:
-      - name: Clean workspace
-        shell: bash -l {0}
-        run: |
-          set -euxo pipefail
-          echo "::group::Cleanup debug output"
-          rm -rf "${GITHUB_WORKSPACE}"
-          mkdir -p "${GITHUB_WORKSPACE}"
-          echo "::endgroup::"
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{ needs.setup-variables.outputs.TEST_INFRA_REPOSITORY }}
-          ref: ${{ needs.setup-variables.outputs.TEST_INFRA_REF }}
-          path: test-infra
-      - uses: pytorch/test-infra/.github/actions/set-channel@main
-      - name: Set PYTORCH_VERSION
-        if: ${{ env.CHANNEL == 'test' }}
-        run: |
-          # When building RC, set the version to be the current candidate version,
-          # otherwise, leave it alone so nightly will pick up the latest
-          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
-      - uses: pytorch/test-infra/.github/actions/setup-binary-builds@main
-        env:
-          PLATFORM: ${{ env.ARCH == 'aarch64'  && 'linux-aarch64' || ''}}
-        with:
-          repository: ${{ needs.setup-variables.outputs.REPOSITORY }}
-          ref: ${{ needs.setup-variables.outputs.REF }}
-          setup-miniconda: true
-          python-version: ${{ env.PYTHON_VERSION }}
-          cuda-version: ${{ env.CU_VERSION }}
-          arch: ${{ needs.setup-variables.outputs.ARCH }}
-      - name: Install torch dependency
-        run: |
-          set -euxo pipefail
-          # shellcheck disable=SC1090
-          source "${BUILD_ENV_FILE}"
-          # shellcheck disable=SC2086
-          ${CONDA_RUN} ${PIP_INSTALL_TORCH}
-      - name: Install python build dependency
-        run: |
-          set -euxo pipefail
-          # shellcheck disable=SC1090
-          source "${BUILD_ENV_FILE}"
-          # shellcheck disable=SC2086
-          ${CONDA_RUN} python -m pip install build
-      - name: Build the wheel (bdist_wheel)
-        working-directory: ${{ needs.setup-variables.outputs.REPOSITORY }}
-        shell: bash -l {0}
-        run: |
-          set -euxo pipefail
-          source "${BUILD_ENV_FILE}"
-          export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-          ${CONDA_RUN} python -m build --wheel
-      - name: Smoke Test
-        shell: bash -l {0}
-        env:
-          REPOSITORY: ${{ needs.setup-variables.outputs.REPOSITORY }}
-          PACKAGE_NAME: ${{ needs.setup-variables.outputs.PACKAGE_NAME }}
-          SMOKE_TEST_SCRIPT: ${{ needs.setup-variables.outputs.SMOKE_TEST_SCRIPT }}
-        run: |
-          set -euxo pipefail
-          source "${BUILD_ENV_FILE}"
-          WHEEL_NAME=$(ls "${{ env.REPOSITORY }}/dist/")
-          echo "$WHEEL_NAME"
-
-          ${CONDA_RUN} pip install "$REPOSITORY/dist/$WHEEL_NAME"
-          # Checking that we have a pinned version of torch in our dependency tree
-          (
-            pushd "${RUNNER_TEMP}"
-            unzip -o "${GITHUB_WORKSPACE}/$REPOSITORY/dist/$WHEEL_NAME"
-            # Ensure that pytorch version is pinned, should output file where it was found
-            grep "Requires-Dist: torch (==.*)" -r .
-          )
-
-          if [[ (! -f "$REPOSITORY/${SMOKE_TEST_SCRIPT}) ]]; then
-            echo "$REPOSITORY/${SMOKE_TEST_SCRIPT} not found"
-            ${CONDA_RUN} python -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
-          else
-            echo "$REPOSITORY/${SMOKE_TEST_SCRIPT} found"
-            ${CONDA_RUN} python "$REPOSITORY/${SMOKE_TEST_SCRIPT}"
-          fi
-      - name: Upload wheel to GitHub
-        continue-on-error: true
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: $REPOSITORY/dist/
-  upload:
-    needs:
-      - setup-variables
-      - build
-      - generate-matrix
-    uses: pytorch/test-infra/.github/workflows/_binary_upload.yml@main
-    if: always()
     with:
-      repository: $REPOSITORY
-      ref: $REF
-      test-infra-repository: $TEST_INFRA_REPOSITORY
-      test-infra-ref: $TEST_INFRA_REF
+      repository: pytorch/torchtune
+      ref: ""
+      pre-script: ""
+      post-script: ""
+      smoke-test-script: ""
+      package-name: torchtune
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      architecture: $ARCH
       trigger-event: ${{ github.event_name }}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-$REPOSITORY-${{ github.event_name == 'workflow_dispatch' }}
-  cancel-in-progress: true

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -63,14 +63,14 @@ jobs:
           repository: pytorch/test-infra
           ref: main
           path: test-infra
-      - uses: ./test-infra/.github/actions/set-channel
+      - uses: pytorch/test-infra/.github/actions/set-channel
       - name: Set PYTORCH_VERSION
         if: ${{ env.CHANNEL == 'test' }}
         run: |
           # When building RC, set the version to be the current candidate version,
           # otherwise, leave it alone so nightly will pick up the latest
           echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
-      - uses: ./test-infra/.github/actions/setup-binary-builds
+      - uses: pytorch/test-infra/.github/actions/setup-binary-builds
         env:
           PLATFORM: ${{ env.ARCH == 'aarch64'  && 'linux-aarch64' || ''}}
         with:
@@ -139,7 +139,7 @@ jobs:
 
   upload:
     needs: build
-    uses: ./.github/workflows/_binary_upload.yml
+    uses: pytorch/test-infra/.github/workflows/_binary_upload.yml
     if: always()
     with:
       repository: pytorch.torchtune

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       package-type: $PACKAGE_TYPE
       os: linux
-      test-infra-repository: ${{ env.TEST_INFRA_REPOSITORY }}
+      test-infra-repository: ${{ TEST_INFRA_REPOSITORY }}
       test-infra-ref: $TEST_INFRA_REF
       with-cuda: disable
       with-rocm: disable

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -136,17 +136,16 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.REPOSITORY }}/dist/
-
   upload:
     needs: build
     uses: pytorch/test-infra/.github/workflows/_binary_upload.yml@main
     if: always()
     with:
-      repository: pytorch.torchtune
+      repository: pytorch/torchtune
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ matrix.output.matrix }}
+      build-matrix: ${{ needs.build.needs.generate-matrix.outputs.matrix }}
       architecture: x86_64
       trigger-event: ${{ github.event_name }}
 

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,7 +31,7 @@ jobs:
       PACKAGE_TYPE: wheel
       REPOSITORY: pytorch/torchtune
       PACKAGE_NAME: torchtune
-      REF: ""
+      REF: pkg-for-wheel
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
       ARCH: x86_64

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
     with:
       repository: pytorch/torchtune
-      ref: pkg-for-wheel
+      ref: ""
       pre-script: ""
       post-script: ""
       smoke-test-script: ""

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,6 +33,8 @@ jobs:
       PACKAGE_NAME: torchtune
       PACKAGE_TYPE: wheel
       ARCH: x86_64
+    steps:
+      - run: echo "Exposing env vars"
   generate-matrix:
     needs:
       - setup-variables

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -63,14 +63,14 @@ jobs:
           repository: pytorch/test-infra
           ref: main
           path: test-infra
-      - uses: pytorch/test-infra/.github/actions/set-channel/action.yml@main
+      - uses: pytorch/test-infra/.github/actions/set-channel@main
       - name: Set PYTORCH_VERSION
         if: ${{ env.CHANNEL == 'test' }}
         run: |
           # When building RC, set the version to be the current candidate version,
           # otherwise, leave it alone so nightly will pick up the latest
           echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
-      - uses: pytorch/test-infra/.github/actions/setup-binary-builds/action.yml@main
+      - uses: pytorch/test-infra/.github/actions/setup-binary-builds@main
         env:
           PLATFORM: ${{ env.ARCH == 'aarch64'  && 'linux-aarch64' || ''}}
         with:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -3,6 +3,7 @@
 
 name: Build Linux Wheels
 
+
 on:
   pull_request:
   push:
@@ -16,32 +17,37 @@ on:
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
 
+
 permissions:
   id-token: write
   contents: read
 
-# Setup env variables used by all jobs
-env:
-  TEST_INFRA_REPOSITORY: pytorch/test-infra
-  TEST_INFRA_REF: main
-  REPOSITORY: pytorch/torchtune
-  REF: pkg-for-wheel
-  PACKAGE_NAME: torchtune
-  PACKAGE_TYPE: wheel
-  ARCH: x86_64
 
 jobs:
+  setup-variables:
+    outputs:
+      TEST_INFRA_REPOSITORY: pytorch/test-infra
+      TEST_INFRA_REF: main
+      REPOSITORY: pytorch/torchtune
+      REF: pkg-for-wheel
+      PACKAGE_NAME: torchtune
+      PACKAGE_TYPE: wheel
+      ARCH: x86_64
   generate-matrix:
+    needs:
+      - setup-variables
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: $PACKAGE_TYPE
       os: linux
-      test-infra-repository: ${{ env.TEST_INFRA_REPOSITORY }}
+      test-infra-repository: ${{ needs.setup-variables.outputs.TEST_INFRA_REPOSITORY }}
       test-infra-ref: $TEST_INFRA_REF
       with-cuda: disable
       with-rocm: disable
   build:
-    needs: generate-matrix
+    needs:
+      - setup-variables
+      - generate-matrix
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -150,6 +156,7 @@ jobs:
           path: $REPOSITORY/dist/
   upload:
     needs:
+      - setup-variables
       - build
       - generate-matrix
     uses: pytorch/test-infra/.github/workflows/_binary_upload.yml@main

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   setup-variables:
+    runs-on: ubuntu-latest
     outputs:
       TEST_INFRA_REPOSITORY: pytorch/test-infra
       TEST_INFRA_REF: main

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -137,7 +137,9 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.REPOSITORY }}/dist/
   upload:
-    needs: build
+    needs:
+      - build
+      - generate-matrix
     uses: pytorch/test-infra/.github/workflows/_binary_upload.yml@main
     if: always()
     with:
@@ -145,7 +147,7 @@ jobs:
       ref: pkg-for-wheel
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.build.needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       architecture: x86_64
       trigger-event: ${{ github.event_name }}
 

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       package-type: $PACKAGE_TYPE
       os: linux
-      test-infra-repository: ${TEST_INFRA_REPOSITORY}
+      test-infra-repository: ${{ env.TEST_INFRA_REPOSITORY }}
       test-infra-ref: $TEST_INFRA_REF
       with-cuda: disable
       with-rocm: disable

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -1,3 +1,6 @@
+# Heavy inspiration taken from:
+# https://github.com/pytorch/test-infra/blob/main/.github/workflows/build_wheels_linux.yml
+
 name: Build Linux Wheels
 
 on:
@@ -17,6 +20,7 @@ permissions:
   id-token: write
   contents: read
 
+# Setup env variables used by all jobs
 env:
   TEST_INFRA_REPOSITORY: pytorch/test-infra
   TEST_INFRA_REF: main
@@ -32,7 +36,7 @@ jobs:
     with:
       package-type: $PACKAGE_TYPE
       os: linux
-      test-infra-repository: $TEST_INFRA_REPOSITORY
+      test-infra-repository: ${TEST_INFRA_REPOSITORY}
       test-infra-ref: $TEST_INFRA_REF
       with-cuda: disable
       with-rocm: disable

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -1,0 +1,157 @@
+name: Custom Build Linux Wheels
+
+on:
+  pull_request:
+  push:
+    branches:
+      - pkg-for-wheel
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: disable
+      with-rocm: disable
+  build:
+    needs: generate-matrix
+    name: ${{ matrix.repository }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(matrix.outputs.matrix) }}
+    env:
+      PYTHON_VERSION: ${{ matrix.python_version }}
+      PACKAGE_TYPE: wheel
+      REPOSITORY: pytorch/torchtune
+      PACKAGE_NAME: torchtune
+      REF: ""
+      CU_VERSION: ${{ matrix.desired_cuda }}
+      UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
+      ARCH: x86_64
+
+    name: ${{ matrix.build_name }}
+    runs-on: ${{ matrix.validation_runner }}
+    container:
+      image: ${{ matrix.container_image }}
+      options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
+    # If a build is taking longer than 60 minutes on these runners we need
+    # to have a conversation
+    timeout-minutes: 120
+    steps:
+      - name: Clean workspace
+        shell: bash -l {0}
+        run: |
+          set -euxo pipefail
+          echo "::group::Cleanup debug output"
+          rm -rf "${GITHUB_WORKSPACE}"
+          mkdir -p "${GITHUB_WORKSPACE}"
+
+          if [[ "${{ env.ARCH }}" = "aarch64" ]]; then
+            rm -rf "${RUNNER_TEMP}/*"
+          fi
+
+          echo "::endgroup::"
+      - uses: actions/checkout@v3
+        with:
+          # Support the use case where we need to checkout someone's fork
+          repository: pytorch/test-infra
+          ref: main
+          path: test-infra
+      - uses: ./test-infra/.github/actions/set-channel
+      - name: Set PYTORCH_VERSION
+        if: ${{ env.CHANNEL == 'test' }}
+        run: |
+          # When building RC, set the version to be the current candidate version,
+          # otherwise, leave it alone so nightly will pick up the latest
+          echo "PYTORCH_VERSION=${{ matrix.stable_version }}" >> "${GITHUB_ENV}"
+      - uses: ./test-infra/.github/actions/setup-binary-builds
+        env:
+          PLATFORM: ${{ env.ARCH == 'aarch64'  && 'linux-aarch64' || ''}}
+        with:
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REF }}
+          setup-miniconda: true
+          python-version: ${{ env.PYTHON_VERSION }}
+          cuda-version: ${{ env.CU_VERSION }}
+          arch: ${{ env.ARCH }}
+      - name: Install torch dependency
+        run: |
+          set -euxo pipefail
+          # shellcheck disable=SC1090
+          source "${BUILD_ENV_FILE}"
+          # shellcheck disable=SC2086
+          ${CONDA_RUN} ${PIP_INSTALL_TORCH}
+      - name: Install python build dependency
+        run: |
+          set -euxo pipefail
+          # shellcheck disable=SC1090
+          source "${BUILD_ENV_FILE}"
+          # shellcheck disable=SC2086
+          ${CONDA_RUN} python -m pip install build
+      - name: Build the wheel (bdist_wheel)
+        working-directory: ${{ env.REPOSITORY }}
+        shell: bash -l {0}
+        run: |
+          set -euxo pipefail
+          source "${BUILD_ENV_FILE}"
+          export PYTORCH_VERSION="$(${CONDA_RUN} pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
+          ${CONDA_RUN} python -m build --wheel
+      - name: Smoke Test
+        shell: bash -l {0}
+        env:
+          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+          SMOKE_TEST_SCRIPT: ""
+        run: |
+          set -euxo pipefail
+          source "${BUILD_ENV_FILE}"
+          WHEEL_NAME=$(ls "${{ env.REPOSITORY }}/dist/")
+          echo "$WHEEL_NAME"
+
+          ${CONDA_RUN} pip install "${{ env.REPOSITORY }}/dist/$WHEEL_NAME"
+          # Checking that we have a pinned version of torch in our dependency tree
+          (
+            pushd "${RUNNER_TEMP}"
+            unzip -o "${GITHUB_WORKSPACE}/${{ env.REPOSITORY }}/dist/$WHEEL_NAME"
+            # Ensure that pytorch version is pinned, should output file where it was found
+            grep "Requires-Dist: torch (==.*)" -r .
+          )
+
+          if [[ (! -f "${{ env.REPOSITORY }}"/${SMOKE_TEST_SCRIPT}) ]]; then
+            echo "${{ env.REPOSITORY }}/${SMOKE_TEST_SCRIPT} not found"
+            ${CONDA_RUN} python -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
+          else
+            echo "${{ env.REPOSITORY }}/${SMOKE_TEST_SCRIPT} found"
+            ${CONDA_RUN} python "${{ env.REPOSITORY }}/${SMOKE_TEST_SCRIPT}"
+          fi
+      # NB: Only upload to GitHub after passing smoke tests
+      - name: Upload wheel to GitHub
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.REPOSITORY }}/dist/
+
+  upload:
+    needs: build
+    uses: ./.github/workflows/_binary_upload.yml
+    if: always()
+    with:
+      repository: pytorch.torchtune
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ matrix.output.matrix }}
+      architecture: x86_64
+      trigger-event: ${{ github.event_name }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-pytorch/torchtune-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,8 +34,9 @@ jobs:
       PACKAGE_NAME: torchtune
       PACKAGE_TYPE: wheel
       ARCH: x86_64
+      SMOKE_TEST_SCRIPT: ""
     steps:
-      - run: echo "Exposing env vars"
+      - run: echo "Exposing env vars to all jobs"
   generate-matrix:
     needs:
       - setup-variables
@@ -112,7 +113,7 @@ jobs:
           # shellcheck disable=SC2086
           ${CONDA_RUN} python -m pip install build
       - name: Build the wheel (bdist_wheel)
-        working-directory: ${{ env.REPOSITORY }}
+        working-directory: ${{ needs.setup-variables.outputs.REPOSITORY }}
         shell: bash -l {0}
         run: |
           set -euxo pipefail
@@ -122,8 +123,9 @@ jobs:
       - name: Smoke Test
         shell: bash -l {0}
         env:
-          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
-          SMOKE_TEST_SCRIPT: ""
+          REPOSITORY: ${{ needs.setup-variables.outputs.REPOSITORY }}
+          PACKAGE_NAME: ${{ needs.setup-variables.outputs.PACKAGE_NAME }}
+          SMOKE_TEST_SCRIPT: ${{ needs.setup-variables.outputs.SMOKE_TEST_SCRIPT }}
         run: |
           set -euxo pipefail
           source "${BUILD_ENV_FILE}"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -25,7 +25,7 @@ jobs:
     needs: generate-matrix
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     env:
       PYTHON_VERSION: ${{ matrix.python_version }}
       PACKAGE_TYPE: wheel

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
     with:
       repository: pytorch/torchtune
-      ref: ""
+      ref: pkg-for-wheel
       pre-script: ""
       post-script: ""
       smoke-test-script: ""

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -1,24 +1,39 @@
-name: Custom Build Linux Wheels
+name: Build Linux Wheels
 
 on:
   pull_request:
   push:
     branches:
-      - pkg-for-wheel
+      - nightly
+      - main
+      - release/*
+    tags:
+        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # Release candidate tags look like: v1.11.0-rc1
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
 
+env:
+  TEST_INFRA_REPOSITORY: pytorch/test-infra
+  TEST_INFRA_REF: main
+  REPOSITORY: pytorch/torchtune
+  REF: pkg-for-wheel
+  PACKAGE_NAME: torchtune
+  PACKAGE_TYPE: wheel
+  ARCH: x86_64
+
 jobs:
   generate-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
-      package-type: wheel
+      package-type: $PACKAGE_TYPE
       os: linux
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: $TEST_INFRA_REPOSITORY
+      test-infra-ref: $TEST_INFRA_REF
       with-cuda: disable
       with-rocm: disable
   build:
@@ -28,13 +43,8 @@ jobs:
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     env:
       PYTHON_VERSION: ${{ matrix.python_version }}
-      PACKAGE_TYPE: wheel
-      REPOSITORY: pytorch/torchtune
-      PACKAGE_NAME: torchtune
-      REF: pkg-for-wheel
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
-      ARCH: x86_64
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     container:
@@ -59,9 +69,8 @@ jobs:
           echo "::endgroup::"
       - uses: actions/checkout@v3
         with:
-          # Support the use case where we need to checkout someone's fork
-          repository: pytorch/test-infra
-          ref: main
+          repository: $TEST_INFRA_REPOSITORY
+          ref: $TEST_INFRA_REF
           path: test-infra
       - uses: pytorch/test-infra/.github/actions/set-channel@main
       - name: Set PYTORCH_VERSION
@@ -74,12 +83,12 @@ jobs:
         env:
           PLATFORM: ${{ env.ARCH == 'aarch64'  && 'linux-aarch64' || ''}}
         with:
-          repository: ${{ env.REPOSITORY }}
-          ref: ${{ env.REF }}
+          repository: $REPOSITORY
+          ref: $REF
           setup-miniconda: true
-          python-version: ${{ env.PYTHON_VERSION }}
-          cuda-version: ${{ env.CU_VERSION }}
-          arch: ${{ env.ARCH }}
+          python-version: $PYTHON_VERSION
+          cuda-version: $CU_VERSION
+          arch: $ARCH
       - name: Install torch dependency
         run: |
           set -euxo pipefail
@@ -113,29 +122,28 @@ jobs:
           WHEEL_NAME=$(ls "${{ env.REPOSITORY }}/dist/")
           echo "$WHEEL_NAME"
 
-          ${CONDA_RUN} pip install "${{ env.REPOSITORY }}/dist/$WHEEL_NAME"
+          ${CONDA_RUN} pip install "$REPOSITORY/dist/$WHEEL_NAME"
           # Checking that we have a pinned version of torch in our dependency tree
           (
             pushd "${RUNNER_TEMP}"
-            unzip -o "${GITHUB_WORKSPACE}/${{ env.REPOSITORY }}/dist/$WHEEL_NAME"
+            unzip -o "${GITHUB_WORKSPACE}/$REPOSITORY/dist/$WHEEL_NAME"
             # Ensure that pytorch version is pinned, should output file where it was found
             grep "Requires-Dist: torch (==.*)" -r .
           )
 
-          if [[ (! -f "${{ env.REPOSITORY }}"/${SMOKE_TEST_SCRIPT}) ]]; then
-            echo "${{ env.REPOSITORY }}/${SMOKE_TEST_SCRIPT} not found"
+          if [[ (! -f "$REPOSITORY/${SMOKE_TEST_SCRIPT}) ]]; then
+            echo "$REPOSITORY/${SMOKE_TEST_SCRIPT} not found"
             ${CONDA_RUN} python -c "import ${PACKAGE_NAME}; print('package version is ', ${PACKAGE_NAME}.__version__)"
           else
-            echo "${{ env.REPOSITORY }}/${SMOKE_TEST_SCRIPT} found"
-            ${CONDA_RUN} python "${{ env.REPOSITORY }}/${SMOKE_TEST_SCRIPT}"
+            echo "$REPOSITORY/${SMOKE_TEST_SCRIPT} found"
+            ${CONDA_RUN} python "$REPOSITORY/${SMOKE_TEST_SCRIPT}"
           fi
-      # NB: Only upload to GitHub after passing smoke tests
       - name: Upload wheel to GitHub
         continue-on-error: true
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.REPOSITORY }}/dist/
+          path: $REPOSITORY/dist/
   upload:
     needs:
       - build
@@ -143,14 +151,14 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/_binary_upload.yml@main
     if: always()
     with:
-      repository: pytorch/torchtune
-      ref: pkg-for-wheel
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      repository: $REPOSITORY
+      ref: $REF
+      test-infra-repository: $TEST_INFRA_REPOSITORY
+      test-infra-ref: $TEST_INFRA_REF
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      architecture: x86_64
+      architecture: $ARCH
       trigger-event: ${{ github.event_name }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-pytorch/torchtune-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-$REPOSITORY-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -23,7 +23,6 @@ jobs:
       with-rocm: disable
   build:
     needs: generate-matrix
-    name: ${{ matrix.repository }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(matrix.outputs.matrix) }}
@@ -36,7 +35,6 @@ jobs:
       CU_VERSION: ${{ matrix.desired_cuda }}
       UPLOAD_TO_BASE_BUCKET: ${{ matrix.upload_to_base_bucket }}
       ARCH: x86_64
-
     name: ${{ matrix.build_name }}
     runs-on: ${{ matrix.validation_runner }}
     container:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -41,10 +41,10 @@ jobs:
       - setup-variables
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
-      package-type: $PACKAGE_TYPE
+      package-type: ${{ needs.setup-variables.outputs.PACKAGE_TYPE }}
       os: linux
       test-infra-repository: ${{ needs.setup-variables.outputs.TEST_INFRA_REPOSITORY }}
-      test-infra-ref: $TEST_INFRA_REF
+      test-infra-ref: ${{ needs.setup-variables.outputs.TEST_INFRA_REF }}
       with-cuda: disable
       with-rocm: disable
   build:
@@ -74,16 +74,11 @@ jobs:
           echo "::group::Cleanup debug output"
           rm -rf "${GITHUB_WORKSPACE}"
           mkdir -p "${GITHUB_WORKSPACE}"
-
-          if [[ "${{ env.ARCH }}" = "aarch64" ]]; then
-            rm -rf "${RUNNER_TEMP}/*"
-          fi
-
           echo "::endgroup::"
       - uses: actions/checkout@v3
         with:
-          repository: $TEST_INFRA_REPOSITORY
-          ref: $TEST_INFRA_REF
+          repository: ${{ needs.setup-variables.outputs.TEST_INFRA_REPOSITORY }}
+          ref: ${{ needs.setup-variables.outputs.TEST_INFRA_REF }}
           path: test-infra
       - uses: pytorch/test-infra/.github/actions/set-channel@main
       - name: Set PYTORCH_VERSION
@@ -96,12 +91,12 @@ jobs:
         env:
           PLATFORM: ${{ env.ARCH == 'aarch64'  && 'linux-aarch64' || ''}}
         with:
-          repository: $REPOSITORY
-          ref: $REF
+          repository: ${{ needs.setup-variables.outputs.REPOSITORY }}
+          ref: ${{ needs.setup-variables.outputs.REF }}
           setup-miniconda: true
-          python-version: $PYTHON_VERSION
-          cuda-version: $CU_VERSION
-          arch: $ARCH
+          python-version: ${{ env.PYTHON_VERSION }}
+          cuda-version: ${{ env.CU_VERSION }}
+          arch: ${{ needs.setup-variables.outputs.ARCH }}
       - name: Install torch dependency
         run: |
           set -euxo pipefail

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 
 from setuptools import find_packages, setup
 
+# test
 
 def read_requirements(file):
     with open(file) as f:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@
 
 from setuptools import find_packages, setup
 
-# test
 
 def read_requirements(file):
     with open(file) as f:


### PR DESCRIPTION
This uses the NOVA workflows from test-infra to build a Linux wheel.

Currently, I've set the ref to `pkg-for-wheel` for testing. This will need to be changed back before merging.