### PR TITLE
Refactor model saving code and print size of the quantized model

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -150,7 +150,7 @@ checkpointer:
 # make sure to change the checkpointer component
 checkpointer:
   _component_: torchtune.utils.FullModelTorchTuneCheckpointer
-  checkpoint_files: [meta_model_0.4w.pt]
+  checkpoint_files: [meta_model_0-4w.pt]
 
 # Quantization Arguments
 quantizer:


### PR DESCRIPTION
Summary:
att

Test Plan:
$ tune run quantize --config quantize

2024-04-08:09:22:09,938 INFO     [_parse.py:52] Running main with parameters {'model': {'_component_': 'torchtune.models.llama2.llama2_7b'}, 'checkpointer': {'_component_': 'torchtune.utils.FullModelMetaCheckpointe
r', 'checkpoint_dir': '/tmp/llama2/', 'checkpoint_files': ['meta_model_0.pt'], 'output_dir': '/tmp/llama2/', 'model_type': 'LLAMA2'}, 'device': 'cuda', 'dtype': 'bf16', 'seed': 1234, 'quantizer': {'_component_': 't
orchtune.utils.quantization.Int4WeightOnlyQuantizer', 'groupsize': 256}}
2024-04-08:09:22:10,339 DEBUG    [seed.py:59] Setting manual seed to local seed 1234. Local seed is seed + rank = 1234 + 0
2024-04-08:09:22:10,677 INFO     [quantize.py:60] Model is initialized with precision torch.bfloat16.
linear: layers.0.attn.q_proj, in=4096, out=4096
linear: layers.0.attn.k_proj, in=4096, out=4096
linear: layers.0.attn.v_proj, in=4096, out=4096
...
linear: output, in=4096, out=32000
2024-04-08:09:22:42,318 INFO     [quantize.py:68] Time for quantization: 31.64 sec
2024-04-08:09:22:42,319 INFO     [quantize.py:69] Memory used: 13.95 GB
output dir: /tmp/llama2 meta_model_0 4w <class 'str'>
2024-04-08:09:22:51,136 INFO     [quantize.py:83] Model checkpoint of size 3.67 GB saved to /tmp/llama2/meta_model_0-4w.pt

Reviewers:

Subscribers:

Tasks:

Tags:

#### Context
- ...

#### Changelog
- ...

#### Test plan
- ....
