### PR TITLE
[ez] remove unused test checkpoint path

### DIFF
--- a/tests/cache_artifacts.sh
+++ b/tests/cache_artifacts.sh
@@ -13,7 +13,6 @@
 # In all cases, if the files already exist locally they will not be downloaded from S3.
 
 SMALL_MODEL_URLS=(
-    "s3://pytorch-multimodal/small-ckpt-01242024"
     "s3://pytorch-multimodal/small-ckpt-tune-03082024.pt"
     "s3://pytorch-multimodal/small-ckpt-meta-03082024.pt"
     "s3://pytorch-multimodal/small-ckpt-hf-03082024.pt"


### PR DESCRIPTION
One less thing to download on integration tests

(after running `rm -r /tmp/test-artifacts`)
```
pytest tests -m integration_test
...
========== 15 passed, 195 deselected, 4 warnings in 179.29s (0:02:59) ====
```

CI should be green too