### PR TITLE
Try package with updated version

### DIFF
--- a/torchtune/__init__.py
+++ b/torchtune/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = "0.0.1"
+__version__ = "0.0.1dev"
 
 from torchtune import datasets, models, modules, utils
 


### PR DESCRIPTION
`pip install` via the PyTorch index seems to be caching the wrong version. I am testing if a new version solves this issue.