### PR TITLE
remove extra dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "pytest-mock",
     "pytest-integration",
     "tensorboard",
-    "transformers",
     "wandb",
 ]
 


### PR DESCRIPTION
This was only explicitly used in some random comparison script which was removed in #537