### PR TITLE
drop 3.8 and 3.9 distributed tests from every PR

### DIFF
--- a/.github/workflows/recipe_test_multi_gpu.yaml
+++ b/.github/workflows/recipe_test_multi_gpu.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: linux.8xlarge.nvidia.gpu
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
         torch-version: ["nightly", "stable"]
     steps:
       - name: Check out repo

--- a/.github/workflows/recipe_test_multi_gpu.yaml
+++ b/.github/workflows/recipe_test_multi_gpu.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: linux.8xlarge.nvidia.gpu
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11']
         torch-version: ["nightly", "stable"]
     steps:
       - name: Check out repo


### PR DESCRIPTION
Our queue times for GPU runners are long. We doubled the number of distributed CI jobs that run on every PR yesterday. This gets us back to the original number, but keeps us testing on both nightly and stable versions of PyTorch