### PR TITLE
Enable CUDA binaries

### DIFF
--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -25,7 +25,7 @@ jobs:
       os: linux
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      with-cuda: disable
+      with-cuda: enable
       with-rocm: disable
       build-python-only: enable
   build:


### PR DESCRIPTION
Although TorchTune has no GPU specific code that needs to be compiled for a specific GPU Architecture, we do need nightly builds to pull the correct PyTorch Architecture. This means we need to enable CUDA binaries.