### PR TITLE
[Easy] Update supported finetune methods section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The library currently supports the following models and fine-tuning methods.
 
 | Model                                         | Sizes     |   Finetuning Methods |
 |-----------------------------------------------|-----------|-----------------------------------------------------------|
-| [Llama2](torchtune/models/llama2/_model_builders.py)   | 7B        | Full Finetuning [[single device low memory](recipes/configs/llama2/7B_full_low_memory.yaml),  [distributed](recipes/configs/llama2/7B_full.yaml)] LoRA [[single device](recipes/configs/llama2/7B_lora_single_device.yaml),  [distributed](recipes/configs/llama2/7B_lora.yaml)] QLoRA [single device](recipes/configs/llama2/7B_qlora_single_device.yaml) |
+| [Llama2](torchtune/models/llama2/_model_builders.py)   | 7B        | Full Finetuning [[single device low memory](recipes/configs/llama2/7B_full_low_memory.yaml),  [distributed](recipes/configs/llama2/7B_full.yaml)] LoRA [[single device](recipes/configs/llama2/7B_lora_single_device.yaml),  [distributed](recipes/configs/llama2/7B_lora.yaml)] QLoRA [[single device](recipes/configs/llama2/7B_qlora_single_device.yaml)] |
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 13B       | [Full Finetuning](recipes/configs/llama2/13B_full.yaml), [LoRA](recipes/configs/llama2/13B_lora.yaml)
-| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | Full Finetuning [[single device low memory](recipes/configs/mistral/7B_full_low_memory.yaml), [distributed](recipes/configs/mistral/7B_full.yaml)] LoRA [[single device](recipes/configs/mistral/7B_lora_single_device.yaml), [distributed](recipes/configs/mistral/7B_lora.yaml)] QLoRA [single device](recipes/configs/mistral/7B_qlora_single_device.yaml)
+| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | Full Finetuning [[single device low memory](recipes/configs/mistral/7B_full_low_memory.yaml), [distributed](recipes/configs/mistral/7B_full.yaml)] LoRA [[single device](recipes/configs/mistral/7B_lora_single_device.yaml), [distributed](recipes/configs/mistral/7B_lora.yaml)] [QLoRA [single device](recipes/configs/mistral/7B_qlora_single_device.yaml)]
 
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The library currently supports the following models and fine-tuning methods.
 |-----------------------------------------------|-----------|-----------------------------------------------------------|
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 7B        | Full Finetuning [[single device low memory](recipes/configs/llama2/7B_full_low_memory.yaml),  [distributed](recipes/configs/llama2/7B_full.yaml)] LoRA [[single device](recipes/configs/llama2/7B_lora_single_device.yaml),  [distributed](recipes/configs/llama2/7B_lora.yaml)] QLoRA [[single device](recipes/configs/llama2/7B_qlora_single_device.yaml)] |
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 13B       | [Full Finetuning](recipes/configs/llama2/13B_full.yaml), [LoRA](recipes/configs/llama2/13B_lora.yaml)
-| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | Full Finetuning [[single device low memory](recipes/configs/mistral/7B_full_low_memory.yaml), [distributed](recipes/configs/mistral/7B_full.yaml)] LoRA [[single device](recipes/configs/mistral/7B_lora_single_device.yaml), [distributed](recipes/configs/mistral/7B_lora.yaml)] QLoRA [[single device](recipes/configs/mistral/7B_qlora_single_device.yaml)]
+| [Mistral](torchtune/models/mistral/_model_builders.py)   | 7B       | Full Finetuning [[single device low memory](recipes/configs/mistral/7B_full_low_memory.yaml), [distributed](recipes/configs/mistral/7B_full.yaml)] LoRA [[single device](recipes/configs/mistral/7B_lora_single_device.yaml), [distributed](recipes/configs/mistral/7B_lora.yaml)] QLoRA [[single device](recipes/configs/mistral/7B_qlora_single_device.yaml)]
+| [Gemma](torchtune/models/gemma/_model_builders.py)   | 2B        | [Full Finetuning](recipes/configs/gemma/2B_full.yaml)
 
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The library currently supports the following models and fine-tuning methods.
 
 | Model                                         | Sizes     |   Finetuning Methods |
 |-----------------------------------------------|-----------|-----------------------------------------------------------|
-| [Llama2](torchtune/models/llama2/_model_builders.py)   | 7B        | Full Finetuning [[single device](recipes/configs/llama2/7B_full_single_device.yaml),  [distributed](recipes/configs/llama2/7B_full.yaml)] LoRA [[single device](recipes/configs/llama2/7B_lora_single_device.yaml),  [distributed](recipes/configs/llama2/7B_lora.yaml)] QLoRA [single device](recipes/configs/llama2/7B_qlora_single_device.yaml) |
+| [Llama2](torchtune/models/llama2/_model_builders.py)   | 7B        | Full Finetuning [[single device low memory](recipes/configs/llama2/7B_full_low_memory.yaml),  [distributed](recipes/configs/llama2/7B_full.yaml)] LoRA [[single device](recipes/configs/llama2/7B_lora_single_device.yaml),  [distributed](recipes/configs/llama2/7B_lora.yaml)] QLoRA [single device](recipes/configs/llama2/7B_qlora_single_device.yaml) |
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 13B       | [Full Finetuning](recipes/configs/llama2/13B_full.yaml), [LoRA](recipes/configs/llama2/13B_lora.yaml)
-| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | [Full Finetuning](recipes/configs/mistral/7B_full.yaml), [LoRA](recipes/configs/mistral/7B_lora.yaml)
+| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | Full Finetuning [[single device low memory](recipes/configs/mistral/7B_full_low_memory.yaml), [distributed](recipes/configs/mistral/7B_full.yaml)] LoRA [[single device](recipes/configs/mistral/7B_lora_single_device.yaml), [distributed](recipes/configs/mistral/7B_lora.yaml)] QLoRA [single device](recipes/configs/mistral/7B_qlora_single_device.yaml)
 
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The library currently supports the following models and fine-tuning methods.
 |-----------------------------------------------|-----------|-----------------------------------------------------------|
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 7B        | Full Finetuning [[single device low memory](recipes/configs/llama2/7B_full_low_memory.yaml),  [distributed](recipes/configs/llama2/7B_full.yaml)] LoRA [[single device](recipes/configs/llama2/7B_lora_single_device.yaml),  [distributed](recipes/configs/llama2/7B_lora.yaml)] QLoRA [[single device](recipes/configs/llama2/7B_qlora_single_device.yaml)] |
 | [Llama2](torchtune/models/llama2/_model_builders.py)   | 13B       | [Full Finetuning](recipes/configs/llama2/13B_full.yaml), [LoRA](recipes/configs/llama2/13B_lora.yaml)
-| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | Full Finetuning [[single device low memory](recipes/configs/mistral/7B_full_low_memory.yaml), [distributed](recipes/configs/mistral/7B_full.yaml)] LoRA [[single device](recipes/configs/mistral/7B_lora_single_device.yaml), [distributed](recipes/configs/mistral/7B_lora.yaml)] [QLoRA [single device](recipes/configs/mistral/7B_qlora_single_device.yaml)]
+| [Mistral](torchtune/models/mistral//_model_builders.py)   | 7B       | Full Finetuning [[single device low memory](recipes/configs/mistral/7B_full_low_memory.yaml), [distributed](recipes/configs/mistral/7B_full.yaml)] LoRA [[single device](recipes/configs/mistral/7B_lora_single_device.yaml), [distributed](recipes/configs/mistral/7B_lora.yaml)] QLoRA [[single device](recipes/configs/mistral/7B_qlora_single_device.yaml)]
 
 
 &nbsp;


### PR DESCRIPTION
#### Context
- Update the supported finetune methods section to reflect the latest changes on 
  - more supported methods for mistral 
  - llama2 7B full finetune single device -> llama2 7B full finetune low memory 
  - support for gemma 2B model

#### Changelog
- update readme supported finetune methods section

#### Test plan
![Screenshot 2024-04-11 at 11 52 02 PM](https://github.com/pytorch/torchtune/assets/29116689/62a6c86c-5be0-4705-8e3c-9654f4b79173)


