### PR TITLE
[Easy] Fix mistral LoRA single device and QLoRA config

### DIFF
--- a/recipes/configs/mistral/7B_lora_single_device.yaml
+++ b/recipes/configs/mistral/7B_lora_single_device.yaml
@@ -73,6 +73,7 @@ batch_size: 4
 epochs: 3
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1
+compile: False
 
 # Training env
 device: cuda

--- a/recipes/configs/mistral/7B_qlora_single_device.yaml
+++ b/recipes/configs/mistral/7B_qlora_single_device.yaml
@@ -74,6 +74,7 @@ batch_size: 4
 epochs: 3
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1
+compile: False
 
 # Training env
 device: cuda


### PR DESCRIPTION
#### Context
- mistral LoRA single device config and QLoRA config miss essential config key 'compile' and break training

#### Changelog
- add compile key to mistral LoRA single device config and QLoRA config

#### Test plan
- tune run lora_finetune_single_device --config mistral/7B_lora_single_device
- tune run lora_finetune_single_device --config mistral/7B_qlora_single_device 
