### PR TITLE
[QoL] Keep launch commands in config to one line

### DIFF
--- a/recipes/configs/eleuther_eval.yaml
+++ b/recipes/configs/eleuther_eval.yaml
@@ -1,7 +1,7 @@
 # Config for EleutherEvalRecipe in eleuther_eval.py
 #
 # To launch, run the following command from root torchtune directory:
-#    tune eleuther_eval --config llama2_eleuther_eval tasks=["truthfulqa_mc2", "hellaswag"]
+#    tune run eleuther_eval --config llama2_eleuther_eval tasks=["truthfulqa_mc2", "hellaswag"]
 
 # Model Arguments
 model:

--- a/recipes/configs/gemma/2B_full.yaml
+++ b/recipes/configs/gemma/2B_full.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/gemma2
+#   tune download google/gemma-2b --hf-token <HF_TOKEN> --output-dir /tmp/gemma2
 #
 # To launch on 4 devices, run the following command from root:
-#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
-#   --config gemma/2B_full \
+#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma/2B_full
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
-#   --config gemma/2B_full \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma/2B_full checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only when the model is being fine-tuned on 2+ GPUs.
 

--- a/recipes/configs/generate.yaml
+++ b/recipes/configs/generate.yaml
@@ -1,3 +1,7 @@
+# Config for running the InferenceRecipe in generate.py to generate output from an LLM
+#
+# To launch, run the following command from root torchtune directory:
+#    tune run generate --config generate
 
 # Model arguments
 model:

--- a/recipes/configs/llama2/13B_full.yaml
+++ b/recipes/configs/llama2/13B_full.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-2-13b-hf \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2-13b-hf
+#   tune download meta-llama/Llama-2-13b-hf --hf-token <HF_TOKEN> --output-dir /tmp/llama2-13b-hf
 #
 # To launch on 4 devices, run the following command from root:
-#   tune run --nproc_per_node 4 full_finetune_distributed \
-#   --config llama2/13B_full \
+#   tune run --nproc_per_node 4 full_finetune_distributed --config llama2/13B_full
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
-#   --config llama2/13B_full \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config llama2/13B_full checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config should be used with 2+ GPUs. Single device full fine-tuning
 # requires several memory optimizations which are exposed through

--- a/recipes/configs/llama2/13B_lora.yaml
+++ b/recipes/configs/llama2/13B_lora.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-2-13b-hf \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2-13b-hf
+#   tune download meta-llama/Llama-2-13b-hf --hf-token <HF_TOKEN> --output-dir /tmp/llama2-13b-hf
 #
 # To launch on 4 devices, run the following command from root:
-#   tune run --nproc_per_node 4 lora_finetune_distributed \
-#   --config llama2/13B_lora \
+#   tune run --nproc_per_node 4 lora_finetune_distributed --config llama2/13B_lora \
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed \
-#   --config llama2/13B_lora \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config llama2/13B_lora checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works best when the model is being fine-tuned on 2+ GPUs.
 # For single device LoRA finetuning please use 7B_lora_single_device.yaml

--- a/recipes/configs/llama2/7B_full.yaml
+++ b/recipes/configs/llama2/7B_full.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-2-7b \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2
+#   tune download meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir /tmp/llama2
 #
 # To launch on 4 devices, run the following command from root:
-#   tune run --nproc_per_node 4 full_finetune_distributed \
-#   --config llama2/7B_full \
+#   tune run --nproc_per_node 4 full_finetune_distributed --config llama2/7B_full
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
-#   --config llama2/7B_full \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config llama2/7B_full checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works best when the model is being fine-tuned on 2+ GPUs.
 # Single device full finetuning requires more memory optimizations. It's

--- a/recipes/configs/llama2/7B_full_low_memory.yaml
+++ b/recipes/configs/llama2/7B_full_low_memory.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-2-7b \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2
+#   tune download meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune run full_finetune_single_device \
-#   --config llama2/7B_full_low_memory \
+#   tune run full_finetune_single_device --config llama2/7B_full_low_memory
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run full_finetune_single_device \
-#   --config llama2/7B_full_low_memory \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run full_finetune_single_device --config llama2/7B_full_low_memory checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 

--- a/recipes/configs/llama2/7B_lora.yaml
+++ b/recipes/configs/llama2/7B_lora.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-2-7b \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2
+#   tune download meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir /tmp/llama2
 #
 # To launch on 4 devices, run the following command from root:
-#   tune run --nproc_per_node 4 lora_finetune_distributed \
-#   --config llama2/7B_lora \
+#   tune run --nproc_per_node 4 lora_finetune_distributed --config llama2/7B_lora
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed \
-#   --config llama2/7B_lora \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config llama2/7B_lora checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works best when the model is being fine-tuned on 2+ GPUs.
 # For single device LoRA finetuning please use 7B_lora_single_device.yaml

--- a/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download --repo-id meta-llama/Llama-2-7b \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2
+#   tune download --repo-id meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune run lora_dpo_single_device \
-#   --config llama2/7B_lora_dpo_single_device \
+#   tune run lora_dpo_single_device --config llama2/7B_lora_dpo_single_device
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune --nnodes 1 --nproc_per_node 1 lora_dpo_single_device \
-#   --config 7B_lora_dpo_single_device \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune --nnodes 1 --nproc_per_node 1 lora_dpo_single_device --config 7B_lora_dpo_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 

--- a/recipes/configs/llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_single_device.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-2-7b \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2
+#   tune download meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune run lora_finetune_single_device \
-#   --config llama2/7B_lora_single_device \
+#   tune run lora_finetune_single_device --config llama2/7B_lora_single_device
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 1 lora_finetune_single_device \
-#   --config 7B_lora_single_device \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 1 lora_finetune_single_device --config 7B_lora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 

--- a/recipes/configs/llama2/7B_qlora_single_device.yaml
+++ b/recipes/configs/llama2/7B_qlora_single_device.yaml
@@ -3,20 +3,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-2-7b \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/llama2
+#   tune download meta-llama/Llama-2-7b --hf-token <HF_TOKEN> --output-dir /tmp/llama2
 #
 # To launch on a single device, run the following command from root:
-#   tune run lora_finetune_single_device \
-#   --config llama2\7B_qlora_single_device \
+#   tune run lora_finetune_single_device --config llama2\7B_qlora_single_device
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 1 lora_finetune_single_device \
-#   --config 7B_qlora_single_device \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 1 lora_finetune_single_device --config 7B_qlora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 

--- a/recipes/configs/mistral/7B_full.yaml
+++ b/recipes/configs/mistral/7B_full.yaml
@@ -7,19 +7,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download mistralai/Mistral-7B-v0.1 \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/Mistral-7B-v0.1
+#   tune download mistralai/Mistral-7B-v0.1 --hf-token <HF_TOKEN> --output-dir /tmp/Mistral-7B-v0.1
 #
 # Run this config on 4 GPUs using the following:
-# tune run --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full
+#   tune run --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed \
-#   --config mistral/7B_full \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works best when the model is being fine-tuned on 2+ GPUs.
 # Single device full finetuning requires more memory optimizations. It's

--- a/recipes/configs/mistral/7B_full_low_memory.yaml
+++ b/recipes/configs/mistral/7B_full_low_memory.yaml
@@ -7,20 +7,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download mistralai/Mistral-7B-v0.1 \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/Mistral-7B-v0.1
+#   tune download mistralai/Mistral-7B-v0.1 --hf-token <HF_TOKEN> --output-dir /tmp/Mistral-7B-v0.1
 #
 # To launch on a single device, run the following command from root:
-#   tune run full_finetune_single_device \
-#   --config mistral/7B_full_low_memory \
+#   tune run full_finetune_single_device --config mistral/7B_full_low_memory
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run full_finetune_single_device \
-#   --config mistral/7B_full_low_memory \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run full_finetune_single_device --config mistral/7B_full_low_memory checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -7,19 +7,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download mistralai/Mistral-7B-v0.1 \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/Mistral-7B-v0.1
+#   tune download mistralai/Mistral-7B-v0.1 --hf-token <HF_TOKEN> --output-dir /tmp/Mistral-7B-v0.1
 #
 # Run this config on 4 GPUs using the following:
-# tune run --nproc_per_node 4 lora_finetune_distributed --config mistral/7B_lora
+#   tune run --nproc_per_node 4 lora_finetune_distributed --config mistral/7B_lora
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed \
-#   --config mistral/7B_lora \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config mistral/7B_lora checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works best when the model is being fine-tuned on 2+ GPUs.
 # For single device LoRA finetuning please use 7B_lora_single_device.yaml

--- a/recipes/configs/mistral/7B_lora_single_device.yaml
+++ b/recipes/configs/mistral/7B_lora_single_device.yaml
@@ -7,20 +7,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download mistralai/Mistral-7B-v0.1 \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/Mistral-7B-v0.1
+#   tune download mistralai/Mistral-7B-v0.1 --hf-token <HF_TOKEN> --output-dir /tmp/Mistral-7B-v0.1
 #
 # To launch on a single device, run the following command from root:
-#   tune run lora_finetune_single_device \
-#   --config mistral/7B_lora_single_device \
+#   tune run lora_finetune_single_device --config mistral/7B_lora_single_device
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run lora_finetune_single_device \
-#   --config mistral/7B_lora_single_device \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run lora_finetune_single_device --config mistral/7B_lora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 

--- a/recipes/configs/mistral/7B_qlora_single_device.yaml
+++ b/recipes/configs/mistral/7B_qlora_single_device.yaml
@@ -7,20 +7,15 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download mistralai/Mistral-7B-v0.1 \
-#   --hf-token <HF_TOKEN> \
-#   --output-dir /tmp/Mistral-7B-v0.1
+#   tune download mistralai/Mistral-7B-v0.1 --hf-token <HF_TOKEN> --output-dir /tmp/Mistral-7B-v0.1
 #
 # To launch on a single device, run the following command from root:
-#   tune run lora_finetune_single_device \
-#   --config mistral/7B_qlora_single_device \
+#   tune run lora_finetune_single_device --config mistral/7B_qlora_single_device
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run lora_finetune_single_device \
-#   --config mistral/7B_qlora_single_device \
-#   checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run lora_finetune_single_device --config mistral/7B_qlora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 

--- a/recipes/configs/quantize.yaml
+++ b/recipes/configs/quantize.yaml
@@ -1,7 +1,7 @@
 # Config for QuantizationRecipe in quantize.py
 #
 # To launch, run the following command from root torchtune directory:
-#    tune quantize --config quantize
+#    tune run quantize --config quantize
 #
 # Supported quantization modes are:
 #      8w:


### PR DESCRIPTION
The launch commands in the configs are broken up into multiple lines - unfortunately since they are comments, I can't copy-paste them and run on command-line without having to manually delete all the comment #'s. So this PR puts them all in one line so it's easy to copy. I don't think the slightly longer line is offensive enough to offset the value of quickly copy-pasting the command.

## Test plan
eyes
