### PR TITLE
Update script to upload model to HF (from #698)

### DIFF
--- a/torchtune/_cli/hf_upload/upload.py
+++ b/torchtune/_cli/hf_upload/upload.py
@@ -7,9 +7,8 @@
 import argparse
 import os
 from typing import Any, List
-import warnings
 
-from huggingface_hub import HfApi, CommitOperationAdd
+from huggingface_hub import CommitOperationAdd, HfApi
 
 
 def add_files_to_repo(
@@ -67,12 +66,15 @@ def upload_to_hf_hub(args: Any):
     api.create_commit(
         repo_id=repo_url.repo_id,
         operations=[
-            CommitOperationAdd(path_in_repo=os.path.basename(file_path), path_or_fileobj=file_path)
+            CommitOperationAdd(
+                path_in_repo=os.path.basename(file_path), path_or_fileobj=file_path
+            )
             for file_path in [args.model_path, args.readme_path, args.license_path]
             if file_path and os.path.exists(file_path)
         ],
-        commit_message="Initial commit with model, README, and License"
+        commit_message="Initial commit with model, README, and License",
     )
+
 
 if __name__ == "__main__":
     # Create argument parser
@@ -94,7 +96,11 @@ if __name__ == "__main__":
         "--readme_path", type=str, required=False, help="Path to the README file."
     )
     parser.add_argument(
-        "--hf_token", type=str, required=False, help="Hugging Face API token."
+        "--hf_token",
+        type=str,
+        required=False,
+        help="Hugging Face API token.",
+        default=os.getenv("HF_TOKEN", None),
     )
     parser.add_argument(
         "--license_path",


### PR DESCRIPTION
> The logic to upload a model to the Hugging Face Hub is ideal. It is not necessary (and even less robust) to create a local git repo to push your changes (see why https://huggingface.co/docs/huggingface_hub/concepts/git_vs_http).  We have an upload guide https://huggingface.co/docs/huggingface_hub/guides/upload as well if interested. This PR simplifies the logic to make it up to date with the latest changes in `huggingface_hub`. Also worth mentioning that a `huggingface-cli upload` command also exists to upload any file/folder to the Hub. The logic is pretty similar to the one here but more robust/more maintained. I let you decide what you prefer! Disclaimer: I'm working at HF as a maintainer of the `huggingface_hub` library. Feel free to ping me anytime :)

#### Context
- ...

#### Changelog
- ...

#### Test plan
- ....
