### PR TITLE
Add log_config on rank 0 utility

### DIFF
--- a/recipes/configs/eleuther_evaluation.yaml
+++ b/recipes/configs/eleuther_evaluation.yaml
@@ -1,7 +1,7 @@
 # Config for EleutherEvalRecipe in eleuther_eval.py
 #
 # To launch, run the following command from root torchtune directory:
-#    tune run eleuther_eval --config llama2_eleuther_eval tasks=["truthfulqa_mc2", "hellaswag"]
+#    tune run eleuther_eval --config eleuther_evaluation tasks=["truthfulqa_mc2","hellaswag"]
 
 # Model Arguments
 model:

--- a/recipes/configs/generation.yaml
+++ b/recipes/configs/generation.yaml
@@ -1,7 +1,7 @@
 # Config for running the InferenceRecipe in generate.py to generate output from an LLM
 #
 # To launch, run the following command from root torchtune directory:
-#    tune run generate --config generate
+#    tune run generate --config generation
 
 # Model arguments
 model:

--- a/recipes/configs/quantization.yaml
+++ b/recipes/configs/quantization.yaml
@@ -1,7 +1,7 @@
 # Config for QuantizationRecipe in quantize.py
 #
 # To launch, run the following command from root torchtune directory:
-#    tune run quantize --config quantize
+#    tune run quantize --config quantization
 
 #
 # Model arguments

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -200,6 +200,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
 @config.parse
 def recipe_main(cfg: DictConfig) -> None:
     """Entry point for the recipe."""
+    config.log_config(recipe_name="EleutherEvalRecipe", cfg=cfg)
     recipe = EleutherEvalRecipe(cfg=cfg)
     recipe.setup()
     recipe.evaluate()

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -504,6 +504,8 @@ def recipe_main(cfg: DictConfig) -> None:
 
     init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
 
+    config.log_config(recipe_name="FullFinetuneRecipeDistributed", cfg=cfg)
+
     recipe = FullFinetuneRecipeDistributed(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.train()

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -460,6 +460,7 @@ def recipe_main(cfg: DictConfig) -> None:
         - Parameters specified in config (see available configs through ``tune ls``)
         - Overwritten by arguments from the command-line
     """
+    config.log_config(recipe_name="FullFinetuneRecipeSingleDevice", cfg=cfg)
     recipe = FullFinetuneRecipeSingleDevice(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.train()

--- a/recipes/gemma_full_finetune_distributed.py
+++ b/recipes/gemma_full_finetune_distributed.py
@@ -487,6 +487,8 @@ def recipe_main(cfg: DictConfig) -> None:
 
     init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
 
+    config.log_config(recipe_name="FullFinetuneRecipeDistributed", cfg=cfg)
+
     recipe = FullFinetuneRecipeDistributed(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.train()

--- a/recipes/generate.py
+++ b/recipes/generate.py
@@ -134,6 +134,7 @@ class InferenceRecipe:
 
 @config.parse
 def main(cfg: DictConfig) -> None:
+    config.log_config(recipe_name="InferenceRecipe", cfg=cfg)
     recipe = InferenceRecipe(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.generate(cfg=cfg)

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -510,6 +510,7 @@ def recipe_main(cfg: DictConfig) -> None:
         - Parameters specified in config (see available configs through ``tune ls``)
         - Overwritten by arguments from the command-line
     """
+    config.log_config(recipe_name="LoRADPORecipeSingleDevice", cfg=cfg)
     recipe = LoRADPORecipeSingleDevice(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.train()

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -601,6 +601,8 @@ def recipe_main(cfg: DictConfig) -> None:
 
     init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
 
+    config.log_config(recipe_name="LoRAFinetuneRecipeDistributed", cfg=cfg)
+
     recipe = LoRAFinetuneRecipeDistributed(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.train()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -494,6 +494,7 @@ def recipe_main(cfg: DictConfig) -> None:
         - Parameters specified in config (see available configs through ``tune ls``)
         - Overwritten by arguments from the command-line
     """
+    config.log_config(recipe_name="LoRAFinetuneRecipeSingleDevice", cfg=cfg)
     recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.train()

--- a/recipes/quantize.py
+++ b/recipes/quantize.py
@@ -110,6 +110,7 @@ class QuantizationRecipe:
 
 @config.parse
 def main(cfg: DictConfig) -> None:
+    config.log_config(recipe_name="QuantizationRecipe", cfg=cfg)
     recipe = QuantizationRecipe(cfg=cfg)
     recipe.setup(cfg=cfg)
     recipe.quantize(cfg=cfg)

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -150,6 +150,7 @@ class TestUtils:
         # Create a logger and add a StreamHandler to it so we can patch the
         # config logger and assert on logged strings
         logger = logging.getLogger(__name__)
+        logger.setLevel("DEBUG")
         stream = StringIO()
         handler = logging.StreamHandler(stream)
         logger.addHandler(handler)

--- a/torchtune/config/__init__.py
+++ b/torchtune/config/__init__.py
@@ -6,10 +6,12 @@
 
 from ._instantiate import instantiate
 from ._parse import parse
+from ._utils import log_config
 from ._validate import validate
 
 __all__ = [
     "parse",
     "instantiate",
     "validate",
+    "log_config",
 ]

--- a/torchtune/config/_parse.py
+++ b/torchtune/config/_parse.py
@@ -11,7 +11,6 @@ from typing import Any, Callable
 from omegaconf import DictConfig
 from torchtune.config._utils import _merge_yaml_and_cli_args
 from torchtune.utils.argparse import TuneRecipeArgumentParser
-from torchtune.utils.logging import get_logger
 
 
 Recipe = Callable[[DictConfig], Any]
@@ -47,9 +46,6 @@ def parse(recipe_main: Recipe) -> Callable[[Recipe], Any]:
         # Get user-specified args from config and CLI and create params for recipe
         yaml_args, cli_args = parser.parse_known_args()
         conf = _merge_yaml_and_cli_args(yaml_args, cli_args)
-
-        logger = get_logger("DEBUG")
-        logger.info(msg=f"Running {recipe_main.__name__} with parameters {conf}")
 
         sys.exit(recipe_main(conf))
 

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -30,7 +30,8 @@ def log_config(recipe_name: str, cfg: DictConfig) -> None:
         return
 
     logger = get_logger("DEBUG")
-    logger.info(msg=f"Running {recipe_name} with parameters {cfg}")
+    cfg_str = OmegaConf.to_yaml(cfg, resolve=True, sort_keys=True)
+    logger.info(msg=f"Running {recipe_name} with resolved config:\n\n{cfg_str}")
 
 
 def _has_component(node: Union[Dict[str, Any], DictConfig]) -> bool:

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -13,6 +13,24 @@ from omegaconf import DictConfig, OmegaConf
 
 from torchtune.config._errors import InstantiationError
 from torchtune.data import ChatFormat, InstructTemplate
+from torchtune.utils import get_logger, get_world_size_and_rank
+
+
+def log_config(recipe_name: str, cfg: DictConfig) -> None:
+    """
+    Logs the parsed config to rank zero.
+
+    Args:
+        recipe_name (str): name of the recipe to display
+        cfg (DictConfig): parsed config object
+    """
+    # Log the config only on rank 0
+    _, rank = get_world_size_and_rank()
+    if rank != 0:
+        return
+
+    logger = get_logger("DEBUG")
+    logger.info(msg=f"Running {recipe_name} with parameters {cfg}")
 
 
 def _has_component(node: Union[Dict[str, Any], DictConfig]) -> bool:


### PR DESCRIPTION
## Context
Add a utility to log the config on rank 0 that any recipe can use. Update all recipes to use this.

## Test plan
Ran all recipes to confirm the log only appears once.

```
2024-04-14:14:29:36,160 INFO     [_utils.py:34] Running FullFinetuneRecipeDistributed with resolved config:

batch_size: 2
checkpointer:
  _component_: torchtune.utils.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Llama-2-7b-hf
  checkpoint_files:
  - pytorch_model-00001-of-00002.bin
  - pytorch_model-00002-of-00002.bin
  model_type: LLAMA2
  output_dir: /tmp/Llama-2-7b-hf
  recipe_checkpoint: null
dataset:
  _component_: torchtune.datasets.alpaca_dataset
  train_on_input: true
device: cuda
dtype: bf16
enable_activation_checkpointing: true
epochs: 3
gradient_accumulation_steps: 1
log_every_n_steps: null
loss:
  _component_: torch.nn.CrossEntropyLoss
max_steps_per_epoch: null
metric_logger:
  _component_: torchtune.utils.metric_logging.DiskLogger
  log_dir: /tmp/alpaca-llama2-finetune
model:
  _component_: torchtune.models.llama2.llama2_7b
optimizer:
  _component_: torch.optim.AdamW
  lr: 2.0e-05
output_dir: /tmp/alpaca-llama2-finetune
resume_from_checkpoint: false
seed: null
shuffle: true
tokenizer:
  _component_: torchtune.models.llama2.llama2_tokenizer
  path: /tmp/Llama-2-7b-hf/tokenizer.model
```
