### PR TITLE
Speed up model loading for generate

### DIFF
--- a/torchtune/modules/kv_cache.py
+++ b/torchtune/modules/kv_cache.py
@@ -34,6 +34,7 @@ class KVCache(nn.Module):
     ) -> None:
         super().__init__()
         cache_shape = (max_batch_size, num_heads, max_seq_len, head_dim)
+        self.dtype = dtype
         self.register_buffer(
             "k_cache", torch.zeros(cache_shape, dtype=dtype), persistent=False
         )
@@ -41,6 +42,11 @@ class KVCache(nn.Module):
             "v_cache", torch.zeros(cache_shape, dtype=dtype), persistent=False
         )
         self.max_batch_size = max_batch_size
+
+    # Used when using meta device initialization
+    def reset_non_persistent_buffers(self):
+        self.k_cache = torch.zeros(self.k_cache.size(), dtype=self.dtype)
+        self.v_cache = torch.zeros(self.v_cache.size(), dtype=self.dtype)
 
     def update(self, input_pos, k_val, v_val) -> Tuple[Tensor, Tensor]:
         # input_pos: [S], k_val: [B, H, S, D]

--- a/torchtune/modules/position_embeddings.py
+++ b/torchtune/modules/position_embeddings.py
@@ -49,6 +49,10 @@ class RotaryPositionalEmbeddings(nn.Module):
     def reset_parameters(self):
         self._rope_init()
 
+    # Used when using meta device initialization
+    def reset_non_persistent_buffers(self):
+        self._rope_init()
+
     def _rope_init(self):
         theta = 1.0 / (
             self.base


### PR DESCRIPTION
**This has not been extensively tested  (only mistral 7b) and more of a proposal!**

This change does the follow:
- Create the model on the meta device
- Load the state dict with assign=True which preserve the properties of the checkpoint (mmap-ed cpu Tensor in this case)
- Initialize non-persistent buffers remaining on the meta device
- Move the finalized model to the requested device/dtype

This makes the model loading almost instant on my machine.