### PR TITLE
Update curl command in cache_artifacts

### DIFF
--- a/tests/cache_artifacts.sh
+++ b/tests/cache_artifacts.sh
@@ -84,7 +84,7 @@ for S3_URL in "${S3_URLS[@]}"; do
             fi
         # For https: download with curl
         else
-            cp_cmd="curl -O --output-dir ${LOCAL_DIR} ${S3_URL}"
+            cp_cmd="curl --output ${LOCAL_DIR}/${FILE_NAME} ${S3_URL}"
         fi
         bash -c "${cp_cmd}"
         # Check if download was successful


### PR DESCRIPTION
## Context
Using `--output-dir` with curl is only supported for `7.73.0` and above, which doesn't ship with all Linux distros (see https://stackoverflow.com/a/63843412). Use `--output` which is more widely supported.

## Test plan
`pytest tests -m integration_test`
