### PR TITLE
Make docs of utility APIs consistent with  how we use / expose them in recipes

### DIFF
--- a/docs/source/api_ref_utilities.rst
+++ b/docs/source/api_ref_utilities.rst
@@ -45,10 +45,8 @@ Utilities for working in a reduced precision setting.
     :toctree: generated/
     :nosignatures:
 
-    precision.get_autocast
-    precision.get_gradient_scaler
-    precision.get_dtype
-    precision.list_dtypes
+    get_dtype
+    list_dtypes
 
 .. _ac_label:
 
@@ -61,7 +59,7 @@ Utilities to reduce memory consumption during training.
     :toctree: generated/
     :nosignatures:
 
-    memory.set_activation_checkpointing
+    set_activation_checkpointing
 
 .. _metric_logging_label:
 
@@ -88,7 +86,7 @@ Utilities for working with data and datasets.
     :toctree: generated/
     :nosignatures:
 
-    collate.padded_collate
+    padded_collate
 
 .. _gen_label:
 
@@ -100,7 +98,7 @@ Miscellaneous
     :toctree: generated/
     :nosignatures:
 
-    argparse.TuneRecipeArgumentParser
-    logging.get_logger
+    TuneRecipeArgumentParser
+    get_logger
     get_device
-    seed.set_seed
+    set_seed


### PR DESCRIPTION
#### Context
- In recipes, we generally choose to do `utils.get_precision` instead of `utils.precision.get_precision`, and `utils.set_activation_checkpointing` instead of `utils.memory.set_activation_checkpointing`. Our docs were inconsistent in how we referred to these APIs, this PR attempts to fix that.
- We keep metric logging as `metric_logging.WandBLogger` (for example) as we don't use this directly in recipe and this is how they're exposed in configs, and they're not piped through in `utils/__init__.py`.
- Also removed documentation for `get_autocast` and gradient scaler APIs. We don't use these in recipes today and don't support mixed precision or fp16 training in torchtune today. Can easily add these back if we do eventually support it, but IMO currently it creates noise as we don't support these training techniques and it could just cause confusion. Open to keeping it in though.

#### Changelog
- ...

#### Test plan
- ....
