### PR TITLE
Clean up usages of max_batch_size throughout some docstrings

### DIFF
--- a/tests/recipes/utils.py
+++ b/tests/recipes/utils.py
@@ -7,7 +7,7 @@
 import json
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import torch
 from torch.utils.data import Dataset
@@ -55,7 +55,7 @@ def dummy_alpaca_dataset_config():
     return out
 
 
-def llama2_test_config(max_batch_size: Optional[int] = None) -> List[str]:
+def llama2_test_config() -> List[str]:
     return [
         "model._component_=torchtune.models.llama2.llama2",
         "model.vocab_size=32_000",
@@ -74,7 +74,6 @@ def lora_llama2_test_config(
     apply_lora_to_output: bool = False,
     lora_rank: int = 8,
     lora_alpha: float = 16,
-    max_batch_size: Optional[int] = None,
     quantize_base: bool = False,
 ) -> List[str]:
     lora_attn_modules_str = "['" + "','".join([x for x in lora_attn_modules]) + "']"

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -117,10 +117,9 @@ def _merge_yaml_and_cli_args(yaml_args: Namespace, cli_args: List[str]) -> DictC
     cli args, respectively) and merges them into a single OmegaConf DictConfig.
 
     If a cli arg overrides a yaml arg with a _component_ field, the cli arg can
-    be specified with the parent field directly, i.e.,
-    model=torchtune.models.llama2_7b instead of model._component_=torchtune.models.llama2_7b.
-    Nested fields within the component should be specified with dot notation, i.e.,
-    model.max_batch_size=2.
+    be specified with the parent field directly, e.g., model=torchtune.models.lora_llama2_7b
+    instead of model._component_=torchtune.models.lora_llama2_7b. Nested fields within the
+    component should be specified with dot notation, e.g., model.lora_rank=16.
 
     Example:
         >>> config.yaml:

--- a/torchtune/models/llama2/_model_builders.py
+++ b/torchtune/models/llama2/_model_builders.py
@@ -24,9 +24,6 @@ def llama2_7b() -> TransformerDecoder:
     Builder for creating a Llama2 model initialized w/ the default 7b parameter values
     from https://arxiv.org/abs/2307.09288
 
-    Args:
-        max_batch_size (Optional[int]): Maximum batch size to be passed to KVCache.
-
     Returns:
         TransformerDecoder: Instantiation of Llama2 7B model
     """
@@ -75,7 +72,6 @@ def lora_llama2_7b(
             Default: False
         lora_rank (int): rank of each low-rank approximation
         lora_alpha (float): scaling factor for the low-rank approximation
-        max_batch_size (Optional[int]): Maximum batch size to be passed to KVCache.
         quantize_base (bool): Whether to quantize base model weights
 
     Returns:
@@ -112,9 +108,6 @@ def llama2_13b() -> TransformerDecoder:
     """
     Builder for creating a Llama2 model initialized w/ the default 13b parameter values
     from https://arxiv.org/abs/2307.09288
-
-    Args:
-        max_batch_size (Optional[int]): Maximum batch size to be passed to KVCache.
 
     Returns:
         TransformerDecoder: Instantiation of Llama2 13B model
@@ -157,7 +150,6 @@ def lora_llama2_13b(
             Default: False
         lora_rank (int): rank of each low-rank approximation
         lora_alpha (float): scaling factor for the low-rank approximation
-        max_batch_size (Optional[int]): Maximum batch size to be passed to KVCache.
         quantize_base (bool): Whether to quantize base model weights
 
     Returns:

--- a/torchtune/models/mistral/_model_builders.py
+++ b/torchtune/models/mistral/_model_builders.py
@@ -68,7 +68,6 @@ def lora_mistral_7b(
             Default: False
         lora_rank (int): rank of each low-rank approximation
         lora_alpha (float): scaling factor for the low-rank approximation
-        max_batch_size (Optional[int]): Maximum batch size to be passed to KVCache.
         quantize_base (bool): Whether to quantize base model weights
 
     Returns:


### PR DESCRIPTION
Cleaning up some lingering instances of this as it's now not used by our model builders
