### PR TITLE
Generalize dataset builders as families

### DIFF
--- a/recipes/configs/llama2/13B_lora.yaml
+++ b/recipes/configs/llama2/13B_lora.yaml
@@ -45,7 +45,7 @@ resume_from_checkpoint: False
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.llama2.llama2_tokenizer
-  path: /tmp/llama2/tokenizer.model
+  path: /tmp/llama2-13b-hf/tokenizer.model
 
 # Dataset and Sampler
 dataset:

--- a/torchtune/data/_instruct_templates.py
+++ b/torchtune/data/_instruct_templates.py
@@ -39,7 +39,7 @@ class InstructTemplate(ABC):
 
 class AlpacaInstructTemplate(InstructTemplate):
     """
-    Prompt template for the Alpaca dataset. Template prompt changes slightly depending
+    Prompt template for Alpaca-style datasets. Template prompt changes slightly depending
     on if there's an instruction + input or just an instruction.
     """
 
@@ -89,7 +89,7 @@ class AlpacaInstructTemplate(InstructTemplate):
 
 class GrammarErrorCorrectionTemplate(InstructTemplate):
     """
-    Prompt template for the Grammar dataset.
+    Prompt template for grammar correction datasets.
     """
 
     template = "Correct this to standard English: {sentence}\n---\nCorrected: "
@@ -149,7 +149,7 @@ class SummarizeTemplate(InstructTemplate):
 
 class StackExchangedPairedTemplate(InstructTemplate):
     """
-    Prompt template for the StackExchangedPaired dataset.
+    Prompt template for preference datasets similar to StackExchanged paired.
     """
 
     template = "Question: {question}\n\nAnswer: "

--- a/torchtune/datasets/_alpaca.py
+++ b/torchtune/datasets/_alpaca.py
@@ -35,10 +35,8 @@ def alpaca_dataset(
         source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is True.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
-            Default is 512, as set by `Stanford Alpaca
-            <https://github.com/tatsu-lab/stanford_alpaca?tab=readme-ov-file#fine-tuning>`_,
-            but we recommend setting this to the highest you can fit in memory and is supported by the model.
-            For example, llama2-7B supports up to 4096 for sequence length.
+            Default is 512, but we recommend setting this to the highest you can fit in memory and
+            is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
 
     Returns:
         InstructDataset: dataset configured with source data and template

--- a/torchtune/datasets/_alpaca.py
+++ b/torchtune/datasets/_alpaca.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import partial
+
 from torchtune.data import AlpacaInstructTemplate
 from torchtune.datasets._instruct import InstructDataset
 from torchtune.modules import Tokenizer
@@ -11,36 +13,35 @@ from torchtune.modules import Tokenizer
 
 def alpaca_dataset(
     tokenizer: Tokenizer,
+    source: str = "tatsu-lab/alpaca",
     train_on_input: bool = True,
     max_seq_len: int = 512,
 ) -> InstructDataset:
     """
-    Support for the Alpaca dataset from Hugging Face Datasets.
-    https://huggingface.co/datasets/tatsu-lab/alpaca
-
-    Data input format: https://huggingface.co/datasets/tatsu-lab/alpaca#data-instances
-
-    The input is created using the prompt template from the original alpaca codebase:
-    https://github.com/tatsu-lab/stanford_alpaca/blob/761dc5bfbdeeffa89b8bff5d038781a4055f796a/train.py#L31
-
-    where `instruction`, `input`, and `output` are fields from the dataset.
+    Support for family of Alpaca-style datasets from Hugging Face Datasets using
+    the `data input format <https://huggingface.co/datasets/tatsu-lab/alpaca#data-instances>`_
+    and `prompt template <https://github.com/tatsu-lab/stanford_alpaca/blob/main/train.py#L31>`_
+    from the original alpaca codebase, where `instruction`, `input`, and `output`
+    are fields from the dataset.
 
     Masking of the prompt during training is controlled by the `train_on_input` flag, which is
-    set to `True` by default (ref: https://github.com/tloen/alpaca-lora/blob/main/finetune.py#L49)
+    set to `True` by `default <https://github.com/tloen/alpaca-lora/blob/main/finetune.py#L49>`_
     - If `train_on_input` is True, the prompt is used during training and
     contributes to the loss.
     - If `train_on_input` is False, the prompt is masked out (tokens replaced with -100)
 
     Args:
         tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
+        source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is True.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
-            Default is 512, as set by Stanford Alpaca (https://github.com/tatsu-lab/stanford_alpaca?tab=readme-ov-file#fine-tuning),
+            Default is 512, as set by `Stanford Alpaca
+            <https://github.com/tatsu-lab/stanford_alpaca?tab=readme-ov-file#fine-tuning>`_,
             but we recommend setting this to the highest you can fit in memory and is supported by the model.
             For example, llama2-7B supports up to 4096 for sequence length.
 
     Returns:
-        InstructDataset: dataset configured with Alpaca source data and template
+        InstructDataset: dataset configured with source data and template
 
 
     Example:
@@ -52,7 +53,7 @@ def alpaca_dataset(
 
     return InstructDataset(
         tokenizer=tokenizer,
-        source="tatsu-lab/alpaca",
+        source=source,
         template=AlpacaInstructTemplate,
         train_on_input=train_on_input,
         max_seq_len=max_seq_len,
@@ -60,56 +61,4 @@ def alpaca_dataset(
     )
 
 
-def alpaca_cleaned_dataset(
-    tokenizer: Tokenizer,
-    train_on_input: bool = True,
-    max_seq_len: int = 512,
-) -> InstructDataset:
-    """
-    Support for the Alpaca cleaned dataset from Hugging Face Datasets.
-    https://huggingface.co/datasets/yahma/alpaca-cleaned
-
-    Data input format: https://huggingface.co/datasets/tatsu-lab/alpaca#data-instances
-
-    The input is created using the prompt template from the original alpaca codebase:
-    https://github.com/tatsu-lab/stanford_alpaca/blob/761dc5bfbdeeffa89b8bff5d038781a4055f796a/train.py#L31
-
-    where `instruction`, `input`, and `output` are fields from the dataset.
-
-    Masking of the prompt during training is controlled by the `train_on_input` flag, which is
-    set to `True` by default (ref: https://github.com/tloen/alpaca-lora/blob/main/finetune.py#L49)
-    - If `train_on_input` is True, the prompt is used during training and
-    contributes to the loss.
-    - If `train_on_input` is False, the prompt is masked out (tokens replaced with -100)
-
-    This is the cleaned version of the original Alpaca dataset, which removes hallucinations,
-    poorly formed instructions/inputs/outputs, wrong answers, and other errors. See more details
-    on the Hugging Face dataset card.
-
-    Args:
-        tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
-        train_on_input (bool): Whether the model is trained on the prompt or not. Default is True.
-        max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
-            Default is 512, as set by Stanford Alpaca (https://github.com/tatsu-lab/stanford_alpaca?tab=readme-ov-file#fine-tuning),
-            but we recommend setting this to the highest you can fit in memory and is supported by the model.
-            For example, llama2-7B supports up to 4096 for sequence length.
-
-    Returns:
-        InstructDataset: dataset configured with Alpaca source data and template
-
-
-    Example:
-        >>> alpaca_ds = alpaca_dataset(tokenizer=tokenizer)
-        >>> for batch in Dataloader(alpaca_ds, batch_size=8):
-        >>>     print(f"Batch size: {len(batch)}")
-        >>> Batch size: 8
-    """
-
-    return InstructDataset(
-        tokenizer=tokenizer,
-        source="yahma/alpaca-cleaned",
-        template=AlpacaInstructTemplate,
-        train_on_input=train_on_input,
-        max_seq_len=max_seq_len,
-        split="train",
-    )
+alpaca_cleaned_dataset = partial(alpaca_dataset, source="yahma/alpaca-cleaned")

--- a/torchtune/datasets/_grammar.py
+++ b/torchtune/datasets/_grammar.py
@@ -11,16 +11,15 @@ from torchtune.modules import Tokenizer
 
 def grammar_dataset(
     tokenizer: Tokenizer,
+    source: str = "liweili/c4_200m",
     train_on_input: bool = False,
 ) -> InstructDataset:
     """
-    Support for the Grammar dataset and its variants from Hugging Face Datasets.
-    https://huggingface.co/datasets/liweili/c4_200m
+    Support for grammar correction datasets and their variants from Hugging Face Datasets.
+    Here is an `example <https://huggingface.co/datasets/liweili/c4_200m>`_ of a grammar correction dataset.
 
-    Data input format: https://huggingface.co/datasets/liweili/c4_200m#description
-
-    The prompt template is created from llama_recipes codebase:
-    https://github.com/meta-llama/llama-recipes/blob/main/src/llama_recipes/datasets/grammar_dataset/grammar_dataset.py#L50
+    The prompt template mirrors what is used in the `llama_recipes codebase
+    <https://github.com/meta-llama/llama-recipes/blob/main/src/llama_recipes/datasets/grammar_dataset/grammar_dataset.py#L50>`_
 
     where `input` and `output` are fields from the dataset.
 
@@ -32,10 +31,11 @@ def grammar_dataset(
 
     Args:
         tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
+        source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
 
     Returns:
-        InstructDataset: dataset configured with Grammar source data and template
+        InstructDataset: dataset configured with source data and template
 
 
     Example:
@@ -47,7 +47,7 @@ def grammar_dataset(
 
     return InstructDataset(
         tokenizer=tokenizer,
-        source="liweili/c4_200m",
+        source=source,
         template=GrammarErrorCorrectionTemplate,
         column_map={"sentence": "input"},
         train_on_input=train_on_input,

--- a/torchtune/datasets/_samsum.py
+++ b/torchtune/datasets/_samsum.py
@@ -11,16 +11,15 @@ from torchtune.modules import Tokenizer
 
 def samsum_dataset(
     tokenizer: Tokenizer,
+    source: str = "samsum",
     train_on_input: bool = False,
 ) -> InstructDataset:
     """
-    Support for the Summarize dataset and its variants from Hugging Face Datasets.
-    https://huggingface.co/datasets/samsum
+    Support for summarization datasets and their variants from Hugging Face Datasets.
+    An example is the `SAMsum dataset <https://huggingface.co/datasets/samsum>`_.
 
-    Data input format: https://huggingface.co/datasets/samsum#data-fields
-
-    The prompt template is created from llama_recipes codebase:
-    https://github.com/meta-llama/llama-recipes/blob/main/src/llama_recipes/datasets/samsum_dataset.py#L13
+    The prompt template mirrors what is used in the llama_recipes `codebase
+    <https://github.com/meta-llama/llama-recipes/blob/main/src/llama_recipes/datasets/samsum_dataset.py#L13>`_
 
     where `dialogue` and `summary` are fields from the dataset.
 
@@ -32,10 +31,11 @@ def samsum_dataset(
 
     Args:
         tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
+        source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
 
     Returns:
-        InstructDataset: dataset configured with Summarization source data and template
+        InstructDataset: dataset configured with source data and template
 
 
     Example:
@@ -47,7 +47,7 @@ def samsum_dataset(
 
     return InstructDataset(
         tokenizer=tokenizer,
-        source="samsum",
+        source=source,
         template=SummarizeTemplate,
         column_map={"output": "summary"},
         train_on_input=train_on_input,

--- a/torchtune/datasets/_slimorca.py
+++ b/torchtune/datasets/_slimorca.py
@@ -12,12 +12,14 @@ from torchtune.modules import Tokenizer
 
 
 def slimorca_dataset(
-    tokenizer: Tokenizer, max_seq_len: int = 1024, train_on_input: bool = False
+    tokenizer: Tokenizer,
+    source: str = "Open-Orca/SlimOrca-Dedup",
+    max_seq_len: int = 1024,
+    train_on_input: bool = False,
 ) -> ChatDataset:
     """
-    PyTorch Representation of the SlimOrca Dataset
-    https://huggingface.co/datasets/Open-Orca/SlimOrca-Dedup
-    from Hugging Face.
+    Support for `SlimOrca-style <https://huggingface.co/datasets/Open-Orca/SlimOrca-Dedup>`_
+    family of conversational datasets.
 
     The data is formatted to adhere to Llama2 Chat Format.
     This format is required if the base model is Llama2 Chat Model.
@@ -28,10 +30,9 @@ def slimorca_dataset(
     input token id list is ensured (by truncation if necessary) to be within
     that length.
 
-    Data input format: https://huggingface.co/datasets/Open-Orca/SlimOrca-Dedup#dataset-format
-
     Args:
         tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
+        source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
             This value needs to be at least 4 though it is generally set to max sequence length accepted by the model.
             Default is 1024.
@@ -60,7 +61,7 @@ def slimorca_dataset(
 
     return ChatDataset(
         tokenizer=tokenizer,
-        source="Open-Orca/SlimOrca-Dedup",
+        source=source,
         convert_to_messages=sharegpt_to_llama2_messages,
         chat_format=Llama2ChatFormat,
         max_seq_len=max_seq_len,

--- a/torchtune/datasets/_stack_exchanged_paired.py
+++ b/torchtune/datasets/_stack_exchanged_paired.py
@@ -11,22 +11,25 @@ from torchtune.modules import Tokenizer
 
 def stack_exchanged_paired_dataset(
     tokenizer: Tokenizer,
+    source: str = "lvwerra/stack-exchange-paired",
     max_seq_len: int = 1024,
 ) -> PreferenceDataset:
     """
-    Build a preference dataset from StackExchange paired data.
+    Family of preference datasets similar to `StackExchange paired data
+    <https://huggingface.co/datasets/lvwerra/stack-exchange-paired>`_.
 
     Args:
         tokenizer (Tokenizer): Tokenizer used to encode data.
+        source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
-            Default is 2048.
+            Default is 1024.
 
     Returns:
-        PreferenceDataset: The preference dataset built from StackExchange paired data.
+        PreferenceDataset: The preference datßaset built from source paired data.
     """
     return PreferenceDataset(
         tokenizer=tokenizer,
-        source="lvwerra/stack-exchange-paired",
+        source=source,
         template=StackExchangedPairedTemplate(),
         column_map={
             "prompt": "question",

--- a/torchtune/datasets/_stack_exchanged_paired.py
+++ b/torchtune/datasets/_stack_exchanged_paired.py
@@ -15,7 +15,7 @@ def stack_exchanged_paired_dataset(
     max_seq_len: int = 1024,
 ) -> PreferenceDataset:
     """
-    Family of preference datasets similar to `StackExchange paired data
+    Family of preference datasets similar to `StackExchangePaired data
     <https://huggingface.co/datasets/lvwerra/stack-exchange-paired>`_.
 
     Args:
@@ -25,7 +25,7 @@ def stack_exchanged_paired_dataset(
             Default is 1024.
 
     Returns:
-        PreferenceDataset: The preference datßaset built from source paired data.
+        PreferenceDataset: The preference dataset built from source paired data.
     """
     return PreferenceDataset(
         tokenizer=tokenizer,


### PR DESCRIPTION
## Context
By moving `source` to a parameter in the builder, we can genrealize dataset builders as "families" (i.e., alpaca family datasets, etc). Also update docstrings.

## Test plan
CI

<img width="862" alt="image" src="https://github.com/pytorch/torchtune/assets/33648637/00a07ee2-7ba2-4d26-93cd-44af28bfea0e">

