### PR TITLE
13B: Decrease batch size to avoid OOM and enable training

### DIFF
--- a/recipes/configs/llama2/13B_lora.yaml
+++ b/recipes/configs/llama2/13B_lora.yaml
@@ -53,7 +53,7 @@ dataset:
   train_on_input: True
 seed: null
 shuffle: True
-batch_size: 32
+batch_size: 2
 
 # Optimizer and Scheduler
 optimizer:


### PR DESCRIPTION
#### Context
- batch_size 32 results in very large activations and OOM for 13B model w/FSDP on 4 GPUs. With a batch size of 2, training is very slow but at least we're able to train with a decreasing loss and about 22ish G of RAM across 4 GPUs.

#### Changelog
- ...

#### Test plan
- ....
