### PR TITLE
[Generation] Remove compile time log

### DIFF
--- a/recipes/generate.py
+++ b/recipes/generate.py
@@ -91,12 +91,9 @@ class InferenceRecipe:
         # to get the accurate performance measurement
         if self._quantization_mode is not None:
             logger.info("Starting compilation to improve generation performance ...")
-            t0 = time.perf_counter()
             custom_generate_next_token = torch.compile(
                 utils.generate_next_token, mode="max-autotune", fullgraph=True
             )
-            t = time.perf_counter() - t0
-            logger.info(f"Compilation for generate_next_token takes: {t:.02f} sec")
             t0 = time.perf_counter()
             _ = utils.generate(
                 model=self._model,


### PR DESCRIPTION
#### Context
- Timing torch.compile overhead via the time it takes to wrap in compile is generally not the most accurate, as the main overhead of torch.compile comes in the first forward pass when the eager mode model is actually compiled.
- As a result, taking this log out, as we already report the warm up time which does a good job at capturing the true compile time overhead.
- For example, here are logs of currently reported compile time and warm up time. Actual compilation is happening within the warm up time:

```
2024-04-15:15:36:59,231 INFO     [generate.py:99] Compilation for generate_next_token takes: 2.45 sec
2024-04-15:15:37:50,256 INFO     [generate.py:111] Warmup run for quantized model takes: 51.02 sec
```

#### Changelog
- ...

#### Test plan
- ....
