### PR TITLE
Some extra W&B improvements

### DIFF
--- a/tests/torchtune/utils/test_metric_logging.py
+++ b/tests/torchtune/utils/test_metric_logging.py
@@ -10,6 +10,7 @@ from io import StringIO
 from typing import cast
 from unittest.mock import patch
 
+from omegaconf import OmegaConf
 from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 
 from tests.test_utils import assert_expected, captured_output
@@ -145,3 +146,20 @@ class WandBLoggerTest:
             logger.close()
 
             mock_log.assert_called_with(metric_dict, step=1)
+
+    def test_save_config(self) -> None:
+        with patch("wandb.init") as mock_init, patch(
+            "wandb.run", create=True
+        ) as mock_run, patch("OmegaConf.save") as mock_save, patch(
+            "wandb.save"
+        ) as mock_wandb_save:
+
+            logger = WandBLogger(project="test_project")
+            cfg = OmegaConf.create({"a": 1, "b": 2})
+
+            with patch.object(logger, "_wandb", mock_run):
+                logger.save_config(cfg)
+
+            expected_config_path = "torchtune_config.yaml"
+            mock_save.assert_called_once_with(cfg, expected_config_path)
+            mock_wandb_save.assert_called_once_with(expected_config_path)

--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -183,16 +183,15 @@ class WandBLogger(MetricLoggerInterface):
 
         _, self.rank = get_world_size_and_rank()
 
-        if self._wandb.run is None:
+        if self._wandb.run is None and self.rank == 0:
             # we check if wandb.init got called externally,
-            if self.rank == 0:
-                run = self._wandb.init(
-                    project=project,
-                    entity=entity,
-                    group=group,
-                    dir=self.log_dir,
-                    **kwargs,
-                )
+            run = self._wandb.init(
+                project=project,
+                entity=entity,
+                group=group,
+                dir=self.log_dir,
+                **kwargs,
+            )
 
         # define default x-axis (for latest wandb versions)
         if getattr(self._wandb, "define_metric", None):

--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -193,6 +193,9 @@ class WandBLogger(MetricLoggerInterface):
                 **kwargs,
             )
 
+        if self._wandb.run:
+            self._wandb.run._label(repo="torchtune")
+
         # define default x-axis (for latest wandb versions)
         if getattr(self._wandb, "define_metric", None):
             self._wandb.define_metric("total_training_steps")
@@ -210,7 +213,6 @@ class WandBLogger(MetricLoggerInterface):
             config (DictConfig): config to log
         """
         if self._wandb.run:
-            self._wandb.run._label(repo="torchtune")
             resolved = OmegaConf.to_container(config, resolve=True)
             self._wandb.config.update(resolved)
             try:

--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -194,6 +194,13 @@ class WandBLogger(MetricLoggerInterface):
                     **kwargs,
                 )
 
+        # define default x-axis (for latest wandb versions)
+        if getattr(self._wandb, "define_metric", None):
+            self._wandb.define_metric("total_training_steps")
+            self._wandb.define_metric(
+                "*", step_metric="total_training_steps", step_sync=True
+            )
+
     def log_config(self, config: DictConfig) -> None:
         """Saves the config locally and also logs the config to W&B. The config is
         stored in the same directory as the checkpoint. You can
@@ -229,11 +236,11 @@ class WandBLogger(MetricLoggerInterface):
 
     def log(self, name: str, data: Scalar, step: int) -> None:
         if self._wandb.run:
-            self._wandb.log({name: data}, step=step)
+            self._wandb.log({name: data, "total_training_steps": step})
 
     def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         if self._wandb.run:
-            self._wandb.log(payload, step=step)
+            self._wandb.log({**payload, "total_training_steps": step})
 
     def __del__(self) -> None:
         if self._wandb.run:


### PR DESCRIPTION
- Overwrite the resolved config so we don't end up with a checkpoints folder full of configs
- Check if a run is active, use that run instead of creating a new one
- Create a unified X-axis following the `total_training_steps`
