### PR TITLE
Add missing attributions in docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ We also want to acknowledge some awesome libraries and tools from the ecosystem:
 - [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) for bringing several memory and performance based techniques to the PyTorch ecosystem
 - [@winglian](https://github.com/winglian/) and [axolotl](https://github.com/OpenAccess-AI-Collective/axolotl) for early feedback and brainstorming on torchtune's design and feature set.
 - [lit-gpt](https://github.com/Lightning-AI/litgpt) for pushing the LLM fine-tuning community forward.
-- [Hugging Face TRL](https://github.com/huggingface/trl) for awesome training utilities for aligning transformer-based models.
+- [HF TRL](https://github.com/huggingface/trl) for making reward modeling more accessible to the PyTorch community.
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ We also want to acknowledge some awesome libraries and tools from the ecosystem:
 - [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) for bringing several memory and performance based techniques to the PyTorch ecosystem
 - [@winglian](https://github.com/winglian/) and [axolotl](https://github.com/OpenAccess-AI-Collective/axolotl) for early feedback and brainstorming on torchtune's design and feature set.
 - [lit-gpt](https://github.com/Lightning-AI/litgpt) for pushing the LLM fine-tuning community forward.
+- [Hugging Face TRL](https://github.com/huggingface/trl) for awesome training utilities for aligning transformer-based models.
 
 &nbsp;
 

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -34,7 +34,7 @@ log = utils.get_logger("DEBUG")
 class LoRADPORecipeSingleDevice(FTRecipeInterface):
     """
     LoRA DPO recipe for dense transformer-based LLMs such as Llama2 for
-    single device training. This is largely inspired by HF's DPOTrainer in the
+    single device training. This is based on HF's DPOTrainer in the
     TRL library: https://github.com/huggingface/trl/blob/main/trl/trainer/dpo_trainer.py#L65
 
     This recipe supports:
@@ -375,8 +375,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
-        Largely inspired by the implementation in HF's TRL library:
-        https://github.com/huggingface/trl/blob/5d1deb1445828cfd0e947cb3a7925b1c03a283fc/trl/trainer/dpo_trainer.py#L961
+        Run forward pass of the model with chosen and rejected samples concatenated.
 
         Args:
             model (nn.Module): The model to be used for the forward pass.
@@ -411,8 +410,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         label_pad_token_id: int = CROSS_ENTROPY_IGNORE_IDX,
     ) -> torch.FloatTensor:
         """
-        Largely inspired by the implementation in HF's TRL library:
-        https://github.com/huggingface/trl/blob/5d1deb1445828cfd0e947cb3a7925b1c03a283fc/trl/trainer/dpo_trainer.py#L924
+        Calculate log probabilities based on provided logits and labels.
 
         Args:
             logits (torch.FloatTensor): direct logits output of the model of shape (b, s, v)

--- a/torchtune/config/_instantiate.py
+++ b/torchtune/config/_instantiate.py
@@ -51,6 +51,9 @@ def instantiate(
     function call. These are automatically merged with the provided config, with keyword
     args taking precedence.
 
+    Inspired by Hydra's `instantiate` utility from Facebook Research:
+    https://github.com/facebookresearch/hydra/blob/main/hydra/_internal/instantiate/_instantiate2.py#L148
+
     Args:
         config (DictConfig): a single field in the OmegaConf object parsed from the yaml file.
             This is expected to have a _component_ field specifying the path of the object

--- a/torchtune/config/_instantiate.py
+++ b/torchtune/config/_instantiate.py
@@ -51,7 +51,7 @@ def instantiate(
     function call. These are automatically merged with the provided config, with keyword
     args taking precedence.
 
-    Inspired by Hydra's `instantiate` utility from Facebook Research:
+    Based on Hydra's `instantiate` utility from Facebook Research:
     https://github.com/facebookresearch/hydra/blob/main/hydra/_internal/instantiate/_instantiate2.py#L148
 
     Args:

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -44,6 +44,9 @@ def _get_component_from_path(path: str) -> Any:
     The base functionality relies on ``getattr()`` and handles all
     possible exceptions accordingly.
 
+    Inspired by Hydra's `_locate` from Facebook Research:
+    https://github.com/facebookresearch/hydra/blob/main/hydra/_internal/utils.py#L614
+
     Args:
         path (str): Dotted path of the object
 

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -44,7 +44,7 @@ def _get_component_from_path(path: str) -> Any:
     The base functionality relies on ``getattr()`` and handles all
     possible exceptions accordingly.
 
-    Inspired by Hydra's `_locate` from Facebook Research:
+    Based on Hydra's `_locate` from Facebook Research:
     https://github.com/facebookresearch/hydra/blob/main/hydra/_internal/utils.py#L614
 
     Args:

--- a/torchtune/modules/loss/dpo.py
+++ b/torchtune/modules/loss/dpo.py
@@ -13,7 +13,10 @@ import torch.nn.functional as F
 
 class DPOLoss(nn.Module):
     """
-    Direct Preference Optimization (DPO) Loss module: https://arxiv.org/abs/2305.18290
+    Direct Preference Optimization (DPO) Loss module: https://arxiv.org/abs/2305.18290.
+
+    Largely inspired by the implementation in HF's TRL library:
+    https://github.com/huggingface/trl/blob/5d1deb1445828cfd0e947cb3a7925b1c03a283fc/trl/trainer/dpo_trainer.py#L844
 
     Args:
         beta (float): Temperature parameter for the DPO loss, typically in the range of 0.1 to 0.5. Default is 0.1.

--- a/torchtune/modules/loss/dpo.py
+++ b/torchtune/modules/loss/dpo.py
@@ -15,7 +15,7 @@ class DPOLoss(nn.Module):
     """
     Direct Preference Optimization (DPO) Loss module: https://arxiv.org/abs/2305.18290.
 
-    Largely inspired by the implementation in HF's TRL library:
+    Based on the implementation in HF's TRL library:
     https://github.com/huggingface/trl/blob/5d1deb1445828cfd0e947cb3a7925b1c03a283fc/trl/trainer/dpo_trainer.py#L844
 
     Args:


### PR DESCRIPTION
## Context
Addressing #782, update docstrings where needed to add code refs to give credit to original implementations, including HF TRL and Hydra.

## Test plan
lint, no code changes
