### PR TITLE
Fix LoRA finetune single device link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ torchtune provides the following fine-tuning recipes.
 | Training                           | Fine-tuning Method                 |
 |------------------------------------|------------------------------------|
 | Distributed Training [1 to 8 GPUs] | Full [[code](recipes/full_finetune_distributed.py), [example](recipes/configs/llama2/7B_full.yaml)], LoRA [[code](recipes/lora_finetune_distributed.py), [example](recipes/configs/llama2/7B_lora.yaml)] |
-| Single Device / Low Memory [1 GPU] | Full [[code](recipes/full_finetune_single_device.py), [example](recipes/configs/llama2/7B_full_low_memory.yaml)], LoRA + QLoRA [[code](recipes/lora_finetune_distributed.py), [example](recipes/configs/llama2/7B_qlora_single_device.yaml)] |
+| Single Device / Low Memory [1 GPU] | Full [[code](recipes/full_finetune_single_device.py), [example](recipes/configs/llama2/7B_full_low_memory.yaml)], LoRA + QLoRA [[code](recipes/lora_finetune_single_device.py), [example](recipes/configs/llama2/7B_qlora_single_device.yaml)] |
 | Single Device [1 GPU]              | DPO [[code](recipes/full_finetune_distributed.py), [example](recipes/configs/llama2/7B_lora_dpo_single_device.yaml)]
 
 &nbsp;


### PR DESCRIPTION
#### Context
- The link to the LoRA recipe in the Single device case in the README pointed to `recipes/lora_finetune_distributed.py` instead of `recipes/lora_finetune_single_device.py`. 

#### Changelog
- Fix LoRA finetune single device link in README

#### Test plan
- When I click on the link, it opens `recipes/lora_finetune_single_device.py`.
