### PR TITLE
Adding support for Llama2 70B LoRA finetuning

### DIFF
--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -24,7 +24,7 @@ tokenizer:
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir: /tmp/Llama-2-70b-hf/
+  checkpoint_dir:  /tmp/Llama-2-70b-hf
   checkpoint_files: [
     pytorch_model-00001-of-00015.bin,
     pytorch_model-00002-of-00015.bin,
@@ -43,7 +43,7 @@ checkpointer:
     pytorch_model-00015-of-00015.bin,
   ]
   recipe_checkpoint: null
-  output_dir: /tmp/Llama-2-70b-hf/
+  output_dir: /tmp/Llama-2-70b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
 

--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -24,7 +24,7 @@ tokenizer:
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir: /data/users/kartikayk/cpts/Llama-2-70b-hf/
+  checkpoint_dir: /tmp/Llama-2-70b-hf/
   checkpoint_files: [
     pytorch_model-00001-of-00015.bin,
     pytorch_model-00002-of-00015.bin,
@@ -43,7 +43,7 @@ checkpointer:
     pytorch_model-00015-of-00015.bin,
   ]
   recipe_checkpoint: null
-  output_dir: /tmp/Llama-2-70b-hf/Llama-2-70b-hf/
+  output_dir: /tmp/Llama-2-70b-hf/
   model_type: LLAMA2
 resume_from_checkpoint: False
 
@@ -75,7 +75,7 @@ gradient_accumulation_steps: 1
 # Logging
 output_dir: /tmp/lora_finetune_output
 metric_logger:
-  _component_: torchtune.utils.metric_logging.WandBLogger
+  _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 log_every_n_steps: null
 

--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -1,3 +1,14 @@
+# Config for multi-device LoRA in lora_finetune_distributed.py
+# using a Llama2 70B model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download meta-llama/Llama-2-70b-hf --output-dir /tmp/Llama-2-70b-hf --hf-token <HF_TOKEN>
+#
+# This config needs 8 GPUs to run
+#   # tune run --nproc_per_node 8 lora_finetune_distributed --config llama2/70B_lora
+#
+
 # Model Arguments
 model:
   _component_: torchtune.models.llama2.lora_llama2_70b

--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -1,0 +1,74 @@
+# Model Arguments
+model:
+  _component_: torchtune.models.llama2.lora_llama2_70b
+  lora_attn_modules: ['q_proj', 'v_proj', 'k_proj']
+  apply_lora_to_mlp: False
+  apply_lora_to_output: False
+  lora_rank: 16
+  lora_alpha: 32
+
+tokenizer:
+  _component_: torchtune.models.llama2.llama2_tokenizer
+  path: /tmp/Llama-2-70b-hf/tokenizer.model
+
+checkpointer:
+  _component_: torchtune.utils.FullModelHFCheckpointer
+  checkpoint_dir: /data/users/kartikayk/cpts/Llama-2-70b-hf/
+  checkpoint_files: [
+    pytorch_model-00001-of-00015.bin,
+    pytorch_model-00002-of-00015.bin,
+    pytorch_model-00003-of-00015.bin,
+    pytorch_model-00004-of-00015.bin,
+    pytorch_model-00005-of-00015.bin,
+    pytorch_model-00006-of-00015.bin,
+    pytorch_model-00007-of-00015.bin,
+    pytorch_model-00008-of-00015.bin,
+    pytorch_model-00009-of-00015.bin,
+    pytorch_model-00010-of-00015.bin,
+    pytorch_model-00011-of-00015.bin,
+    pytorch_model-00012-of-00015.bin,
+    pytorch_model-00013-of-00015.bin,
+    pytorch_model-00014-of-00015.bin,
+    pytorch_model-00015-of-00015.bin,
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/Llama-2-70b-hf/Llama-2-70b-hf/
+  model_type: LLAMA2
+resume_from_checkpoint: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.alpaca_dataset
+  train_on_input: True
+seed: null
+shuffle: True
+batch_size: 2
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.modules.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torch.nn.CrossEntropyLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 1
+
+# Logging
+output_dir: /tmp/lora_finetune_output
+metric_logger:
+  _component_: torchtune.utils.metric_logging.WandBLogger
+  log_dir: ${output_dir}
+log_every_n_steps: null
+
+# Environment
+device: cuda
+dtype: bf16
+enable_activation_checkpointing: True

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -93,6 +93,7 @@ _ALL_RECIPES = [
         configs=[
             Config(name="llama2/7B_lora", file_path="llama2/7B_lora.yaml"),
             Config(name="llama2/13B_lora", file_path="llama2/13B_lora.yaml"),
+            Config(name="llama2/70B_lora", file_path="llama2/70B_lora.yaml"),
             Config(name="mistral/7B_lora", file_path="mistral/7B_lora.yaml"),
         ],
         supports_distributed=True,

--- a/torchtune/models/llama2/__init__.py
+++ b/torchtune/models/llama2/__init__.py
@@ -8,12 +8,12 @@ from ._component_builders import llama2, lora_llama2
 
 from ._model_builders import (  # noqa
     llama2_13b,
-    llama2_7b,
     llama2_70b,
+    llama2_7b,
     llama2_tokenizer,
     lora_llama2_13b,
-    lora_llama2_7b,
     lora_llama2_70b,
+    lora_llama2_7b,
     qlora_llama2_13b,
     qlora_llama2_7b,
 )

--- a/torchtune/models/llama2/__init__.py
+++ b/torchtune/models/llama2/__init__.py
@@ -9,9 +9,11 @@ from ._component_builders import llama2, lora_llama2
 from ._model_builders import (  # noqa
     llama2_13b,
     llama2_7b,
+    llama2_70b,
     llama2_tokenizer,
     lora_llama2_13b,
     lora_llama2_7b,
+    lora_llama2_70b,
     qlora_llama2_13b,
     qlora_llama2_7b,
 )

--- a/torchtune/models/llama2/_model_builders.py
+++ b/torchtune/models/llama2/_model_builders.py
@@ -122,6 +122,7 @@ def llama2_13b() -> TransformerDecoder:
         max_seq_len=4096,
         attn_dropout=0.0,
         norm_eps=1e-5,
+
     )
 
 
@@ -176,3 +177,75 @@ def lora_llama2_13b(
     )
 
 qlora_llama2_13b = partial(lora_llama2_13b, quantize_base=True)
+
+
+def llama2_70b() -> TransformerDecoder:
+    """
+    Builder for creating a Llama2 model initialized w/ the default 70 parameter values
+    from https://arxiv.org/abs/2307.09288
+
+    Returns:
+        TransformerDecoder: Instantiation of Llama2 70 model
+    """
+    return llama2(
+        vocab_size=32_000,
+        num_layers=80,
+        num_heads=64,
+        num_kv_heads=8,
+        embed_dim=8192,
+        intermediate_dim=28672,
+        max_seq_len=4096,
+        attn_dropout=0.0,
+        norm_eps=1e-5,
+    )
+
+
+def lora_llama2_70b(
+    lora_attn_modules: List[LORA_ATTN_MODULES],
+    apply_lora_to_mlp: bool = False,
+    apply_lora_to_output: bool = False,
+    lora_rank: int = 8,
+    lora_alpha: float = 16,
+    lora_dropout: float = 0.05,
+    quantize_base: bool = False,
+) -> TransformerDecoder:
+    """
+    Builder for creating a Llama2 70B model with LoRA enabled.
+
+    The Llama2 defaults are the same as in :func:`~torchtune.models.llama2.llama2_7b`,
+    while LoRA default params are based on
+    https://github.com/tloen/alpaca-lora/blob/8bb8579e403dc78e37fe81ffbb253c413007323f/finetune.py#L41-L43.
+
+    Args:
+        lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers
+            LoRA should be applied to in each self-attention block. Options are
+            ``{"q_proj", "k_proj", "v_proj", "output_proj"}``.
+        apply_lora_to_mlp (bool): whether to apply LoRA to the MLP in each transformer layer.
+            Default: False
+        apply_lora_to_output (bool): whether to apply LoRA to the model's final output projection.
+            Default: False
+        lora_rank (int): rank of each low-rank approximation
+        lora_alpha (float): scaling factor for the low-rank approximation
+        quantize_base (bool): Whether to quantize base model weights
+
+    Returns:
+        TransformerDecoder: Instantiation of Llama2 70B model with LoRA applied
+    """
+    return lora_llama2(
+        lora_attn_modules=lora_attn_modules,
+        apply_lora_to_mlp=apply_lora_to_mlp,
+        apply_lora_to_output=apply_lora_to_output,
+        vocab_size=32_000,
+        num_layers=80,
+        num_heads=64,
+        num_kv_heads=8,
+        embed_dim=8192,
+        max_seq_len=4096,
+        intermediate_dim=28672,
+        attn_dropout=0.0,
+        norm_eps=1e-5,
+        lora_rank=lora_rank,
+        lora_alpha=lora_alpha,
+        lora_dropout=0.05,
+        quantize_base=quantize_base,
+    )


### PR DESCRIPTION
#### Context

As per title

#### Changelog
- Builder function + config

#### Test plan
- Trained for one epoch with the following loss

<img width="526" alt="image" src="https://github.com/pytorch/torchtune/assets/47255723/62a12011-ff64-403d-b5da-a84ec717ab5c">

&nbsp; 

- Training Speed

![image](https://github.com/pytorch/torchtune/assets/47255723/c964b0f4-3f46-47a2-92c7-856791c0be93)


&nbsp; 


- Memory 

<img width="630" alt="image" src="https://github.com/pytorch/torchtune/assets/47255723/1f6f38b3-9e63-4813-8262-ab355707667e">




