### PR TITLE
remove check for cuda version and package so the bf16 check passes on non Nvidia CUDA devices that support bf16

### DIFF
--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -18,7 +18,6 @@ from typing import (
 
 import torch
 import torch.nn as nn
-from pkg_resources import packaging
 
 from torch.cuda.amp import GradScaler
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler

--- a/torchtune/utils/precision.py
+++ b/torchtune/utils/precision.py
@@ -67,9 +67,7 @@ def list_dtypes() -> List[str]:
 def verify_bf16_support():
     return (
         torch.cuda.is_available()
-        and torch.version.cuda
         and torch.cuda.is_bf16_supported()
-        and packaging.version.parse(torch.version.cuda).release >= (11, 0)
         and torch.distributed.is_nccl_available()
         and torch.cuda.nccl.version() >= (2, 10)
     )


### PR DESCRIPTION
Remove checks that prohibit AMD cards that support pytorch as cuda devices from training.

#### Context
I have a 7900xtx running pytorch 2.2 w/ROCM 6.1 and wanted to train a mistral/llama model but ran into an error that my card didn't support bf16


#### Changelog
Remove cuda package and version check - returns none for rocm


#### Test plan
Training mistral 07b on my 7900xtx using lora.
