### PR TITLE
Fix Gemma inference generation

### DIFF
--- a/torchtune/models/gemma/transformer.py
+++ b/torchtune/models/gemma/transformer.py
@@ -124,7 +124,7 @@ class GemmaTransformerDecoder(nn.Module):
 
         for layer in self.layers:
             # shape: [b, s, d]
-            h = layer(h, mask, None)
+            h = layer(h, mask, input_pos)
 
         # shape: [b, s, d]
         h = self.norm(h)


### PR DESCRIPTION
#### Context
Running generate.py for Gemma 2B gives the following error:
_File "torchtune/modules/kv_cache.py", line 47, in update
    assert input_pos.shape[0] == k_val.shape[2]
AttributeError: 'NoneType' object has no attribute 'shape'_

#### Changelog
Re-add input_pos to modules/gemma/transformer.py to match the base transformer.py

This allows the config to successfully generate text.
