### PR TITLE
Fix max_seq_len for llama 3 70b

### DIFF
--- a/torchtune/models/llama3/_model_builders.py
+++ b/torchtune/models/llama3/_model_builders.py
@@ -57,7 +57,7 @@ def llama3_70b() -> TransformerDecoder:
         num_heads=64,
         num_kv_heads=8,
         embed_dim=8192,
-        max_seq_len=4096,
+        max_seq_len=8192,
         intermediate_dim=28672,
         attn_dropout=0.0,
         norm_eps=1e-5,

--- a/torchtune/models/llama3/_model_builders.py
+++ b/torchtune/models/llama3/_model_builders.py
@@ -161,7 +161,7 @@ def lora_llama3_70b(
         num_heads=64,
         num_kv_heads=8,
         embed_dim=8192,
-        max_seq_len=4096,
+        max_seq_len=8192,
         intermediate_dim=28672,
         attn_dropout=0.0,
         norm_eps=1e-5,


### PR DESCRIPTION
Fixes the default max_seq_len to 8192