### PR TITLE
keyword-only args for chat dataset, optional chat format

### DIFF
--- a/tests/torchtune/data/test_data_utils.py
+++ b/tests/torchtune/data/test_data_utils.py
@@ -50,15 +50,6 @@ def test_validate_messages():
     ):
         validate_messages(messages)
 
-    # Test empty message
-    messages = [
-        Message(role="system", content="hello"),
-        Message(role="user", content=""),
-        Message(role="assistant", content="world"),
-    ]
-    with pytest.raises(ValueError, match="Message at index 1 in messages is empty"):
-        validate_messages(messages)
-
     # Test empty assistant message
     messages = [
         Message(role="system", content="hello"),

--- a/torchtune/data/_utils.py
+++ b/torchtune/data/_utils.py
@@ -59,10 +59,4 @@ def validate_messages(
             raise ValueError(
                 f"System message at index {i} in messages, but system messages must come first"
             )
-        # Assistant messages can be empty because they will not be tokenized and
-        # will not contribute to the loss, assuming the entire batch is not full
-        # of empty assistant messages. The alpaca dataset is an example of the
-        # output assistant message being empty sometimes.
-        if not message.content and message.role != "assistant":
-            raise ValueError(f"Message at index {i} in messages is empty")
         last_turn = message.role

--- a/torchtune/datasets/_chat.py
+++ b/torchtune/datasets/_chat.py
@@ -50,9 +50,11 @@ class ChatDataset(Dataset):
             (https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path)
         convert_to_messages (Callable[[Mapping[str, Any]], List[Message]]): function that keys into the desired field in the sample
             and converts to a list of `Messages` that follows the llama format with the expected keys
-        chat_format (Optional[ChatFormat]): template used to format the chat. If the placeholder variable
-            names in the template do not match the column/key names in the dataset, use `column_map` to map them.
-            Default: None
+        chat_format (Optional[ChatFormat]): template used to format the chat. This is used to add structured text around the actual
+            messages, such as the [INST] tags in LLaMA2 and in Mistral. The extra text will still get tokenized as normal text, not
+            as special tokens. In models like LLaMA3 where the tokenizer adds tags as special tokens, `chat_format` is not needed,
+            unless you want to structure messages in a particular way for inference. If the placeholder variable names in the
+            template do not match the column/key names in the dataset, use `column_map` to map them. Default: None
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to `load_dataset`.
@@ -118,7 +120,8 @@ def chat_dataset(
             (https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path)
         conversation_style (str): string specifying expected style of conversations in the dataset
             for automatic conversion to the llama style. Supported styles are: "sharegpt"
-        chat_format (str): name of ChatFormat class used to format the messages.
+        chat_format (str): name of ChatFormat class used to format the messages. See the description in
+            :class:`~torchtune.datasets.ChatDataset` for more details.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to `load_dataset`.

--- a/torchtune/datasets/_slimorca.py
+++ b/torchtune/datasets/_slimorca.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtune.data import Llama2ChatFormat, sharegpt_to_llama2_messages
+from typing import Optional
+
+from torchtune.data import ChatFormat, Llama2ChatFormat, sharegpt_to_llama2_messages
 
 from torchtune.datasets._chat import ChatDataset
 
@@ -12,8 +14,10 @@ from torchtune.modules.tokenizers import Tokenizer
 
 
 def slimorca_dataset(
+    *,
     tokenizer: Tokenizer,
     source: str = "Open-Orca/SlimOrca-Dedup",
+    chat_format: Optional[ChatFormat] = Llama2ChatFormat,
     max_seq_len: int = 1024,
     train_on_input: bool = False,
 ) -> ChatDataset:
@@ -33,6 +37,9 @@ def slimorca_dataset(
     Args:
         tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
         source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
+        chat_format (Optional[ChatFormat]): template used to format the chat. If the placeholder variable
+            names in the template do not match the column/key names in the dataset, use `column_map` to map them.
+            Default: Llama2ChatFormat
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
             This value needs to be at least 4 though it is generally set to max sequence length accepted by the model.
             Default is 1024.
@@ -63,7 +70,7 @@ def slimorca_dataset(
         tokenizer=tokenizer,
         source=source,
         convert_to_messages=sharegpt_to_llama2_messages,
-        chat_format=Llama2ChatFormat,
+        chat_format=chat_format,
         max_seq_len=max_seq_len,
         train_on_input=train_on_input,
         split="train",

--- a/torchtune/datasets/_slimorca.py
+++ b/torchtune/datasets/_slimorca.py
@@ -39,7 +39,7 @@ def slimorca_dataset(
         source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         chat_format (Optional[ChatFormat]): template used to format the chat. If the placeholder variable
             names in the template do not match the column/key names in the dataset, use `column_map` to map them.
-            Default: Llama2ChatFormat
+            See the description in :class:`~torchtune.datasets.ChatDataset` for more details. Default: Llama2ChatFormat
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
             This value needs to be at least 4 though it is generally set to max sequence length accepted by the model.
             Default is 1024.


### PR DESCRIPTION
Not all datasets need chat format, so we should make it optional. Also we should be using keyword-only args more. In this case the latter is beneficial for the former, so enable it for ChatDataset.

#### Test plan:

```
pytest tests
...
======= 191 passed, 19 skipped, 4 warnings in 60.28s (0:01:00) =========
```

```
pytest tests -m integration_test
...
======= 14 passed, 4 skipped, 192 deselected, 2 warnings in 190.73s (0:03:10) =========
```

Now we can run without applying chat format via e.g. 

```
tune run lora_finetune_single_device --config llama3/8B_lora_single_device dataset=torchtune.datasets.slimorca_dataset dataset.chat_format=null
...
1|32|Loss: 2.4104795455932617:   0%|                                    
```

