### PR TITLE
feat: added packed continued pretraining dataset functionality

### DIFF
--- a/tests/torchtune/datasets/test_concat_dataset.py
+++ b/tests/torchtune/datasets/test_concat_dataset.py
@@ -1,0 +1,46 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+from datasets import Dataset
+from tests.test_utils import DummyTokenizer
+from torchtune.datasets import ConcatDataset
+
+
+class TestInstructDataset:
+    expected_tokenized_prompts = [
+        [0, 4, 2, 1, 7, 4, -1, 0, 1, 9],
+        [5, 2, 6, 4, 3, 8, -1, 0, 4, 3],
+    ]
+
+    def get_samples(self):
+        samples_list = [
+            "This is a packing test",
+            "A fantastic test. It should pack two samples.",
+            "This one will not be fully packed.",
+        ]
+
+        samples_dict = {"content": samples_list}
+
+        return Dataset.from_dict(samples_dict)
+
+    @mock.patch("torchtune.datasets._concat.load_dataset")
+    def test_get_item(self, mock_load_dataset):
+        mock_load_dataset.return_value = self.get_samples()
+        dataset = ConcatDataset(
+            tokenizer=DummyTokenizer(),
+            source="were/going/jellyfishing",
+            text_column="content",
+            max_seq_len=10,
+        )
+        assert len(dataset) == 2
+        mock_load_dataset.assert_called_once()
+
+        for i in range(len(dataset)):
+            prompt, label = dataset[i]
+            assert prompt == self.expected_tokenized_prompts[i]
+            assert label == self.expected_tokenized_prompts[i]

--- a/tests/torchtune/datasets/test_stack_dataset.py
+++ b/tests/torchtune/datasets/test_stack_dataset.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import pytest
+from datasets import Dataset
+
+from tests.test_utils import get_assets_path
+from torchtune.datasets import stack_dataset
+from torchtune.modules.tokenizers import SentencePieceTokenizer
+
+
+class TestAlpacaDataset:
+    @pytest.fixture
+    def tokenizer(self):
+        # m.model is a pretrained Sentencepiece model using the following command:
+        # spm.SentencePieceTrainer.train('--input=<TRAIN_FILE> --model_prefix=m --vocab_size=2000')
+        return SentencePieceTokenizer(str(get_assets_path() / "m.model"))
+
+    def get_samples(self):
+        samples_list = [
+            "This is a packing test",
+            "A fantastic test. It should pack two samples.",
+            "This one will not be fully packed.",
+        ]
+
+        samples_dict = {"content": samples_list}
+
+        return Dataset.from_dict(samples_dict)
+
+    @patch("torchtune.datasets._concat.load_dataset")
+    def test_label(self, load_dataset, tokenizer):
+        """
+        Test whether the input and the labels are correctly created.
+        """
+
+        # mock the call to HF datasets
+        load_dataset.return_value = self.get_samples()
+
+        stack_ds = stack_dataset(
+            tokenizer=tokenizer,
+            max_seq_len=10,
+            train_split_name=None,
+        )
+
+        for i in range(len(stack_ds)):
+            inputs, label = stack_ds[i]
+            assert len(inputs) == 10
+            assert len(inputs) == len(label)
+            assert inputs == label
+
+            if i == 0:
+                assert inputs[0] == tokenizer.bos_id

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -6,11 +6,14 @@
 
 from torchtune.datasets._alpaca import alpaca_cleaned_dataset, alpaca_dataset
 from torchtune.datasets._chat import chat_dataset, ChatDataset
+from torchtune.datasets._concat import ConcatDataset
 from torchtune.datasets._grammar import grammar_dataset
 from torchtune.datasets._instruct import instruct_dataset, InstructDataset
 from torchtune.datasets._samsum import samsum_dataset
 from torchtune.datasets._slimorca import slimorca_dataset
+from torchtune.datasets._stack import stack_dataset
 from torchtune.datasets._stack_exchanged_paired import stack_exchanged_paired_dataset
+
 
 __all__ = [
     "alpaca_dataset",
@@ -23,4 +26,6 @@ __all__ = [
     "ChatDataset",
     "instruct_dataset",
     "chat_dataset",
+    "ConcatDataset",
+    "stack_dataset",
 ]

--- a/torchtune/datasets/_concat.py
+++ b/torchtune/datasets/_concat.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from datasets import load_dataset, load_from_disk
+from torch.utils.data import Dataset
+from torchtune.modules.tokenizers import Tokenizer
+from tqdm import tqdm
+
+
+class ConcatDataset(Dataset):
+    """
+    Class that enables continued pretraining by packing a single column of text data into equally sized samples.
+
+    The class loads, tokenizes, and packs examples on initialization - no tokenization is done during training.
+
+    Streaming datasets are supported. To stream a dataset, pass `'streaming': True` in the `load_dataset_kwargs`.
+    If streaming, the total number of samples will be unknown until the end of the dataset, and the progress bar
+    will be indeterminate.
+
+    The general flow is:
+
+    On initialization:
+    optionally shuffle sample -> load sample -> tokenize and add to buffer ->
+        when buffer is long enough, add to self.samples.
+
+    During training:
+    return self.samples[idx] as input and label.
+
+    Args:
+        tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
+        source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`,
+            or if `is_local` is true, a local path to load with `load_from_disk`.
+        text_column (str): column name of the dataset to pack into samples.
+        max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
+            Default is None, disabling truncation. We recommend setting this to the highest you can fit in memory
+            and is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
+        max_rows (int): maximum number of samples to pack. Default is None, which will pack as many samples as possible.
+        is_local (bool): whether the source is a local path. Default is False.
+        shuffle_before_packing (bool): whether to shuffle the dataset before packing. Default is False.
+        seed (int): seed for shuffling. Default is 29.
+        train_split_name (str): name of the split to use. Default is None, which will use the full dataset.
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to `load_dataset`.
+    """
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        source: str,
+        text_column: str,
+        max_seq_len: int,
+        max_rows: int = None,
+        is_local: bool = False,
+        shuffle_before_packing: bool = False,
+        seed: int = 29,
+        train_split_name: str = None,
+        **load_dataset_kwargs: Dict[str, Any],
+    ):
+
+        assert tokenizer is not None, "tokenizer must be provided"
+        assert source is not None, "source must be provided"
+        assert text_column is not None, "text_column must be provided"
+        assert max_seq_len is not None, "max_seq_len must be provided"
+
+        if is_local:
+            dataset = load_from_disk(source, **load_dataset_kwargs)
+        else:
+            dataset = load_dataset(source, **load_dataset_kwargs)
+
+        if train_split_name is not None:
+            dataset = dataset[train_split_name]
+
+        if shuffle_before_packing:
+            dataset = dataset.shuffle(seed=seed)
+
+        # where final samples will be held
+        self.samples = []
+
+        # buffer to hold samples until they are long enough to be added to self.samples
+        buffer = []
+
+        def tokenize(sample):
+            tokenized = tokenizer.encode(
+                sample[text_column].strip(),
+                add_bos=True,
+                add_eos=True,
+            )
+            return {"input_ids": tokenized}
+
+        pbar_total = None
+        if max_rows is not None:
+            pbar_total = max_rows
+        # trying to get length of streaming dataset will throw an error
+        elif (
+            "streaming" in load_dataset_kwargs
+            and load_dataset_kwargs["streaming"] is not True
+        ):
+            pbar_total = len(dataset)
+
+        # create max_rows number of packed samples. If max_rows is None, create as many as possible
+        pbar = tqdm(
+            dataset, total=pbar_total, desc="Packing dataset", dynamic_ncols=True
+        )
+        for sample in dataset:
+            if max_rows is not None:
+                if len(self.samples) >= max_rows:
+                    break
+
+            sample = tokenize(sample)
+
+            buffer = buffer + sample["input_ids"]
+            while len(buffer) >= max_seq_len + 1:
+                if max_rows is not None:
+                    if len(self.samples) >= max_rows:
+                        break
+
+                self.samples.append(buffer[:max_seq_len])
+                buffer = buffer[max_seq_len:]
+
+                if max_rows is not None:
+                    pbar.update(1)
+
+            if max_rows is None:
+                pbar.update(1)
+
+    def __getitem__(self, idx):
+        return self.samples[idx], self.samples[idx]
+
+    def __len__(self):
+        return len(self.samples)

--- a/torchtune/datasets/_stack.py
+++ b/torchtune/datasets/_stack.py
@@ -1,0 +1,76 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from torchtune.datasets._concat import ConcatDataset
+from torchtune.modules.tokenizers import Tokenizer
+
+
+def stack_dataset(
+    tokenizer: Tokenizer,
+    source: str = "bigcode/the-stack-dedup",
+    text_column: str = "content",
+    max_seq_len: int = 4096,
+    max_rows: int = 1000,
+    is_local: bool = False,
+    shuffle_before_packing: bool = True,
+    seed: int = 29,
+    train_split_name: str = "train",
+    train_on_input: bool = None,  # dummy argument for compatibility with config yaml files
+    **load_dataset_kwargs: Dict[str, Any],
+) -> ConcatDataset:
+    """
+    Example showing how to pass the [The Stack V1 Dedup](https://huggingface.co/datasets/bigcode/the-stack-dedup)
+    as a streaming dataset to the ConcatDataset class for continued pretraining. The Stack Dedup is
+    a dataset of code that is a popular solution for training code assistants.
+
+    Note how `streaming` and `token` values are passed to the `load_dataset_kwargs` dictionary - they are not
+    function arguments. This example uses the `HF_TOKEN` environment variable to authenticate
+    with the Hugging Face API. If you don't have that env var set, you can pass your token directly as a string.
+
+    Args:
+        tokenizer (Tokenizer): Tokenizer used to encode data. Tokenize must implement an `encode` and `decode` method.
+        source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`,
+            or if `is_local` is true, a local path to load with `load_from_disk`.
+        text_column (str): column name of the dataset to pack into samples.
+        max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
+            Default is 512, but we recommend setting this to the highest you can fit in memory and
+            is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
+        max_rows (int): maximum number of samples to pack. Default is 1000. Note: The Stack Dedup is very large,
+            so we limit the number of samples to 1000 for this example.
+        is_local (bool): whether the source dataset is a local path. Default is False.
+        shuffle_before_packing (bool): whether to shuffle the dataset before packing. Default is True.
+        seed (int): seed for shuffling. Default is 29.
+        train_split_name (str): name of the split to use. Default is 'train'.
+        train_on_input (bool): dummy argument for compatibility with config yaml files.
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to `load_dataset`. You will need
+            to pass a Huggingface API token value as a `token`, and we recommend setting `streaming` to True, since the
+            stack is a large dataset.
+
+    Returns:
+        ConcatDataset: dataset containing packed, tokenized samples.
+
+
+    Example:
+        >>> stack_ds = stack_dataset(tokenizer=tokenizer, max_seq_len=2048, max_rows=50000)
+        >>> for batch in Dataloader(stack_ds, batch_size=8):
+        >>>     print(f"Batch size: {len(batch)}")
+        >>> Batch size: 8
+    """
+
+    return ConcatDataset(
+        tokenizer=tokenizer,
+        source=source,
+        text_column=text_column,
+        max_seq_len=max_seq_len,
+        max_rows=max_rows,
+        is_local=is_local,
+        shuffle_before_packing=shuffle_before_packing,
+        seed=seed,
+        train_split_name=train_split_name,
+        **load_dataset_kwargs,
+    )


### PR DESCRIPTION
#### Context
This PR seeks to resolve issue #809 by adding the ability to pack and tokenize input/label pairs from a Huggingface dataset and then continue a model's pretraining phase on that processed dataset. The dataset can be local, or streamed.

This is my first attempt contributing to this repo. I expect a few changes will be requested, but hope you will consider it a good effort!

Ccing @RdoubleA.

One limitation of this new feature is that you can only pack as many examples as will fit in your system's RAM. This does not mean you can't use large datasets - just that you will only be able to use as many examples as will fit in RAM. This is because when creating a dataset class, you need to implement `__get_item__`, which requires an index to get an item. However, you will not know what a given index will return without packing the examples ahead of time.

One other thing to note is the `train_on_input` argument in the `stack_dataset` function, which is only there for compatibility with existing config yaml files. I'm not convinced it's a good practice to include that kind of thing, but I without it, we may have to change many of the existing recipe configs.

#### Changelog
The PR implements a new class, `ConcatDataset`, which was inspired by the [ConcatDataset class in llama-recipes](https://github.com/meta-llama/llama-recipes/blob/79aa70442e97c3127e53c2d22c54438c32adcf5e/src/llama_recipes/data/concatenator.py#L10).

It also implements a new example dataset, `stack_dataset`, which makes use of `ConcatDataset` to stream and pack the the [Stack V1 Dedup](https://huggingface.co/datasets/bigcode/the-stack-dedup) dataset. This is a popular (and very large) dataset for training coding assistants.

#### Test plan
The new `ConcatDataset` class and `stack_dataset` function both get tests that attempt to mimic the structure and spirit of existing tests - specifically, I used the tests covering `InstructDataset` and `alpaca_dataset` as a guide.

Also, I tested the code by training on a custom dataset which is designed to increase a model's knowledge of a certain Python library, and after a few thousand optimizer steps, the model had clearly learned about that library.

You can kick off a training run with a command like this:

```
clear && tune run \
    --nproc_per_node=4 \
    full_finetune_distributed \
    --config llama3/8B_full \
    batch_size=1 \
    seed=29 \
    tokenizer.path=<checkpoint_dir> \
    checkpointer.checkpoint_dir=<checkpoint_dir> \
    checkpointer.output_dir=<checkpoint_dir> \
    dataset=torchtune.datasets.stack_dataset \
    gradient_accumulation_steps=5 \
    lr_scheduler.num_warmup_steps=100 \
    enable_activation_checkpointing=True \
    epochs=3 \
    dataset.max_rows=200 \
    dataset.streaming=True
    dataset.token='<HF_token_goes_here>'
```