### PR TITLE
Update nightly build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ tune run --nproc_per_node 8 lora_finetune_distributed --config recipes/configs/l
 
 ## Installation
 
-**Step 1:** [Install PyTorch](ttps://pytorch.org/get-started/locally/). torchtune is tested with the latest stable PyTorch release (2.2.2) as well as the preview nightly version.
+**Step 1:** [Install PyTorch](https://pytorch.org/get-started/locally/). torchtune is tested with the latest stable PyTorch release (2.2.2) as well as the preview nightly version.
 
 **Step 2:** The latest stable version of torchtune is hosted on PyPI and can be downloaded with the following command:
 
@@ -154,6 +154,8 @@ options:
 
 ...
 ```
+
+You can also install the latest and greatest torchtune has to offer by [installing a nightly build](https://pytorch.org/torchtune/main/install.html).
 
 &nbsp;
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -60,7 +60,7 @@ to the package *without* installing via ``git clone``, you can install with the 
 
 .. code-block:: bash
 
-    pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/test/cpu --no-cache-dir
+    pip install --pre torchtune --index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
 
 .. note::
 
@@ -70,4 +70,4 @@ to the package *without* installing via ``git clone``, you can install with the 
 If you already have PyTorch installed, torchtune will default to using that version. However, if you want to
 use the nightly version of PyTorch, you can append the ``--force-reinstall`` option to the above command. If you
 opt for this install method, you will likely need to change the "cpu" suffix in the index url to match your CUDA
-version. For example, if you are running CUDA 12, your index url would be "https://download.pytorch.org/whl/test/cu121".
+version. For example, if you are running CUDA 12, your index url would be "https://download.pytorch.org/whl/nightly/cu121".

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -60,7 +60,7 @@ to the package *without* installing via ``git clone``, you can install with the 
 
 .. code-block:: bash
 
-    pip install --pre torchtune --index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
+    pip install --pre torchtune --extra-index-url https://download.pytorch.org/whl/nightly/cpu --no-cache-dir
 
 .. note::
 


### PR DESCRIPTION
#### Context
- Our nightly builds previously needed an option ``--extra-index-url``, which allowed pip to look both in PyPI and the PyTorch Index. After @atalman runs the new changes in test-infra, these packages should exist on PyTorch Index so we only need to look in a single place. 

#### Changelog
- Replace ``extra-index-url`` with ``--index-url``

#### Test plan
- Eyes and confirming the command works


DO NOT LAND UNTIL INDEX IS UPDATED.
