### PR TITLE
[FSDP1] reduce GPU memory usage from 78G instead of 23G

### DIFF
--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -276,7 +276,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
               the correct device.
         """
 
-        if self._is_rank_zero:
+        # if self._is_rank_zero:
+        if True:
             log.info("FSDP is enabled. Instantiating Model on CPU for Rank 0 ...")
             init_start = time.perf_counter()
 
@@ -311,10 +312,10 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             if lora_weights_state_dict:
                 model.load_state_dict(lora_weights_state_dict, strict=False)
 
-        else:
-            # For non-zero ranks, load the model on meta device
-            with utils.set_default_dtype(self._dtype), torch.device("meta"):
-                model = config.instantiate(cfg_model)
+        # else:
+        #     # For non-zero ranks, load the model on meta device
+        #     with utils.set_default_dtype(self._dtype), torch.device("meta"):
+        #         model = config.instantiate(cfg_model)
 
         if self._dtype == torch.bfloat16:
             model = model.to(torch.bfloat16)
@@ -337,15 +338,15 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             # this recipe does not currently support mixed precision training
             mixed_precision=None,
             # Ensure we broadcast params and buffers from rank 0
-            sync_module_states=True,
+            # sync_module_states=True,
             # Initialize empty modules on all non-zero ranks
-            param_init_fn=(
-                lambda module: module.to_empty(
-                    device=torch.device("cuda"), recurse=False
-                )
-                if not self._is_rank_zero
-                else None
-            ),
+            # param_init_fn=(
+            #     lambda module: module.to_empty(
+            #         device=torch.device("cuda"), recurse=False
+            #     )
+            #     if not self._is_rank_zero
+            #     else None
+            # ),
         )
 
         # Ensure no params and buffers are on meta device


### PR DESCRIPTION
In trunk, non-zero ranks have 78G memory during model init with `sync_module_states=True`. It's calling `dist._broadcast_coalesced` https://fburl.com/rkq73zyp and use recordstream by default. As a result, GPU memories not immeidately released

this PR set ``TORCH_NCCL_AVOID_RECORD_STREAMS=1`` and it reduced the memory from 78G to 23G

**memory profiles during model init without the fix**
<img width="1630" alt="Screenshot 2024-04-22 at 3 19 45 PM" src="https://github.com/pytorch/torchtune/assets/134637289/37581d72-432c-4ace-8dda-cb985ef53430">

**memory profiles after the fix**
memory profiles for 78G with accumulating spikes from `sync_module_states=True` and `param_init_fn`
<img width="1448" alt="Screenshot 2024-04-22 at 3 19 30 PM" src="https://github.com/pytorch/torchtune/assets/134637289/1c732f50-49ae-4577-a32f-9436b498e376">

