### PR TITLE
update readme.md - add command to download llama3

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,22 @@ To get started with fine-tuning your first LLM with torchtune, see our tutorial 
 
 ### Downloading a model
 
-Follow the instructions on the official [`meta-llama`](https://huggingface.co/meta-llama/Llama-2-7b) repository to ensure you have access to the Llama2 model weights. Once you have confirmed access, you can run the following command to download the weights to your local machine. This will also download the tokenizer model and a responsible use guide.
+Follow the instructions on the official [`meta-llama`](https://huggingface.co/meta-llama) repository to ensure you have access to the Llama(2 or 3) model weights. Once you have confirmed access, you can run the following command to download the weights to your local machine. This will also download the tokenizer model and a responsible use guide.
 
+### Llama2 download
 ```bash
 tune download meta-llama/Llama-2-7b-hf \
 --output-dir /tmp/Llama-2-7b-hf \
 --hf-token <HF_TOKEN> \
 ```
+
+### Llama3 download
+```bash
+tune download meta-llama/Meta-Llama-3-8B \
+--output-dir /tmp/Meta-Llama-3-8B \
+--hf-token <HF_TOKEN> \
+```
+
 
 > Tip: Set your environment variable `HF_TOKEN` or pass in `--hf-token` to the command in order to validate your access.
 You can find your token at https://huggingface.co/settings/tokens

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ To get started with fine-tuning your first LLM with torchtune, see our tutorial 
 
 ### Downloading a model
 
-Follow the instructions on the official [`meta-llama`](https://huggingface.co/meta-llama) repository to ensure you have access to the Llama(2 or 3) model weights. Once you have confirmed access, you can run the following command to download the weights to your local machine. This will also download the tokenizer model and a responsible use guide.
+Follow the instructions on the official [`meta-llama`](https://huggingface.co/meta-llama) repository to ensure you have access to the official Llama model weights. Once you have confirmed access, you can run the following command to download the weights to your local machine. This will also download the tokenizer model and a responsible use guide.
 
 ### Llama2 download
 ```bash


### PR DESCRIPTION
#### Context
This PR adds the download instructions to pull the llama3 8B weights.  Currently the readme talks about llama3 but then only has the download info to get llama2 weights.  Took a few minutes to figure out how to update to pull, so figured better to update the readme and save users the hassle. 


#### Changelog
only changes readme.md

#### Test plan
used the command in the readme to pull llama3 weights.
