### PR TITLE
Revise the implementation of set_activation_checkpointing

### DIFF
--- a/tests/torchtune/utils/test_memory.py
+++ b/tests/torchtune/utils/test_memory.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch.nn as nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    CheckpointWrapper,
+)
+from torchtune.utils import set_activation_checkpointing
+
+
+class TestSetActivationCheckpointing:
+    @pytest.fixture
+    def model(self) -> int:
+        return nn.Sequential(nn.Linear(10, 10), nn.Linear(10, 10), nn.Linear(10, 10))
+
+    def _verify(self, model):
+        for submodule in model.modules():
+            if isinstance(submodule, CheckpointWrapper):
+                assert isinstance(submodule._checkpoint_wrapped_module, nn.Linear)
+
+    def test_activation_checkpoint_set_policy(self, model):
+        set_activation_checkpointing(model=model, auto_wrap_policy={nn.Linear})
+        self._verify(model)
+
+    def test_activation_checkpoint_custom_policy(self, model):
+        def custom_policy(module: nn.Module, recurse: bool, **kwargs) -> bool:
+            if recurse:
+                return True
+            return isinstance(module, nn.Linear)
+
+        set_activation_checkpointing(model=model, auto_wrap_policy=custom_policy)
+        self._verify(model)

--- a/tests/torchtune/utils/test_memory.py
+++ b/tests/torchtune/utils/test_memory.py
@@ -15,7 +15,13 @@ from torchtune.utils import set_activation_checkpointing
 class TestSetActivationCheckpointing:
     @pytest.fixture
     def model(self) -> int:
-        return nn.Sequential(nn.Linear(10, 10), nn.Linear(10, 10), nn.Linear(10, 10))
+        return nn.Sequential(
+            nn.Linear(10, 10),
+            nn.Linear(10, 10),
+            nn.Linear(10, 10),
+            nn.ReLU(),
+            nn.Dropout(0.5),
+        )
 
     def _verify(self, model):
         for submodule in model.modules():

--- a/torchtune/utils/memory.py
+++ b/torchtune/utils/memory.py
@@ -32,7 +32,7 @@ def set_activation_checkpointing(
         model (nn.Module): Model to setup activation checkpointing.
         auto_wrap_policy (ACWrapPolicyType): Policy to wrap module.
             This can either be a set of ``nn.Module`` types, in which case, modules of the specified type(s)
-            will be wrapped individually with activation checkpointing or a ``callable`` policy describing
+            will be wrapped individually with activation checkpointing, or a ``callable`` policy describing
             how to wrap the model with activation checkpointing. For more information on authoring custom
             policies, please see this tutorial:
             https://pytorch.org/tutorials/intermediate/FSDP_adavnced_tutorial.html#transformer-wrapping-policy.

--- a/torchtune/utils/memory.py
+++ b/torchtune/utils/memory.py
@@ -7,7 +7,7 @@
 import gc
 import logging
 
-from typing import Any, Dict, Optional, Set
+from typing import Any, Callable, Dict, Set, Type, Union
 
 import torch
 
@@ -20,19 +20,27 @@ from torchtune.utils.logging import get_logger
 
 _log: logging.Logger = get_logger()
 
+ACWrapPolicyType: Type = Union[Set[Type], Callable[[nn.Module, bool, int], bool]]
+
 
 def set_activation_checkpointing(
-    model: nn.Module, auto_wrap_policy: Optional[Set[nn.Module]] = None, **kwargs
+    model: nn.Module, auto_wrap_policy: ACWrapPolicyType, **kwargs
 ) -> None:
-    """Utility to setup activation checkpointing and wrap the model for checkpointing.
+    """Utility to apply activation checkpointing to the passed in model.
 
     Args:
         model (nn.Module): Model to setup activation checkpointing.
-        auto_wrap_policy (Optional[Set[nn.Module]]): Policy to wrap module.
-        **kwargs: additional arguments to pass to torch.distributed activation checkpointing.
+        auto_wrap_policy (ACWrapPolicyType): Policy to wrap module.
+            This can either be a set of ``nn.Module`` types, in which case, modules of the specified type(s)
+            will be wrapped individually with activation checkpointing or a ``callable`` policy describing
+            how to wrap the model with activation checkpointing. For more information on authoring custom
+            policies, please see this tutorial:
+            https://pytorch.org/tutorials/intermediate/FSDP_adavnced_tutorial.html#transformer-wrapping-policy.
+        **kwargs: additional arguments to pass to ``torch.distributed`` activation checkpointing.
     """
-    wrap_policy = ModuleWrapPolicy(auto_wrap_policy or set())
-    apply_activation_checkpointing(model, auto_wrap_policy=wrap_policy, **kwargs)
+    if isinstance(auto_wrap_policy, set):
+        auto_wrap_policy = ModuleWrapPolicy(auto_wrap_policy)
+    apply_activation_checkpointing(model, auto_wrap_policy=auto_wrap_policy, **kwargs)
 
 
 def cleanup_before_training() -> None:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [x] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

`set_activation_checkpointing` is a bit restrictive in that it only allows policies to be taken in via a defined `set` instead of allowing users to also author policies. We'll soon be improving our activation checkpointing to make llama3 training more memory efficient, which will require a more custom policy this PR will enable. More context in https://github.com/pytorch/torchtune/issues/781. Also improving some of the documentation around the API and removing allowing passing of `None` into the policy since this does not make sense

#### Changelog
- Improve documentation
- Stop allowing `None` passed as the policy
- Allow custom policy to be passed in, in addition to sets
- Add unittests 

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

`pytest test_memory.py -v`

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
