### PR TITLE
Add missing Gemma recipes to registry, update default log_every_n_steps

### DIFF
--- a/recipes/configs/gemma/2B_full.yaml
+++ b/recipes/configs/gemma/2B_full.yaml
@@ -69,5 +69,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-gemma-finetune
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/gemma/2B_lora.yaml
+++ b/recipes/configs/gemma/2B_lora.yaml
@@ -79,5 +79,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-gemma-lora
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/gemma/2B_lora_single_device.yaml
+++ b/recipes/configs/gemma/2B_lora_single_device.yaml
@@ -5,7 +5,7 @@
 # this run:
 #   tune download google/gemma-2b --hf-token <HF_TOKEN> --output-dir /tmp/gemma --ignore-patterns ""
 #
-# To launch on 4 devices, run the following command from root:
+# To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/2B_lora_single_device
 #
 # You can add specific overrides through the command line. For example
@@ -79,7 +79,7 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-gemma-lora
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Show case the usage of pytorch profiler

--- a/recipes/configs/gemma/2B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/2B_qlora_single_device.yaml
@@ -79,7 +79,7 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-gemma-lora
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Show case the usage of pytorch profiler

--- a/recipes/configs/llama2/13B_full.yaml
+++ b/recipes/configs/llama2/13B_full.yaml
@@ -72,5 +72,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-llama2-finetune
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/llama2/13B_lora.yaml
+++ b/recipes/configs/llama2/13B_lora.yaml
@@ -77,7 +77,7 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Environment

--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -77,7 +77,7 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Environment

--- a/recipes/configs/llama2/7B_full.yaml
+++ b/recipes/configs/llama2/7B_full.yaml
@@ -72,5 +72,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-llama2-finetune
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/llama2/7B_full_low_memory.yaml
+++ b/recipes/configs/llama2/7B_full_low_memory.yaml
@@ -75,5 +75,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-llama2-finetune
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/llama2/7B_lora.yaml
+++ b/recipes/configs/llama2/7B_lora.yaml
@@ -74,7 +74,7 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Environment

--- a/recipes/configs/llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_single_device.yaml
@@ -73,7 +73,7 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Environment

--- a/recipes/configs/llama3/70B_lora.yaml
+++ b/recipes/configs/llama3/70B_lora.yaml
@@ -92,7 +92,7 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Environment

--- a/recipes/configs/llama3/8B_full.yaml
+++ b/recipes/configs/llama3/8B_full.yaml
@@ -74,5 +74,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-llama3-finetune
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/llama3/8B_full_single_device.yaml
+++ b/recipes/configs/llama3/8B_full_single_device.yaml
@@ -74,5 +74,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/alpaca-llama3-finetune
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/llama3/8B_lora.yaml
+++ b/recipes/configs/llama3/8B_lora.yaml
@@ -72,7 +72,7 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Environment

--- a/recipes/configs/llama3/8B_lora_single_device.yaml
+++ b/recipes/configs/llama3/8B_lora_single_device.yaml
@@ -72,7 +72,7 @@ output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Environment

--- a/recipes/configs/mistral/7B_full.yaml
+++ b/recipes/configs/mistral/7B_full.yaml
@@ -74,5 +74,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/Mistral-7B-v0.1/
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/mistral/7B_full_low_memory.yaml
+++ b/recipes/configs/mistral/7B_full_low_memory.yaml
@@ -80,5 +80,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/Mistral-7B-v0.1/
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -86,5 +86,5 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/Mistral-7B-v0.1
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/mistral/7B_lora_single_device.yaml
+++ b/recipes/configs/mistral/7B_lora_single_device.yaml
@@ -84,7 +84,7 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/Mistral-7B-v0.1
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Show case the usage of pytorch profiler

--- a/recipes/configs/mistral/7B_qlora_single_device.yaml
+++ b/recipes/configs/mistral/7B_qlora_single_device.yaml
@@ -85,7 +85,7 @@ metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
 output_dir: /tmp/Mistral-7B-v0.1
-log_every_n_steps: null
+log_every_n_steps: 1
 log_peak_memory_stats: False
 
 # Show case the usage of pytorch profiler

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -86,6 +86,14 @@ _ALL_RECIPES = [
                 name="mistral/7B_qlora_single_device",
                 file_path="mistral/7B_qlora_single_device.yaml",
             ),
+            Config(
+                name="gemma/2B_lora_single_device",
+                file_path="gemma/2B_lora_single_device.yaml",
+            ),
+            Config(
+                name="gemma/2B_qlora_single_device",
+                file_path="gemma/2B_qlora_single_device.yaml",
+            ),
         ],
         supports_distributed=False,
     ),
@@ -121,6 +129,7 @@ _ALL_RECIPES = [
             Config(name="llama3/70B_lora", file_path="llama3/70B_lora.yaml"),
             Config(name="llama3/8B_lora", file_path="llama3/8B_lora.yaml"),
             Config(name="mistral/7B_lora", file_path="mistral/7B_lora.yaml"),
+            Config(name="gemma/2B_lora", file_path="gemma/2B_lora.yaml"),
         ],
         supports_distributed=True,
     ),


### PR DESCRIPTION
Two changes here.
1) The recipe registry is missing our LoRA and QLoRA Gemma recipes, so this PR adds them. 
2) Fix a bug introduced in the last commit of #831. Using `cfg.get('field_name', default)` if field_name is set to null will just return null, not default. To fix this I set the default for `log_every_n_steps` to 1 in our configs. That's what we're doing in the recipes anyways when the config field is null, better to just be explicit about it.

## Test plan:

List all recipes
```
tune ls

full_finetune_single_device              llama2/7B_full_low_memory               
                                         llama3/8B_full_single_device            
                                         mistral/7B_full_low_memory              
full_finetune_distributed                llama2/7B_full                          
                                         llama2/13B_full                         
                                         llama3/8B_full                          
                                         mistral/7B_full                         
                                         gemma/2B_full                           
lora_finetune_single_device              llama2/7B_lora_single_device            
                                         llama2/7B_qlora_single_device           
                                         llama3/8B_lora_single_device            
                                         llama3/8B_qlora_single_device           
                                         llama2/13B_qlora_single_device          
                                         mistral/7B_lora_single_device           
                                         mistral/7B_qlora_single_device          
                                         gemma/2B_lora_single_device             
                                         gemma/2B_qlora_single_device            
lora_dpo_single_device                   llama2/7B_lora_dpo_single_device        
lora_dpo_distributed                     llama2/7B_lora_dpo                      
lora_finetune_distributed                llama2/7B_lora                          
                                         llama2/13B_lora                         
                                         llama2/70B_lora                         
                                         llama3/70B_lora                         
                                         llama3/8B_lora                          
                                         mistral/7B_lora                         
                                         gemma/2B_lora                           
generate                                 generation                              
eleuther_eval                            eleuther_evaluation                     
quantize                                 quantization 
```


```
tune run lora_finetune_single_device --config gemma/2B_lora_single_device
...
1|4|Loss: 2.409506320953369:   0%|▏                                                                                                       | 4/3250 [00:13<2:51:24,  3.17s/it]
```

```
tune run lora_finetune_single_device --config gemma/2B_lora_single_device
...
1|15|Loss: 2.5085432529449463:   0%|▍                                                                                                    | 15/3250 [00:50<2:56:02
```

```
tune run --nproc_per_node 2 lora_finetune_distributed --config gemma/2B_lora
...
1|4|Loss: 2.2445733547210693:   0%|                                                                                                       | 4/6501 [00:06<2:37:29
```
