### PR TITLE
Correctly pass TORCHTUNE_VERSION_DOCS during the build

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -43,16 +43,9 @@ jobs:
           python -m pip install -e .
           cd docs
           python -m pip install -r requirements.txt
-      - name: Get the torchtune version
-        run: | 
-          # Get the github.ref_name and save into the
-          # GITHUB_REF variable. This will be passed in
-          # conf.py to display the version in the
-          # site dropdown
-          GITHUB_REF=${{ github.ref }}
-          TORCHTUNE_VERSION_DOCS="${GITHUB_REF}"
-          echo "$TORCHTUNE_VERSION_DOCS"
       - name: Build docs
+        env:
+            TORCHTUNE_VERSION_DOCS: {{ github.ref }}
         run: |
           cd docs
           make html

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Build docs
         env:
-            TORCHTUNE_VERSION_DOCS: {{ github.ref }}
+            TORCHTUNE_VERSION_DOCS: ${{ github.ref }}
         run: |
           cd docs
           make html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,7 +88,8 @@ project = "TorchTune"
 
 # The code below will cut version displayed in the dropdown like this:
 # By default, set to "main".
-# If it's a tag like refs/tags/v1.2.3-rc4 or refs/tags/v1.2.3, then
+# If it's a tag like refs/tags/v1.2.3-rc4 or refs/tags/v1.2.3, or a
+#  refs/heads/release/1.2 then
 # cut to 1.2
 # the version varible is used in layout.html: https://github.com/pytorch/torchtune/blob/main/docs/source/_templates/layout.html#L29
 version = release = "main"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,10 @@ version = release = "main"
 if torchtune_version_docs:
     if torchtune_version_docs.startswith("refs/tags/v"):
         version = ".".join(
-            torchtune_version_docs.split("/")[-1].split("-")[0].lstrip("v").split(".")[:2]
+            torchtune_version_docs.split("/")[-1]
+            .split("-")[0]
+            .lstrip("v")
+            .split(".")[:2]
         )
     elif torchtune_version_docs.startswith("refs/heads/release/"):
         version = torchtune_version_docs.split("/")[-1]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,7 @@ project = "TorchTune"
 # By default, set to "main".
 # If it's a tag like refs/tags/v1.2.3-rc4 or refs/tags/v1.2.3, then
 # cut to 1.2
-# the version varible is used in layout.html: https://github.com/pytorch/executorch/blob/main/docs/source/_templates/layout.html#L29
+# the version varible is used in layout.html: https://github.com/pytorch/torchtune/blob/main/docs/source/_templates/layout.html#L29
 version = release = "main"
 if torchtune_version_docs:
     if torchtune_version_docs.startswith("refs/tags/v"):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,32 +81,27 @@ source_suffix = [".rst"]
 # Get TORCHTUNE_VERSION_DOCS during the build.
 torchtune_version_docs = os.environ.get("TORCHTUNE_VERSION_DOCS", None)
 
-# The code below will cut version displayed in the dropdown like this:
-# tags like v0.1.0 and v0.1.0-rc3 = > 0.1
-# main will remain main
-# the version varible is used in layout.html: https://github.com/pytorch/torchtune/blob/main/docs/source/_templates/layout.html#L29
+# Get TORCHTUNE_VERSION_DOCS during the build.
+torchtune_version_docs = os.environ.get("TORCHTUNE_VERSION_DOCS", None)
+print(f"torchtune_version_docs: {torchtune_version_docs}")
 project = "TorchTune"
+
+# The code below will cut version displayed in the dropdown like this:
+# By default, set to "main".
+# If it's a tag like refs/tags/v1.2.3-rc4 or refs/tags/v1.2.3, then
+# cut to 1.2
+# the version varible is used in layout.html: https://github.com/pytorch/executorch/blob/main/docs/source/_templates/layout.html#L29
+version = release = "main"
 if torchtune_version_docs:
     if torchtune_version_docs.startswith("refs/tags/v"):
         version = ".".join(
-            torchtune_version_docs.split("/")[-1]
-            .split("-")[0]
-            .lstrip("v")
-            .split(".")[:2]
+            torchtune_version_docs.split("/")[-1].split("-")[0].lstrip("v").split(".")[:2]
         )
-        print(f"Version: {version}")
-        release = version
-        html_title = " ".join((project, version, "documentation"))
-    elif torchtune_version_docs.startswith("refs/heads/"):
+    elif torchtune_version_docs.startswith("refs/heads/release/"):
         version = torchtune_version_docs.split("/")[-1]
-        print(f"Version: {version}")
-        release = version
-        html_title = " ".join((project, version, "documentation"))
-# IF TORCHTUNE_VERSION_DOCS not set, set version to main.
-else:
-    version = "main"
-    release = "main"
-    html_title = " ".join((project, version, "documentation"))
+print(f"Version: {version}")
+html_title = " ".join((project, version, "documentation"))
+
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
#### Context
In the current implementation of the doc_build.yml the version might not be correctly propagated. In this PR, we ensure we propagate the TORCHTUNE_VERSION_DOCS correctly and also simplify the code in the conf.py to handle refs/tags/ refs/heads truncation. 

This:
```
Running Sphinx v5.0.0
torchtune_version_docs: refs/pull/873/merge
Version: main
```
Will become this:
```
Running Sphinx v5.0.0
torchtune_version_docs: refs/heads/realease/0.2
Version: 02
```
and this:
```
Running Sphinx v5.0.0
torchtune_version_docs: refs/tags/v0.2.4-rc4
Version: 02
```