### PR TITLE
Add Phi3 Mini 4K Instruct Model to torchtune

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ torchtune currently supports the following models.
 | [Code-Llama2](https://huggingface.co/codellama)   | 7B, 13B, 70B [[model](torchtune/models/code_llama2/_model_builders.py), [configs](recipes/configs/code_llama2/)] |
 | [Mistral](https://huggingface.co/mistralai)   | 7B [[model](torchtune/models/mistral/_model_builders.py), [configs](recipes/configs/mistral/)] |
 | [Gemma](https://huggingface.co/collections/google/gemma-release-65d5efbccdbb8c4202ec078b)   | 2B [[model](torchtune/models/gemma/_model_builders.py), [configs](recipes/configs/gemma/)] |
-| [Microsoft Phi3](https://huggingface.co/collections/microsoft/phi-3-6626e15e9585a200d2d761e3) | Mini [[model](torchtune/models/phi3/), configs - WIP] |
+| [Microsoft Phi3](https://huggingface.co/collections/microsoft/phi-3-6626e15e9585a200d2d761e3) | Mini [[model](torchtune/models/phi3/)] |
 
 We'll be adding a number of new models in the coming weeks, including support for 70B versions and MoEs.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ torchtune currently supports the following models.
 | [Code-Llama2](https://huggingface.co/codellama)   | 7B, 13B, 70B [[model](torchtune/models/code_llama2/_model_builders.py), [configs](recipes/configs/code_llama2/)] |
 | [Mistral](https://huggingface.co/mistralai)   | 7B [[model](torchtune/models/mistral/_model_builders.py), [configs](recipes/configs/mistral/)] |
 | [Gemma](https://huggingface.co/collections/google/gemma-release-65d5efbccdbb8c4202ec078b)   | 2B [[model](torchtune/models/gemma/_model_builders.py), [configs](recipes/configs/gemma/)] |
+| [Microsoft Phi3](https://huggingface.co/collections/microsoft/phi-3-6626e15e9585a200d2d761e3) | Mini [[model](torchtune/models/phi3/), configs - WIP] |
 
 We'll be adding a number of new models in the coming weeks, including support for 70B versions and MoEs.
 

--- a/recipes/configs/phi3/mini_full.yaml
+++ b/recipes/configs/phi3/mini_full.yaml
@@ -1,0 +1,78 @@
+# Config for multi-device full finetuning in full_finetune_distributed.py
+# using a Mistral 7B model
+#
+# This config uses hyperparameters based on small set of experiments and information
+# available on various forums. These are not meant to replicate the numbers
+# from the paper
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download mistralai/Mistral-7B-v0.1 --hf-token <HF_TOKEN> --output-dir /tmp/Mistral-7B-v0.1
+#
+# Run this config on 4 GPUs using the following:
+#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config mistral/7B_full checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works best when the model is being fine-tuned on 2+ GPUs.
+# Single device full finetuning requires more memory optimizations. It's
+# best to use 7B_full_single_device.yaml for those cases
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.phi3.phi3_tokenizer
+  path: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct/tokenizer.model
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.alpaca_dataset
+  train_on_input: True
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: torchtune.models.phi3.phi3_mini
+
+checkpointer:
+  _component_: torchtune.utils.FullModelHFCheckpointer
+  checkpoint_dir: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct
+  checkpoint_files: [
+    model-00001-of-00002.safetensors,
+    model-00002-of-00002.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct
+  model_type: PHI3_MINI
+resume_from_checkpoint: False
+
+# Fine-tuning arguments
+batch_size: 2
+epochs: 3
+optimizer:
+  _component_: torch.optim.AdamW
+  lr: 5e-6
+loss:
+  _component_: torch.nn.CrossEntropyLoss
+max_steps_per_epoch: null
+gradient_accumulation_steps: 1
+
+
+# Training env
+device: cuda
+
+# Memory management
+enable_activation_checkpointing: True
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
+output_dir: /tmp/Mistral-7B-v0.1/
+log_every_n_steps: null

--- a/recipes/configs/phi3/mini_full.yaml
+++ b/recipes/configs/phi3/mini_full.yaml
@@ -1,10 +1,6 @@
 # Config for multi-device full finetuning in full_finetune_distributed.py
 # using a Phi3 Mini 4K Instruct
 #
-# This config uses hyperparameters based on small set of experiments and information
-# available on various forums. These are not meant to replicate the numbers
-# from the paper
-#
 # This config assumes that you've run the following command before launching
 # this run:
 #   tune download microsoft/Phi-3-mini-4k-instruct --output-dir ./Phi-3-mini-4k-instruct --hf-token <HF_TOKEN> --ignore-patterns ""
@@ -19,12 +15,12 @@
 #
 # This config works best when the model is being fine-tuned on 2+ GPUs.
 # Single device full finetuning requires more memory optimizations. It's
-# best to use 7B_full_single_device.yaml for those cases
+# best to use mini_low_memory.yaml for those cases
 
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.phi3.phi3_tokenizer
-  path: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct/tokenizer.model
+  path: /tmp/cpts/Phi-3-mini-4k-instruct/tokenizer.model
 
 # Dataset
 dataset:
@@ -39,13 +35,13 @@ model:
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct
+  checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
   checkpoint_files: [
     model-00001-of-00002.safetensors,
     model-00002-of-00002.safetensors
   ]
   recipe_checkpoint: null
-  output_dir: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct
+  output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 
@@ -74,5 +70,5 @@ dtype: bf16
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-output_dir: /tmp/Mistral-7B-v0.1/
+output_dir: /tmp/Phi-3-mini-4k-instruct
 log_every_n_steps: null

--- a/recipes/configs/phi3/mini_full_low_memory.yaml
+++ b/recipes/configs/phi3/mini_full_low_memory.yaml
@@ -1,10 +1,6 @@
 # Config for single device full finetuning in full_finetune_single_device.py
 # using a Phi3 Mini 4K Instruct
 #
-# This config uses hyperparameters based on small set of experiments and information
-# available on various forums. These are not meant to replicate the numbers
-# from the paper
-#
 # This config assumes that you've run the following command before launching
 # this run:
 #   tune download microsoft/Phi-3-mini-4k-instruct --output-dir ./Phi-3-mini-4k-instruct --hf-token <HF_TOKEN> --ignore-patterns ""
@@ -14,19 +10,19 @@
 #   pip install bitsandbytes
 #
 # To launch on a single device, run the following command from root:
-#   tune run full_finetune_single_device --config recipes/config/phi3/mini_full_low_memory.yaml
+#   tune run full_finetune_single_device --config recipes/configs/phi3/mini_full_low_memory.yaml
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run full_finetune_single_device --config recipes/config/phi3/mini_full_low_memory.yaml checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run full_finetune_single_device --config recipes/configs/phi3/mini_full_low_memory.yaml checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works only for training on single device.
 
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.phi3.phi3_tokenizer
-  path: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct/tokenizer.model
+  path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
 
 # Dataset
 dataset:
@@ -41,13 +37,13 @@ model:
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct
+  checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
   checkpoint_files: [
     model-00001-of-00002.safetensors,
     model-00002-of-00002.safetensors
   ]
   recipe_checkpoint: null
-  output_dir: /data/users/kartikayk/cpts/Phi-3-mini-4k-instruct
+  output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 
@@ -79,5 +75,5 @@ compile: False
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
   log_dir: ${output_dir}
-output_dir: /tmp/Mistral-7B-v0.1/
+output_dir: /tmp/Phi-3-mini-4k-instruct
 log_every_n_steps: null

--- a/recipes/configs/phi3/mini_full_low_memory.yaml
+++ b/recipes/configs/phi3/mini_full_low_memory.yaml
@@ -1,4 +1,4 @@
-# Config for multi-device full finetuning in full_finetune_distributed.py
+# Config for single device full finetuning in full_finetune_single_device.py
 # using a Phi3 Mini 4K Instruct
 #
 # This config uses hyperparameters based on small set of experiments and information
@@ -9,17 +9,19 @@
 # this run:
 #   tune download microsoft/Phi-3-mini-4k-instruct --output-dir ./Phi-3-mini-4k-instruct --hf-token <HF_TOKEN> --ignore-patterns ""
 #
-# Run this config on 4 GPUs using the following:
-#  tune run --nproc_per_node 4 recipes/full_finetune_distributed.py --config recipes/configs/phi3/mini_full.yaml
+# The default config uses an optimizer from bitsandbytes. If you do not have it installed,
+# you can install it with
+#   pip install bitsandbytes
+#
+# To launch on a single device, run the following command from root:
+#   tune run full_finetune_single_device --config recipes/config/phi3/mini_full_low_memory.yaml
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nproc_per_node 4 recipes/full_finetune_distributed.py --config recipes/configs/phi3/mini_full.yaml checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run full_finetune_single_device --config recipes/config/phi3/mini_full_low_memory.yaml checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
-# This config works best when the model is being fine-tuned on 2+ GPUs.
-# Single device full finetuning requires more memory optimizations. It's
-# best to use 7B_full_single_device.yaml for those cases
+# This config works only for training on single device.
 
 # Tokenizer
 tokenizer:
@@ -53,13 +55,13 @@ resume_from_checkpoint: False
 batch_size: 2
 epochs: 3
 optimizer:
-  _component_: torch.optim.AdamW
+  _component_: bitsandbytes.optim.PagedAdamW
   lr: 5e-6
 loss:
   _component_: torch.nn.CrossEntropyLoss
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1
-
+optimizer_in_bwd: True
 
 # Training env
 device: cuda
@@ -69,6 +71,9 @@ enable_activation_checkpointing: True
 
 # Reduced precision
 dtype: bf16
+
+# Model compilation
+compile: False
 
 # Logging
 metric_logger:

--- a/tests/torchtune/modules/test_position_embeddings.py
+++ b/tests/torchtune/modules/test_position_embeddings.py
@@ -13,6 +13,7 @@ from tests.test_utils import assert_expected
 from torch import tensor
 
 from torchtune.modules.position_embeddings import RotaryPositionalEmbeddings
+from torchtune.models.phi3 import Phi3RotaryPositionalEmbeddings
 from torchtune.utils.seed import set_seed
 
 
@@ -97,3 +98,41 @@ class TestRotaryPositionEmbedding:
         meta_rope._rope_init()
         for p1, p2 in zip(rope_on_device.buffers(), meta_rope.buffers()):
             torch.testing.assert_close(p1, p2)
+
+
+class TestPhi3RotaryPositionalEmbeddings:
+    """
+
+    """
+
+    @pytest.fixture
+    def input_params(self) -> Tuple[int, int, int, int]:
+        bsz = 4
+        num_heads = 32
+        embed_dim = 3072
+        seq_len = 60
+        max_seq_len = 4096
+        head_dim = embed_dim // num_heads
+        return bsz, num_heads, head_dim, seq_len, max_seq_len
+
+    @pytest.fixture
+    def input(self, input_params: Tuple[int, int, int, int]) -> tensor:
+        bsz, num_heads, head_dim, seq_len, _ = input_params
+        return torch.randn(bsz, seq_len, num_heads, head_dim)
+
+    @pytest.fixture
+    def rope_phi3(
+        self, input_params: Tuple[int, int, int, int]
+    ) -> Phi3RotaryPositionalEmbeddings:
+        _, _, head_dim, _, max_seq_len = input_params
+        return Phi3RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len)
+
+    def test_forward(self, input: tensor, rope_phi3: Phi3RotaryPositionalEmbeddings) -> None:
+        x_out = rope_phi3(input)
+
+        # check the numerics of the computed tensor
+        assert_expected(x_out.mean(), tensor(-0.0005), atol=1e-4)
+        assert_expected(x_out.sum(), tensor(-381.0620))
+
+        # check shapes
+        assert_expected(x_out.shape, input.shape)

--- a/tests/torchtune/modules/test_position_embeddings.py
+++ b/tests/torchtune/modules/test_position_embeddings.py
@@ -102,7 +102,9 @@ class TestRotaryPositionEmbedding:
 
 class TestPhi3RotaryPositionalEmbeddings:
     """
-
+    Class for testing the Phi3 models RoPE Embeddings. The expected tensors are
+    computed from the reference implementation here:
+    https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/modeling_phi3.py
     """
 
     @pytest.fixture

--- a/tests/torchtune/modules/test_position_embeddings.py
+++ b/tests/torchtune/modules/test_position_embeddings.py
@@ -11,9 +11,9 @@ import torch
 
 from tests.test_utils import assert_expected
 from torch import tensor
+from torchtune.models.phi3 import Phi3RotaryPositionalEmbeddings
 
 from torchtune.modules.position_embeddings import RotaryPositionalEmbeddings
-from torchtune.models.phi3 import Phi3RotaryPositionalEmbeddings
 from torchtune.utils.seed import set_seed
 
 
@@ -129,7 +129,9 @@ class TestPhi3RotaryPositionalEmbeddings:
         _, _, head_dim, _, max_seq_len = input_params
         return Phi3RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len)
 
-    def test_forward(self, input: tensor, rope_phi3: Phi3RotaryPositionalEmbeddings) -> None:
+    def test_forward(
+        self, input: tensor, rope_phi3: Phi3RotaryPositionalEmbeddings
+    ) -> None:
         x_out = rope_phi3(input)
 
         # check the numerics of the computed tensor

--- a/tests/torchtune/utils/test_checkpointer.py
+++ b/tests/torchtune/utils/test_checkpointer.py
@@ -161,7 +161,7 @@ class TestHFLlama2FullModelCheckpointer:
         return FullModelHFCheckpointer(
             checkpoint_dir=tmp_path,
             checkpoint_files=[checkpoint_file],
-            model_type=ModelType.LLAMA2,
+            model_type='LLAMA2',
             output_dir=tmp_path,
         )
 
@@ -173,7 +173,7 @@ class TestHFLlama2FullModelCheckpointer:
         return FullModelHFCheckpointer(
             checkpoint_dir=tmp_path,
             checkpoint_files=[checkpoint_file_1, checkpoint_file_2],
-            model_type=ModelType.LLAMA2,
+            model_type='LLAMA2',
             output_dir=tmp_path,
         )
 

--- a/tests/torchtune/utils/test_checkpointer.py
+++ b/tests/torchtune/utils/test_checkpointer.py
@@ -14,7 +14,7 @@ import torch
 from torch import randn
 
 from torchtune.models import llama2
-from torchtune.utils._checkpointing import FullModelHFCheckpointer, ModelType
+from torchtune.utils._checkpointing import FullModelHFCheckpointer
 from torchtune.utils._checkpointing._checkpointer_utils import safe_torch_load
 from torchtune.utils.seed import set_seed
 
@@ -161,7 +161,7 @@ class TestHFLlama2FullModelCheckpointer:
         return FullModelHFCheckpointer(
             checkpoint_dir=tmp_path,
             checkpoint_files=[checkpoint_file],
-            model_type='LLAMA2',
+            model_type="LLAMA2",
             output_dir=tmp_path,
         )
 
@@ -173,7 +173,7 @@ class TestHFLlama2FullModelCheckpointer:
         return FullModelHFCheckpointer(
             checkpoint_dir=tmp_path,
             checkpoint_files=[checkpoint_file_1, checkpoint_file_2],
-            model_type='LLAMA2',
+            model_type="LLAMA2",
             output_dir=tmp_path,
         )
 

--- a/torchtune/models/convert_weights.py
+++ b/torchtune/models/convert_weights.py
@@ -109,6 +109,7 @@ def tune_to_meta(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]
 
     return converted_state_dict
 
+
 def hf_to_tune(
     state_dict: Dict[str, torch.Tensor],
     num_heads: int = 32,

--- a/torchtune/models/convert_weights.py
+++ b/torchtune/models/convert_weights.py
@@ -45,7 +45,7 @@ _FROM_HF = {
 }
 
 
-def _get_mapped_key(key: str, mapping_dict: Dict[str, str]) -> str:
+def get_mapped_key(key: str, mapping_dict: Dict[str, str]) -> str:
     try:
         if "layers" in key:
             # Replace layer number with "{}" to create key for lookup
@@ -82,7 +82,7 @@ def meta_to_tune(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]
     converted_state_dict = {}
     for key, value in state_dict.items():
         if key not in ["rope.freqs"]:  # Skip loading the position embeddings
-            new_key = _get_mapped_key(key, _FROM_META)
+            new_key = get_mapped_key(key, _FROM_META)
             converted_state_dict[new_key] = value
 
     return converted_state_dict
@@ -104,11 +104,10 @@ def tune_to_meta(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]
     inverted_mapping_dict = {v: k for k, v in _FROM_META.items()}
 
     for key, value in state_dict.items():
-        new_key = _get_mapped_key(key, inverted_mapping_dict)
+        new_key = get_mapped_key(key, inverted_mapping_dict)
         converted_state_dict[new_key] = value
 
     return converted_state_dict
-
 
 def hf_to_tune(
     state_dict: Dict[str, torch.Tensor],
@@ -149,7 +148,7 @@ def hf_to_tune(
 
     for key, value in state_dict.items():
         if "rotary_emb.inv_freq" not in key:  # Skip loading the position embeddings
-            new_key = _get_mapped_key(key, _FROM_HF)
+            new_key = get_mapped_key(key, _FROM_HF)
             if "q_proj" in key:
                 value = _permute(value, num_heads)
             elif "k_proj" in key:
@@ -190,7 +189,7 @@ def tune_to_hf(
         )
 
     for key, value in state_dict.items():
-        new_key = _get_mapped_key(key, inverted_mapping_dict)
+        new_key = get_mapped_key(key, inverted_mapping_dict)
         if "q_proj" in key:
             value = _permute(value, num_heads)
         elif "k_proj" in key:

--- a/torchtune/models/phi3/__init__.py
+++ b/torchtune/models/phi3/__init__.py
@@ -1,0 +1,4 @@
+from ._component_builders import phi3
+from ._convert_weights import phi3_hf_to_tune, phi3_tune_to_hf
+from ._model_builders import phi3_mini
+from ._position_embeddings import Phi3RotaryPositionalEmbeddings

--- a/torchtune/models/phi3/__init__.py
+++ b/torchtune/models/phi3/__init__.py
@@ -1,4 +1,10 @@
-from ._component_builders import phi3
-from ._convert_weights import phi3_hf_to_tune, phi3_tune_to_hf
-from ._model_builders import phi3_mini, phi3_tokenizer
-from ._position_embeddings import Phi3RotaryPositionalEmbeddings
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ._component_builders import phi3  # noqa
+from ._convert_weights import phi3_hf_to_tune, phi3_tune_to_hf  # noqa
+from ._model_builders import phi3_mini, phi3_tokenizer  # noqa
+from ._position_embeddings import Phi3RotaryPositionalEmbeddings  # noqa

--- a/torchtune/models/phi3/__init__.py
+++ b/torchtune/models/phi3/__init__.py
@@ -1,4 +1,4 @@
 from ._component_builders import phi3
 from ._convert_weights import phi3_hf_to_tune, phi3_tune_to_hf
-from ._model_builders import phi3_mini
+from ._model_builders import phi3_mini, phi3_tokenizer
 from ._position_embeddings import Phi3RotaryPositionalEmbeddings

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -7,6 +7,7 @@ from torchtune.modules import (
     CausalSelfAttention,
     FeedForward,
     RMSNorm,
+    RotaryPositionalEmbeddings,
     TransformerDecoder,
     TransformerDecoderLayer,
 )
@@ -61,6 +62,7 @@ def phi3(
     num_kv_heads = num_kv_heads if num_kv_heads else num_heads
 
     rope = Phi3RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
+    # rope = RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
     self_attn = CausalSelfAttention(
         embed_dim=embed_dim,
         num_heads=num_heads,

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -14,9 +14,9 @@ from torchtune.modules import (
 from torchtune.modules.peft import LORA_ATTN_MODULES, LoRALinear
 
 """
-Component builders for the Mistral 7B models and popular variants such as LoRA.
+Component builders for the Phi3 4K Mini Instruct model.
 
-TorchTune provides composable building blocks. Builder functions help
+torchtune provides composable building blocks. Builder functions help
 stitch these building blocks into higher-level components. This design has
 two benefits:
 - The building blocks themselves are very flexible. For example, ``CausalSelfAttention``
@@ -38,15 +38,6 @@ def phi3(
     rope_base: int = 10_000,
 ) -> TransformerDecoder:
     """
-    Build the decoder assoicated with the mistral model. This includes:
-    - Token embeddings
-    - num_layers number of TransformerDecoderLayer blocks
-    - RMS Norm layer applied to the output of the transformer
-    - Final projection into token space
-
-    This does NOT currently include inference-time optimizations such as
-    sliding-window attention
-
     Args:
         vocab_size (int): number of tokens in vocabulary.
         num_layers (int): number of layers in the transformer decoder.
@@ -64,7 +55,7 @@ def phi3(
         rope_base (int): base for the rotary positional embeddings. Default: 10_000
 
     Returns:
-        TransformerDecoder: Instantiation of mistral model.
+        TransformerDecoder: Instantiation of Phi3 Mini 4K Instruct model.
     """
     head_dim = embed_dim // num_heads
     num_kv_heads = num_kv_heads if num_kv_heads else num_heads
@@ -106,7 +97,7 @@ def phi3(
 
 def phi3_mlp(dim: int, hidden_dim: int) -> FeedForward:
     """
-    Build the MLP layer associated with the Mistral model.
+    Build the MLP layer associated with the Phi3 Mini 4K Instruct model.
     """
     gate_proj = nn.Linear(dim, hidden_dim, bias=False)
     down_proj = nn.Linear(hidden_dim, dim, bias=False)

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -1,0 +1,114 @@
+from typing import List
+
+from torch import nn
+
+from torchtune.models.phi3._position_embeddings import Phi3RotaryPositionalEmbeddings
+from torchtune.modules import (
+    CausalSelfAttention,
+    FeedForward,
+    RMSNorm,
+    TransformerDecoder,
+    TransformerDecoderLayer,
+)
+
+from torchtune.modules.peft import LORA_ATTN_MODULES, LoRALinear
+
+"""
+Component builders for the Mistral 7B models and popular variants such as LoRA.
+
+TorchTune provides composable building blocks. Builder functions help
+stitch these building blocks into higher-level components. This design has
+two benefits:
+- The building blocks themselves are very flexible. For example, ``CausalSelfAttention``
+can take either nn.Linear or nn.LoRALinear for ``q_proj``.
+- Builder functions expose a set of configurable params which keep the constructors of
+the building blocks simple.
+"""
+
+def phi3(
+    vocab_size: int,
+    num_layers: int,
+    num_heads: int,
+    num_kv_heads: int,
+    embed_dim: int,
+    intermediate_dim: int,
+    max_seq_len: int,
+    attn_dropout: float = 0.0,
+    norm_eps: float = 1e-5,
+    rope_base: int = 10_000,
+) -> TransformerDecoder:
+    """
+    Build the decoder assoicated with the mistral model. This includes:
+    - Token embeddings
+    - num_layers number of TransformerDecoderLayer blocks
+    - RMS Norm layer applied to the output of the transformer
+    - Final projection into token space
+
+    This does NOT currently include inference-time optimizations such as
+    sliding-window attention
+
+    Args:
+        vocab_size (int): number of tokens in vocabulary.
+        num_layers (int): number of layers in the transformer decoder.
+        num_heads (int): number of query heads. For MHA this is also the
+            number of heads for key and value
+        num_kv_heads (int): number of key and value heads. If specified,
+            user should ensure `num_heads` % `num_kv_heads` == 0. Default value is
+            `None`, in which case this is the same as MHA
+        embed_dim (int): embedding dimension for self-attention
+        intermediate_dim (int): intermediate dimension for MLP
+        max_seq_len (int): maximum sequence length the model will be run with,
+        attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
+            Default: 0.0
+        norm_eps (float): epsilon in RMS norms
+        rope_base (int): base for the rotary positional embeddings. Default: 10_000
+
+    Returns:
+        TransformerDecoder: Instantiation of mistral model.
+    """
+    head_dim = embed_dim // num_heads
+    num_kv_heads = num_kv_heads if num_kv_heads else num_heads
+
+    rope = Phi3RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
+    self_attn = CausalSelfAttention(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        q_proj=nn.Linear(embed_dim, num_heads * head_dim, bias=False),
+        k_proj=nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False),
+        v_proj=nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False),
+        output_proj=nn.Linear(embed_dim, embed_dim, bias=False),
+        pos_embeddings=rope,
+        kv_cache=None,
+        max_seq_len=max_seq_len,
+        attn_dropout=attn_dropout,
+    )
+    mlp = phi3_mlp(dim=embed_dim, hidden_dim=intermediate_dim)
+    layer = TransformerDecoderLayer(
+        attn=self_attn,
+        mlp=mlp,
+        sa_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
+        mlp_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
+    )
+    tok_embeddings = nn.Embedding(vocab_size, embed_dim)
+    output_proj = nn.Linear(embed_dim, vocab_size, bias=False)
+    return TransformerDecoder(
+        tok_embeddings=tok_embeddings,
+        layer=layer,
+        num_layers=num_layers,
+        max_seq_len=max_seq_len,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        norm=RMSNorm(embed_dim, eps=norm_eps),
+        output=output_proj,
+    )
+
+def phi3_mlp(dim: int, hidden_dim: int) -> FeedForward:
+    """
+    Build the MLP layer associated with the Mistral model.
+    """
+    gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+    down_proj = nn.Linear(hidden_dim, dim, bias=False)
+    up_proj = nn.Linear(dim, hidden_dim, bias=False)
+    return FeedForward(gate_proj=gate_proj, down_proj=down_proj, up_proj=up_proj)

--- a/torchtune/models/phi3/_convert_weights.py
+++ b/torchtune/models/phi3/_convert_weights.py
@@ -1,10 +1,14 @@
-import re
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Dict
 
-from torchtune.models.convert_weights import get_mapped_key
-
 import torch
+
+from torchtune.models.convert_weights import get_mapped_key
 
 
 _PHI3_MINI = {
@@ -19,6 +23,7 @@ _PHI3_MINI = {
     "lm_head.weight": "output.weight",
 }
 
+
 def phi3_hf_to_tune(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
     """
     Convertor from HF state dict to torchtune state dict. This handles:
@@ -30,14 +35,18 @@ def phi3_hf_to_tune(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tens
     for key, value in state_dict.items():
         new_key = get_mapped_key(key, _PHI3_MINI)
         if "qkv" in key:
-            q, k, v, = value.chunk(3, dim=0)
+            (
+                q,
+                k,
+                v,
+            ) = value.chunk(3, dim=0)
             converted_state_dict[new_key] = q
-            converted_state_dict[new_key.replace('q_proj', 'k_proj')] = k
-            converted_state_dict[new_key.replace('q_proj', 'v_proj')] = v
+            converted_state_dict[new_key.replace("q_proj", "k_proj")] = k
+            converted_state_dict[new_key.replace("q_proj", "v_proj")] = v
         elif "gate" in key:
             w1, w3 = value.chunk(2, dim=0)
             converted_state_dict[new_key] = w1
-            converted_state_dict[new_key.replace('w1', 'w3')] = w3
+            converted_state_dict[new_key.replace("w1", "w3")] = w3
         else:
             converted_state_dict[new_key] = value
     return converted_state_dict
@@ -53,26 +62,22 @@ def phi3_tune_to_hf(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tens
     inverted_mapping_dict = {v: k for k, v in _PHI3_MINI.items()}
 
     for key, value in state_dict.items():
-        if (
-            "k_proj" in key or
-            "v_proj" in key or
-            "w3" in key
-        ):
+        if "k_proj" in key or "v_proj" in key or "w3" in key:
             # these keys are accounted for separately and should be skipped
             continue
         new_key = get_mapped_key(key, inverted_mapping_dict)
 
         if "q_proj" in key:
             q = value
-            k = state_dict[key.replace('q_proj', 'k_proj')]
-            v = state_dict[key.replace('q_proj', 'v_proj')]
+            k = state_dict[key.replace("q_proj", "k_proj")]
+            v = state_dict[key.replace("q_proj", "v_proj")]
             qkv = torch.cat([q, k, v], dim=0)
             # q_proj maps to qkv_proj; no need to string replace
             converted_state_dict[new_key] = qkv
 
         elif "w1" in key:
             gate_proj = value
-            up_proj = state_dict[key.replace('w1', 'w3')]
+            up_proj = state_dict[key.replace("w1", "w3")]
             gate_up_proj = torch.cat([gate_proj, up_proj], dim=0)
             # w1 maps to gate_up_proj; no need to string replace
             converted_state_dict[new_key] = gate_up_proj

--- a/torchtune/models/phi3/_convert_weights.py
+++ b/torchtune/models/phi3/_convert_weights.py
@@ -1,0 +1,76 @@
+import re
+
+from typing import Dict
+
+from torchtune.models.convert_weights import get_mapped_key
+
+import torch
+
+
+_PHI3_MINI = {
+    "model.embed_tokens.weight": "tok_embeddings.weight",
+    "model.layers.{}.self_attn.qkv_proj.weight": "layers.{}.attn.q_proj.weight",
+    "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attn.output_proj.weight",
+    "model.layers.{}.mlp.gate_up_proj.weight": "layers.{}.mlp.w1.weight",
+    "model.layers.{}.mlp.down_proj.weight": "layers.{}.mlp.w2.weight",
+    "model.layers.{}.input_layernorm.weight": "layers.{}.sa_norm.scale",
+    "model.layers.{}.post_attention_layernorm.weight": "layers.{}.mlp_norm.scale",
+    "model.norm.weight": "norm.scale",
+    "lm_head.weight": "output.weight",
+}
+
+def phi3_hf_to_tune(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """
+    """
+    converted_state_dict = {}
+
+    for key, value in state_dict.items():
+        new_key = get_mapped_key(key, _PHI3_MINI)
+        if "qkv" in key:
+            q, k, v, = value.chunk(3, dim=0)
+            converted_state_dict[new_key] = q
+            converted_state_dict[new_key.replace('q_proj', 'k_proj')] = k
+            converted_state_dict[new_key.replace('q_proj', 'v_proj')] = v
+        elif "gate" in key:
+            w1, w3 = value.chunk(2, dim=0)
+            converted_state_dict[new_key] = w1
+            converted_state_dict[new_key.replace('w1', 'w3')] = w3
+        else:
+            converted_state_dict[new_key] = value
+    return converted_state_dict
+
+
+def phi3_tune_to_hf(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """
+    """
+    converted_state_dict = {}
+    inverted_mapping_dict = {v: k for k, v in _PHI3_MINI.items()}
+
+    for key, value in state_dict.items():
+        if (
+            "k_proj" in key or
+            "v_proj" in key or
+            "w3" in key
+        ):
+            # these keys are accounted for separately and should be skipped
+            continue
+        new_key = get_mapped_key(key, inverted_mapping_dict)
+
+        if "q_proj" in key:
+            q = value
+            k = state_dict[key.replace('q_proj', 'k_proj')]
+            v = state_dict[key.replace('q_proj', 'v_proj')]
+            qkv = torch.cat([q, k, v], dim=0)
+            # q_proj maps to qkv_proj; no need to string replace
+            converted_state_dict[new_key] = qkv
+
+        elif "w1" in key:
+            gate_proj = value
+            up_proj = state_dict[key.replace('w1', 'w3')]
+            gate_up_proj = torch.cat([gate_proj, up_proj], dim=0)
+            # w1 maps to gate_up_proj; no need to string replace
+            converted_state_dict[new_key] = gate_up_proj
+
+        else:
+            converted_state_dict[new_key] = value
+    return converted_state_dict

--- a/torchtune/models/phi3/_convert_weights.py
+++ b/torchtune/models/phi3/_convert_weights.py
@@ -21,6 +21,9 @@ _PHI3_MINI = {
 
 def phi3_hf_to_tune(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
     """
+    Convertor from HF state dict to torchtune state dict. This handles:
+    - Splitting the fused q,k and v matrix
+    - Splitting the fused gate and up projection matrix
     """
     converted_state_dict = {}
 
@@ -42,6 +45,9 @@ def phi3_hf_to_tune(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tens
 
 def phi3_tune_to_hf(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
     """
+    Convertor from torchtune state dict to HF state dict. This handles:
+    - Fusing q,k and v matrix
+    - Fusing gate and up projection matrix
     """
     converted_state_dict = {}
     inverted_mapping_dict = {v: k for k, v in _PHI3_MINI.items()}

--- a/torchtune/models/phi3/_model_builders.py
+++ b/torchtune/models/phi3/_model_builders.py
@@ -18,12 +18,11 @@ the ``mistral_7b`` model builder uses the ``mistral`` component builder.
 
 def phi3_mini() -> TransformerDecoder:
     """
-    Builder for creating a Mistral 7B model initialized w/ the default 7b parameter values
-    from https://mistral.ai/news/announcing-mistral-7b/
-
+    Builder for creating the Phi3 Mini 4K Instruct Model.
+    Ref: https://huggingface.co/microsoft/Phi-3-mini-4k-instruct
 
     Returns:
-        TransformerDecoder: Instantiation of Mistral 7B model
+        TransformerDecoder: Instantiation of Phi3 Mini 4K Instruct Model
     """
     return phi3(
         vocab_size=32_064,
@@ -39,6 +38,5 @@ def phi3_mini() -> TransformerDecoder:
 
 def phi3_tokenizer(path: str) -> SentencePieceTokenizer:
     tokenizer = SentencePieceTokenizer(path)
-    # Original tokenizer has no pad_id, which causes indexing errors when batch training
     tokenizer.pad_id = 32000
     return tokenizer

--- a/torchtune/models/phi3/_model_builders.py
+++ b/torchtune/models/phi3/_model_builders.py
@@ -1,0 +1,44 @@
+from typing import List
+
+from torchtune.models.phi3._component_builders import phi3
+
+from torchtune.modules import TransformerDecoder
+from torchtune.modules.tokenizers import SentencePieceTokenizer
+from torchtune.modules.peft import LORA_ATTN_MODULES
+from functools import partial
+
+import torch
+
+
+"""
+Model builders build specific instantiations using component builders. For example
+the ``mistral_7b`` model builder uses the ``mistral`` component builder.
+"""
+
+
+def phi3_mini() -> TransformerDecoder:
+    """
+    Builder for creating a Mistral 7B model initialized w/ the default 7b parameter values
+    from https://mistral.ai/news/announcing-mistral-7b/
+
+
+    Returns:
+        TransformerDecoder: Instantiation of Mistral 7B model
+    """
+    return phi3(
+        vocab_size=32_064,
+        num_layers=32,
+        num_heads=32,
+        num_kv_heads=32,
+        embed_dim=3072,
+        intermediate_dim=8192,
+        max_seq_len=4096,
+        attn_dropout=0.0,
+        norm_eps=1e-5,
+    )
+
+def phi3_tokenizer(path: str) -> SentencePieceTokenizer:
+    tokenizer = SentencePieceTokenizer(path)
+    # Original tokenizer has no pad_id, which causes indexing errors when batch training
+    tokenizer.pad_id = 32000
+    return tokenizer

--- a/torchtune/models/phi3/_model_builders.py
+++ b/torchtune/models/phi3/_model_builders.py
@@ -12,7 +12,7 @@ import torch
 
 """
 Model builders build specific instantiations using component builders. For example
-the ``mistral_7b`` model builder uses the ``mistral`` component builder.
+the ``phi3_mini`` model builder uses the ``phi3`` component builder.
 """
 
 
@@ -38,5 +38,5 @@ def phi3_mini() -> TransformerDecoder:
 
 def phi3_tokenizer(path: str) -> SentencePieceTokenizer:
     tokenizer = SentencePieceTokenizer(path)
-    tokenizer.pad_id = 32000
+    tokenizer.pad_id = 0
     return tokenizer

--- a/torchtune/models/phi3/_position_embeddings.py
+++ b/torchtune/models/phi3/_position_embeddings.py
@@ -21,7 +21,7 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
 
     Args:
         dim (int): Embedding dimension. This is usually set to the dim of each
-            head in the attention module computed as ````embed_dim`` // ``num_heads````
+            head in the attention module computed as ``embed_dim`` // ``num_heads``
         max_seq_len (int): Maximum expected sequence length for the
             model, if exceeded the cached freqs will be recomputed
         base (int): The base for the geometric progression used to compute
@@ -89,9 +89,15 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
         seq_len = x.size(1)
         head_dim = x.size(-1)
 
+        # extract the values based on whether input_pos is set or not. When
+        # input_pos is provided, we're in inference mode
+        rope_cache = (
+            self.cache[:seq_len] if input_pos is None else self.cache[input_pos]
+        )
+
         # [s, h_d]
-        cos = self.cache[:seq_len, :head_dim]
-        sin = self.cache[:seq_len, head_dim:]
+        cos = rope_cache[:, :head_dim]
+        sin = rope_cache[:, head_dim:]
 
         x1 = x[..., : x.shape[-1] // 2]
         x2 = x[..., x.shape[-1] // 2 :]

--- a/torchtune/models/phi3/_position_embeddings.py
+++ b/torchtune/models/phi3/_position_embeddings.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+
+from torch import nn, Tensor
+
+class Phi3RotaryPositionalEmbeddings(nn.Module):
+    """
+
+
+    Args:
+        dim (int): Embedding dimension. This is usually set to the dim of each
+            head in the attention module computed as ````embed_dim`` // ``num_heads````
+        max_seq_len (int): Maximum expected sequence length for the
+            model, if exceeded the cached freqs will be recomputed
+        base (int): The base for the geometric progression used to compute
+            the rotation angles
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        max_seq_len: int = 4096,
+        base: int = 10_000,
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.max_seq_len = max_seq_len
+        self._rope_init()
+
+    def _rope_init(self):
+        theta = 1.0 / (
+            self.base
+            ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim)
+        )
+        self.register_buffer("theta", theta, persistent=False)
+        self.build_rope_cache(self.max_seq_len)
+
+    def build_rope_cache(self, max_seq_len: int = 4096) -> None:
+        # Create position indexes `[0, 1, ..., max_seq_len - 1]`
+        seq_idx = torch.arange(
+            max_seq_len, dtype=self.theta.dtype, device=self.theta.device
+        )
+
+        # Outer product of theta and position index; output tensor has
+        # a shape of [max_seq_len, dim // 2]
+        idx_theta = torch.einsum("i, j -> ij", seq_idx, self.theta).float()
+
+        # # cache includes both the cos and sin components and so the output shape is
+        # # [max_seq_len, dim // 2, 2]
+        # cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
+        freqs = torch.cat([idx_theta, idx_theta], dim=-1)
+        cache = torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+        self.register_buffer("cache", cache, persistent=False)
+
+    def forward(self, x: Tensor, input_pos: Optional[Tensor] = None) -> Tensor:
+        """
+        Args:
+            x (Tensor): input tensor with shape
+                [bsz, seq_len, num_heads, head_dim]
+            input_pos (Optional[Tensor]): Optional tensor which contains the position
+                of the current token. This is only used during inference. Default is None
+
+        Returns:
+            Tensor: output tensor with RoPE applied
+
+        Notation used for tensor shapes:
+            - b: batch size
+            - s: sequence length
+            - n_h: num heads
+            - h_d: head dim
+
+        TODO: The implementation below can be made more efficient
+        for inference.
+        """
+        # input tensor has shape [b, s, n_h, n_d]
+        seq_len = x.size(1)
+        head_dim = x.size(-1)
+
+        # [s, h_d]
+        cos = self.cache[:seq_len, :head_dim]
+        sin = self.cache[:seq_len, head_dim:]
+
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        rotated = torch.cat((-x2, x1), dim=-1)
+
+        x_out = (x.transpose(1,2) * cos) + (rotated.transpose(1,2) * sin)
+        return x_out.transpose(1,2).type_as(x)

--- a/torchtune/models/phi3/_position_embeddings.py
+++ b/torchtune/models/phi3/_position_embeddings.py
@@ -10,6 +10,7 @@ import torch
 
 from torch import nn, Tensor
 
+
 class Phi3RotaryPositionalEmbeddings(nn.Module):
     """
     RoPE Embeddings used in the Phi3 model.
@@ -100,5 +101,5 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
         # x: [b, s, n_h, n_d]
         # For the matrix multiplication to line up, transpose the input
         # and the rotated input
-        x_out = (x.transpose(1,2) * cos) + (rotated.transpose(1,2) * sin)
-        return x_out.transpose(1,2).type_as(x)
+        x_out = (x.transpose(1, 2) * cos) + (rotated.transpose(1, 2) * sin)
+        return x_out.transpose(1, 2).type_as(x)

--- a/torchtune/models/phi3/_position_embeddings.py
+++ b/torchtune/models/phi3/_position_embeddings.py
@@ -85,7 +85,7 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
         TODO: The implementation below can be made more efficient
         for inference.
         """
-        # input tensor has shape [b, s, n_h, n_d]
+        # input tensor has shape [b, s, n_h, h_d]
         seq_len = x.size(1)
         head_dim = x.size(-1)
 
@@ -104,7 +104,7 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
         rotated = torch.cat((-x2, x1), dim=-1)
 
         # cos: [s, h_d]
-        # x: [b, s, n_h, n_d]
+        # x: [b, s, n_h, h_d]
         # For the matrix multiplication to line up, transpose the input
         # and the rotated input
         x_out = (x.transpose(1, 2) * cos) + (rotated.transpose(1, 2) * sin)

--- a/torchtune/utils/_checkpointing/_checkpointer_utils.py
+++ b/torchtune/utils/_checkpointing/_checkpointer_utils.py
@@ -19,10 +19,12 @@ from torchtune.utils._distributed import contains_fsdp
 
 
 class ModelType(Enum):
-    LLAMA2 = "llama2"
-    MISTRAL = "mistral"
     GEMMA = "gemma"
+    LLAMA2 = "llama2"
     LLAMA3 = "llama3"
+    MISTRAL = "mistral"
+    PHI3_MINI = "phi3_mini"
+
 
 
 def get_path(input_dir: Path, filename: str, missing_ok: bool = False) -> Path:

--- a/torchtune/utils/_checkpointing/_checkpointer_utils.py
+++ b/torchtune/utils/_checkpointing/_checkpointer_utils.py
@@ -26,7 +26,6 @@ class ModelType(Enum):
     PHI3_MINI = "phi3_mini"
 
 
-
 def get_path(input_dir: Path, filename: str, missing_ok: bool = False) -> Path:
     """
     Utility to recover and validate the path for a given file within a given directory.


### PR DESCRIPTION
Imp Note: The tokenizer still needs some work, this will be a follow up PR.

#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog

This PR adds support for the Phi3 Mini 4K Instruct model to torchtune. Specifically we add the following:
- Phi3's RoPE module. This is not numerically equivalent to the Llama2 or Llama3 models and care needs to be taken to have correct behavior for bf16 training
- State dict conversion logic accounting for the fused qkv and gate_up projection matrices
- Config for multi-gpu full finetuning

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)


Unit Tests

Detailed comparisons with [reference implementation](https://gist.github.com/kartikayk/87db294c9c9791622140cf4c9dc5a628)

```
pytest tests/torchtune
```

Full-finetune Recipe

<img width="1231" alt="Screenshot 2024-04-25 at 7 57 45 PM" src="https://github.com/pytorch/torchtune/assets/47255723/f8d20fae-4cd9-487f-a5a4-6839d549370c">

