### PR TITLE
Add support for 8da4w quantization

### DIFF
--- a/recipes/quantize.py
+++ b/recipes/quantize.py
@@ -46,6 +46,14 @@ class QuantizationRecipe:
                 larger blocks trade off memory for perf, recommended to be a constant
                 multiple of groupsize.
             `percdamp`: GPTQ stablization hyperparameter, recommended to be .01
+
+    8da4w:
+        torchtune.utils.quantization.Int8DynActInt4WeightQuantizer
+        int8 per token dynamic activation with int4 weight only per axis group quantization
+        Args:
+            `groupsize` (int): a parameter of int4 weight only quantization,
+            it refers to the size of quantization groups which get independent quantization parameters
+            e.g. 32, 64, 128, 256, smaller numbers means more fine grained and higher accuracy
     """
 
     def __init__(self, cfg: DictConfig) -> None:

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -11,6 +11,7 @@ from torchao.quantization.quant_api import (
     apply_weight_only_int8_quant,
     Int4WeightOnlyGPTQQuantizer,
     Int4WeightOnlyQuantizer,
+    Int8DynActInt4WeightQuantizer,
     Quantizer,
 )
 
@@ -18,6 +19,7 @@ __all__ = [
     "Int4WeightOnlyQuantizer",
     "Int4WeightOnlyGPTQQuantizer",
     "Int8WeightOnlyQuantizer",
+    "Int8DynActInt4WeightQuantizer",
     "get_quantizer_mode",
 ]
 
@@ -34,6 +36,7 @@ _quantizer_to_mode = {
     Int4WeightOnlyQuantizer: "4w",
     Int8WeightOnlyQuantizer: "8w",
     Int4WeightOnlyGPTQQuantizer: "4w-gptq",
+    Int8DynActInt4WeightQuantizer: "8da4w",
 }
 
 


### PR DESCRIPTION
Summary: Add a new quantization for users to quantize their models using int8 per token dynamic activation + int4 per axis grouped weight quantization.

Test Plan:
```
tune run quantize --config quantization \
    quantizer._component_=torchtune.utils.quantization.Int8DynActInt4WeightQuantizer \
    quantizer.groupsize=256

tune run eleuther_eval --config eleuther_eval \
    checkpointer._component_=torchtune.utils.FullModelTorchTuneCheckpointer \
    checkpointer.checkpoint_files=[hf_model_0001_2-8da4w.pt] \
    quantizer._component_=torchtune.utils.quantization.Int8DynActInt4WeightQuantizer \
    quantizer.groupsize=256
```

Quantize output:
```
2024-04-26:13:09:20,852 INFO     [quantize.py:98] Time for quantization: 7.49 sec
2024-04-26:13:09:20,852 INFO     [quantize.py:99] Memory used: 15.30 GB
2024-04-26:13:09:27,625 INFO     [quantize.py:112] Model checkpoint of size 7.08 GB saved to /home/andrewor/logs/tune/saved-4-25/full_1713990537_complete/quantize_output/hf_model_0001_2-8da4w.pt
```

Eval output:
```
100%|██████████| 5882/5882 [17:05<00:00,  5.74it/s]
2024-04-26:13:50:47,214 INFO     [eleuther_eval.py:196] Eval completed in 1040.88 seconds.
2024-04-26:13:50:47,214 INFO     [eleuther_eval.py:198] truthfulqa_mc2: {'acc,none': 0.4578906989909618, 'acc_stderr,none': 0.01542454257740726, 'alias': 'truthfulqa_mc2'}
```

Reviewers: jerryzh168, kartikayk, ebsmothers

Subscribers: jerryzh168, kartikayk, ebsmothers, supriyar