### PR TITLE
Remove unused imports in models/__init__.py

### DIFF
--- a/torchtune/models/__init__.py
+++ b/torchtune/models/__init__.py
@@ -3,11 +3,3 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
-from torchtune.models import (  # noqa
-    code_llama2,
-    convert_weights,
-    gemma,
-    llama2,
-    mistral,
-)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other: clean up code

Please link to any issues this PR addresses.

#### Changelog
- Remove imports from `torchtune/models/__init__.py`. They aren't really needed since they are just importing directories that are already public and accessible, and it just causes a bit more friction adding each new model directory to this file.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)


Ran the following: 

```
>>> from torchtune.models import llama2
>>> llama2
<module 'torchtune.models.llama2' from '/data/users/ebs/ebs-torchtune/torchtune/models/llama2/__init__.py'>

>>> from torchtune.models.llama2 import llama2_7b
>>> llama2_7b
<function llama2_7b at 0x7fed49a40f70>
```

The results are the same with and without the imports in the `__init__.py`.