### PR TITLE
Remove recipe_state from eleuther config

### DIFF
--- a/recipes/configs/eleuther_evaluation.yaml
+++ b/recipes/configs/eleuther_evaluation.yaml
@@ -14,7 +14,6 @@ checkpointer:
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin,
   ]
-  recipe_checkpoint: null
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

[Please link to any issues this PR addresses.
](https://github.com/pytorch/torchtune/issues/899)
#### Changelog

- Removes `recipe_state` from the eleuther config, as we only need to work with final finetuned model checkpoints and not intermediate checkpoints. This simplifies the config - ideally we'd also remove the `output_dir` as we're not saving checkpoints, but this is required to instantiate the checkpointer. 

#### Test plan
Run eval: `tune run eleuther_eval --config eleuther_evaluation che
ckpointer=torchtune.utils.FullModelMetaCheckpointer checkpointer.checkpoint_files=["m
eta_model_0.pt"] checkpointer.checkpoint_dir=/tmp/tt-compile-out/`
