### PR TITLE
Remove non-existant objects from `__all__`

### DIFF
--- a/torchtune/modules/peft/__init__.py
+++ b/torchtune/modules/peft/__init__.py
@@ -19,7 +19,6 @@ __all__ = [
     "AdapterModule",
     "get_adapter_params",
     "set_trainable_params",
-    "validate_missing_and_unexpected_for_lora",
     "validate_state_dict_for_lora",
     "disable_adapter",
 ]

--- a/torchtune/modules/peft/__init__.py
+++ b/torchtune/modules/peft/__init__.py
@@ -11,6 +11,7 @@ from .peft_utils import (  # noqa
     get_adapter_params,
     LORA_ATTN_MODULES,
     set_trainable_params,
+    validate_missing_and_unexpected_for_lora,
     validate_state_dict_for_lora,
 )
 
@@ -19,6 +20,7 @@ __all__ = [
     "AdapterModule",
     "get_adapter_params",
     "set_trainable_params",
+    "validate_missing_and_unexpected_for_lora",
     "validate_state_dict_for_lora",
     "disable_adapter",
 ]

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -56,9 +56,7 @@ from .quantization import get_quantizer_mode
 from .seed import set_seed
 
 __all__ = [
-    "save_checkpoint",
     "transform_opt_state_dict",
-    "validate_checkpoint",
     "get_memory_stats",
     "log_memory_stats",
     "get_device",
@@ -77,7 +75,6 @@ __all__ = [
     "validate_expected_param_dtype",
     "wrap_compile",
     "TuneRecipeArgumentParser",
-    "CheckpointableDataLoader",
     "OptimizerInBackwardWrapper",
     "create_optim_in_bwd_wrapper",
     "register_optim_in_bwd_hooks",


### PR DESCRIPTION
A couple of objects are listed in `__all__` but can't be found in the lib