### PR TITLE
total_training_steps -> global_step

### DIFF
--- a/docs/source/deep_dives/recipe_deepdive.rst
+++ b/docs/source/deep_dives/recipe_deepdive.rst
@@ -176,7 +176,7 @@ Run forward and backward across all epochs and save checkpoint at end of each ep
                     ...
                     loss = self._loss_fn(logits, labels)
 
-                if self.total_training_steps % self._log_every_n_steps == 0:
+                if self.global_step % self._log_every_n_steps == 0:
                     self._metric_logger.log_dict(...)
 
                 loss.backward()
@@ -184,7 +184,7 @@ Run forward and backward across all epochs and save checkpoint at end of each ep
                 self._optimizer.zero_grad()
 
                 # Update the number of steps when the weights are updated
-                self.total_training_steps += 1
+                self.global_step += 1
 
             self.save_checkpoint(epoch=curr_epoch)
 

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -124,7 +124,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
-        self.total_training_steps = 0
+        self.global_step = 0
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -227,7 +227,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             and self.max_steps_per_epoch < self._steps_per_epoch
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
-        self.total_training_steps = self.epochs_run * self._steps_per_epoch
+        self.global_step = self.epochs_run * self._steps_per_epoch
 
     def _setup_model(
         self,
@@ -483,17 +483,17 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     self._optimizer.zero_grad(set_to_none=True)
 
                     # Update the number of steps when the weights are updated
-                    self.total_training_steps += 1
+                    self.global_step += 1
 
                     loss_to_log = running_loss.item()
                     pbar.update(1)
                     pbar.set_description(
-                        f"{curr_epoch+1}|{self.total_training_steps}|Loss: {loss_to_log}"
+                        f"{curr_epoch+1}|{self.global_step}|Loss: {loss_to_log}"
                     )
 
                     # Log per-step metrics
                     if (
-                        self.total_training_steps % self._log_every_n_steps == 0
+                        self.global_step % self._log_every_n_steps == 0
                         and self._is_rank_zero
                     ):
                         time_per_step = time.perf_counter() - t0
@@ -506,7 +506,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                             log_dict.update(utils.get_memory_stats(device=self._device))
                         self._metric_logger.log_dict(
                             log_dict,
-                            step=self.total_training_steps,
+                            step=self.global_step,
                         )
 
                     # Reset running stats for the next step

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -133,7 +133,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
-        self.total_training_steps = 0
+        self.global_step = 0
 
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
@@ -250,14 +250,14 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             and self.max_steps_per_epoch < self._steps_per_epoch
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
-        self.total_training_steps = self.epochs_run * self._steps_per_epoch
+        self.global_step = self.epochs_run * self._steps_per_epoch
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
             cfg_lr_scheduler=cfg.lr_scheduler,
             num_training_steps=self.total_epochs * self._steps_per_epoch,
-            last_epoch=self.total_training_steps - 1,
+            last_epoch=self.global_step - 1,
         )
 
     def _setup_model(
@@ -646,17 +646,17 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     self._lr_scheduler.step()
 
                     # Update the number of steps when the weights are updated
-                    self.total_training_steps += 1
+                    self.global_step += 1
 
                     loss_to_log = running_loss.item()
                     pbar.update(1)
                     pbar.set_description(
-                        f"{curr_epoch+1}|{self.total_training_steps}|Loss: {loss_to_log}"
+                        f"{curr_epoch+1}|{self.global_step}|Loss: {loss_to_log}"
                     )
 
                     # Log per-step metrics
                     if (
-                        self.total_training_steps % self._log_every_n_steps == 0
+                        self.global_step % self._log_every_n_steps == 0
                         and self._is_rank_zero
                     ):
                         time_per_step = time.perf_counter() - t0
@@ -685,7 +685,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                             log_dict.update(utils.get_memory_stats(device=self._device))
                         self._metric_logger.log_dict(
                             log_dict,
-                            step=self.total_training_steps,
+                            step=self.global_step,
                         )
 
                     # Reset running stats for the next step

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -95,7 +95,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
-        self.total_training_steps = 0
+        self.global_step = 0
 
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
@@ -201,14 +201,14 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             and self.max_steps_per_epoch < self._steps_per_epoch
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
-            self.total_training_steps = self.epochs_run * self._steps_per_epoch
+            self.global_step = self.epochs_run * self._steps_per_epoch
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
             cfg_lr_scheduler=cfg.lr_scheduler,
             num_training_steps=self.total_epochs * self._steps_per_epoch,
-            last_epoch=self.total_training_steps - 1,
+            last_epoch=self.global_step - 1,
         )
 
     def _setup_model(
@@ -501,16 +501,16 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                     self._optimizer.zero_grad(set_to_none=True)
                     self._lr_scheduler.step()
                     # Update the number of steps when the weights are updated
-                    self.total_training_steps += 1
+                    self.global_step += 1
 
                     loss_to_log = running_loss.item()
                     pbar.update(1)
                     pbar.set_description(
-                        f"{curr_epoch+1}|{self.total_training_steps}|Loss: {loss_to_log}"
+                        f"{curr_epoch+1}|{self.global_step}|Loss: {loss_to_log}"
                     )
 
                     # Log per-step metrics
-                    if self.total_training_steps % self._log_every_n_steps == 0:
+                    if self.global_step % self._log_every_n_steps == 0:
                         time_per_step = time.perf_counter() - t0
                         log_dict = {
                             "loss": loss_to_log,
@@ -537,7 +537,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                             log_dict.update(utils.get_memory_stats(device=self._device))
                         self._metric_logger.log_dict(
                             log_dict,
-                            step=self.total_training_steps,
+                            step=self.global_step,
                         )
 
                     # Reset running stats for the next step

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -131,7 +131,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
-        self.total_training_steps = 0
+        self.global_step = 0
 
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
@@ -247,14 +247,14 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             and self.max_steps_per_epoch < self._steps_per_epoch
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
-        self.total_training_steps = self.epochs_run * self._steps_per_epoch
+        self.global_step = self.epochs_run * self._steps_per_epoch
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
             cfg_lr_scheduler=cfg.lr_scheduler,
             num_training_steps=self.total_epochs * self._steps_per_epoch,
-            last_epoch=self.total_training_steps - 1,
+            last_epoch=self.global_step - 1,
         )
 
     def _setup_model(
@@ -559,17 +559,17 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     self._lr_scheduler.step()
 
                     # Update the number of steps when the weights are updated
-                    self.total_training_steps += 1
+                    self.global_step += 1
 
                     loss_to_log = running_loss.item()
                     pbar.update(1)
                     pbar.set_description(
-                        f"{curr_epoch+1}|{self.total_training_steps}|Loss: {loss_to_log}"
+                        f"{curr_epoch+1}|{self.global_step}|Loss: {loss_to_log}"
                     )
 
                     # Log per-step metrics
                     if (
-                        self.total_training_steps % self._log_every_n_steps == 0
+                        self.global_step % self._log_every_n_steps == 0
                         and self._is_rank_zero
                     ):
                         time_per_step = time.perf_counter() - t0
@@ -582,7 +582,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                             log_dict.update(utils.get_memory_stats(device=self._device))
                         self._metric_logger.log_dict(
                             log_dict,
-                            step=self.total_training_steps,
+                            step=self.global_step,
                         )
 
                     # Reset running stats for the next step

--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -198,10 +198,8 @@ class WandBLogger(MetricLoggerInterface):
 
         # define default x-axis (for latest wandb versions)
         if getattr(self._wandb, "define_metric", None):
-            self._wandb.define_metric("total_training_steps")
-            self._wandb.define_metric(
-                "*", step_metric="total_training_steps", step_sync=True
-            )
+            self._wandb.define_metric("global_step")
+            self._wandb.define_metric("*", step_metric="global_step", step_sync=True)
 
     def log_config(self, config: DictConfig) -> None:
         """Saves the config locally and also logs the config to W&B. The config is
@@ -237,11 +235,11 @@ class WandBLogger(MetricLoggerInterface):
 
     def log(self, name: str, data: Scalar, step: int) -> None:
         if self._wandb.run:
-            self._wandb.log({name: data, "total_training_steps": step})
+            self._wandb.log({name: data, "global_step": step})
 
     def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         if self._wandb.run:
-            self._wandb.log({**payload, "total_training_steps": step})
+            self._wandb.log({**payload, "global_step": step})
 
     def __del__(self) -> None:
         if self._wandb.run:


### PR DESCRIPTION
That's it, renaming the step counter to `global_step`. Why?
- It makes more sense and reads better
- It is named `global_step` on the HF Trainer, make using torchtune familiar to folks coming from there
- if we add evals during training (at the end of an epoch for instance) this would make more sense that keeping a "training" naming