### PR TITLE
Remove usage of LRU cache from peft_utils

### DIFF
--- a/tests/torchtune/modules/peft/test_peft_utils.py
+++ b/tests/torchtune/modules/peft/test_peft_utils.py
@@ -15,7 +15,6 @@ from torch import nn
 from torchtune.models.llama2 import llama2, lora_llama2
 from torchtune.modules.peft import LoRALinear
 from torchtune.modules.peft.peft_utils import (
-    _get_base_model_params,
     AdapterModule,
     disable_adapter,
     get_adapter_params,
@@ -166,19 +165,6 @@ class TestPeftUtils:
         adapter_params = get_adapter_params(model)
         expected = request.getfixturevalue(expected_keys)
         assert set(expected) == set(adapter_params.keys())
-
-    @pytest.mark.parametrize(
-        "model_name, expected_keys",
-        [
-            ("dummy_adapter_parent_model", "dummy_model_expected_base_model_keys"),
-            ("lora_llama2_model", "lora_llama2_expected_base_model_keys"),
-        ],
-    )
-    def test_get_base_model_params(self, request, model_name, expected_keys):
-        model = request.getfixturevalue(model_name)
-        base_model_params = _get_base_model_params(model)
-        expected = request.getfixturevalue(expected_keys)
-        assert set(expected) == set(base_model_params.keys())
 
     @pytest.mark.parametrize(
         "model_name, expected_trainable_keys, expected_frozen_keys",

--- a/torchtune/modules/peft/peft_utils.py
+++ b/torchtune/modules/peft/peft_utils.py
@@ -61,23 +61,6 @@ def get_adapter_params(model: nn.Module) -> Dict[str, nn.Parameter]:
     return adapter_params
 
 
-def _get_base_model_params(model: nn.Module) -> Dict[str, Any]:
-    """
-    Given a model containing some adapter weights, return the subset of the model's
-    parameters that correspond to the base model. Assumes that any adapter class has
-    defined the :func:`~torchtune.modules.peft.AdapterModule.adapter_params` method.
-
-    Args:
-        model (nn.Module): Instance of model class containing some adapter params.
-
-    Returns:
-        Dict[str, Any]: the subset of adapted model's state dict containing
-        only the base model's parameters.
-    """
-    adapter_params = get_adapter_params(model)
-    return {k: v for k, v in model.state_dict().items() if k not in adapter_params}
-
-
 def set_trainable_params(model: nn.Module, adapter_params: Dict[str, Any]) -> None:
     """
     Set trainable parameters for an nn.Module based on a state dict of adapter parameters.

--- a/torchtune/modules/peft/peft_utils.py
+++ b/torchtune/modules/peft/peft_utils.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import contextlib
-import functools
 from typing import Any, Dict, Generator, List, Literal, Optional, Protocol, Set
 
 from torch import nn
@@ -33,7 +32,6 @@ class AdapterModule(Protocol):
         pass
 
 
-@functools.lru_cache()
 def get_adapter_params(model: nn.Module) -> Dict[str, nn.Parameter]:
     """
     Return the subset of parameters from a model that correspond to an adapter.
@@ -63,7 +61,6 @@ def get_adapter_params(model: nn.Module) -> Dict[str, nn.Parameter]:
     return adapter_params
 
 
-@functools.lru_cache()
 def _get_base_model_params(model: nn.Module) -> Dict[str, Any]:
     """
     Given a model containing some adapter weights, return the subset of the model's


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Addresses #904 

#### Changelog
Remove usage of LRU cache in `get_adapter_params` and `_get_base_model_params`. It is spiking memory usage as pointed out in #904 and imo the time saved in iterating over the module (usually done quite infrequently) is pretty minimal.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
