### PR TITLE
Remove reference to 2.2.2 as latest stable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can find a full list of all our Llama3 configs [here.](recipes/configs/llama
 
 ## Installation
 
-**Step 1:** [Install PyTorch](https://pytorch.org/get-started/locally/). torchtune is tested with the latest stable PyTorch release (2.2.2) as well as the preview nightly version.
+**Step 1:** [Install PyTorch](https://pytorch.org/get-started/locally/). torchtune is tested with the latest stable PyTorch release as well as the preview nightly version.
 
 **Step 2:** The latest stable version of torchtune is hosted on PyPI and can be downloaded with the following command:
 


### PR DESCRIPTION
#### Context
2.3 is now released, and we test 2.3 by default as our GH workflows install the latest stable PyTorch. Just removing the version number entirely so we don't have to update it everytime pytorch version changes. Plus the link to pytorch download shows the current stable version. 