### PR TITLE
Add LoRA and QLoRA Components, Models, and Configs for Phi3 Mini

### DIFF
--- a/docs/source/api_ref_models.rst
+++ b/docs/source/api_ref_models.rst
@@ -65,6 +65,8 @@ Pre-trained models can be download from the Hugging Face Hub with the following 
     :nosignatures:
 
     phi3.phi3_mini
+    phi3.lora_phi3_mini
+    phi3.qlora_phi3_mini
 
 
 mistral

--- a/recipes/configs/phi3/mini_lora.yaml
+++ b/recipes/configs/phi3/mini_lora.yaml
@@ -1,0 +1,82 @@
+# Config for multi-device LoRA finetuning in lora_finetune_distributed.py
+# using a Phi3 mini (3.8B) model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download microsoft/Phi-3-mini-4k-instruct --output-dir /tmp/Phi-3-mini-4k-instruct --hf-token <HF_TOKEN> --ignore-patterns ""
+#
+# To launch on 2 devices, run the following command from root:
+#   tune run --nnodes 1 --nproc_per_node 2 lora_finetune_distributed --config phi3/mini_lora
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run --nnodes 1 --nproc_per_node 2 lora_finetune_distributed --config phi3/mini_lora checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works best when the model is being fine-tuned on 2+ GPUs.
+# For single device LoRA finetuning please use mini_lora_single_device.yaml
+# or mini_qlora_single_device.yaml
+
+
+# Model Arguments
+model:
+  _component_: torchtune.models.phi3.lora_phi3_mini
+  lora_attn_modules: ['q_proj', 'v_proj']
+  apply_lora_to_mlp: False
+  apply_lora_to_output: False
+  lora_rank: 8
+  lora_alpha: 16
+
+tokenizer:
+  _component_: torchtune.models.phi3.phi3_mini_tokenizer
+  path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
+
+checkpointer:
+  _component_: torchtune.utils.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
+  checkpoint_files: [
+    model-00001-of-00002.safetensors,
+    model-00002-of-00002.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/Phi-3-mini-4k-instruct
+  model_type: PHI3_MINI
+resume_from_checkpoint: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  train_on_input: True
+seed: null
+shuffle: True
+batch_size: 2
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.modules.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torch.nn.CrossEntropyLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 32
+
+# Logging
+output_dir: /tmp/lora_finetune_output
+metric_logger:
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
+log_every_n_steps: 1
+log_peak_memory_stats: False
+
+# Environment
+device: cuda
+dtype: bf16
+enable_activation_checkpointing: False

--- a/recipes/configs/phi3/mini_lora_single_device.yaml
+++ b/recipes/configs/phi3/mini_lora_single_device.yaml
@@ -1,0 +1,88 @@
+# Config for single device LoRA finetuning in lora_finetune_single_device.py
+# using a Phi3 mini (3.8B) model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download microsoft/Phi-3-mini-4k-instruct --output-dir /tmp/Phi-3-mini-4k-instruct --hf-token <HF_TOKEN> --ignore-patterns ""
+#
+# To launch on a single device, run the following command from root:
+#   tune run lora_finetune_single_device --config phi3/mini_lora_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run lora_finetune_single_device --config phi3/mini_lora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+
+# Model Arguments
+model:
+  _component_: torchtune.models.phi3.lora_phi3_mini
+  lora_attn_modules: ['q_proj', 'v_proj']
+  apply_lora_to_mlp: False
+  apply_lora_to_output: False
+  lora_rank: 8
+  lora_alpha: 16
+
+tokenizer:
+  _component_: torchtune.models.phi3.phi3_mini_tokenizer
+  path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
+
+checkpointer:
+  _component_: torchtune.utils.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
+  checkpoint_files: [
+    model-00001-of-00002.safetensors,
+    model-00002-of-00002.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/Phi-3-mini-4k-instruct
+  model_type: PHI3_MINI
+resume_from_checkpoint: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  train_on_input: True
+seed: null
+shuffle: True
+batch_size: 2
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.modules.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torch.nn.CrossEntropyLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 64
+compile: False
+
+# Logging
+output_dir: /tmp/lora_finetune_output
+metric_logger:
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
+log_every_n_steps: 1
+log_peak_memory_stats: False
+
+# Environment
+device: cuda
+dtype: bf16
+enable_activation_checkpointing: True
+
+# Show case the usage of pytorch profiler
+# Set enabled to False as it's only needed for debugging training
+profiler:
+  _component_: torchtune.utils.profiler
+  enabled: False
+  output_dir: ${output_dir}/torchtune_perf_tracing.json

--- a/recipes/configs/phi3/mini_qlora_single_device.yaml
+++ b/recipes/configs/phi3/mini_qlora_single_device.yaml
@@ -64,8 +64,6 @@ loss:
 epochs: 1
 max_steps_per_epoch: null
 gradient_accumulation_steps: 16
-# Note: compile for QLoRA is only supported on nightly
-# PyTorch (>= 2.4.0.dev20240408)
 compile: False
 
 # Logging

--- a/recipes/configs/phi3/mini_qlora_single_device.yaml
+++ b/recipes/configs/phi3/mini_qlora_single_device.yaml
@@ -1,0 +1,89 @@
+# Config for single device QLoRA with lora_finetune_single_device.py
+# using a Phi3 mini (3.8B) model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download microsoft/Phi-3-mini-4k-instruct --output-dir /tmp/Phi-3-mini-4k-instruct --hf-token <HF_TOKEN> --ignore-patterns ""
+#
+# To launch on a single device, run the following command from root:
+#   tune run lora_finetune_single_device --config phi3/mini_qlora_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run lora_finetune_single_device --config phi3/mini_qlora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+# Model Arguments
+model:
+  _component_: torchtune.models.phi3.qlora_phi3_mini
+  lora_attn_modules: ['q_proj', 'v_proj', 'k_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 8
+  lora_alpha: 16
+
+tokenizer:
+  _component_: torchtune.models.phi3.phi3_mini_tokenizer
+  path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
+
+checkpointer:
+  _component_: torchtune.utils.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
+  checkpoint_files: [
+    model-00001-of-00002.safetensors,
+    model-00002-of-00002.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/Phi-3-mini-4k-instruct
+  model_type: PHI3_MINI
+resume_from_checkpoint: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  train_on_input: True
+seed: null
+shuffle: True
+batch_size: 2
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.modules.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torch.nn.CrossEntropyLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 16
+# Note: compile for QLoRA is only supported on nightly
+# PyTorch (>= 2.4.0.dev20240408)
+compile: False
+
+# Logging
+output_dir: /tmp/qlora_finetune_output/
+metric_logger:
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
+log_every_n_steps: 1
+log_peak_memory_stats: False
+
+# Environment
+device: cuda
+dtype: bf16
+enable_activation_checkpointing: True
+
+# Show case the usage of pytorch profiler
+# Set enabled to False as it's only needed for debugging training
+profiler:
+  _component_: torchtune.utils.profiler
+  enabled: False
+  output_dir: ${output_dir}/torchtune_perf_tracing.json

--- a/tests/torchtune/models/phi3/__init__.py
+++ b/tests/torchtune/models/phi3/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/torchtune/models/phi3/test_lora_phi3.py
+++ b/tests/torchtune/models/phi3/test_lora_phi3.py
@@ -1,0 +1,305 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from copy import deepcopy
+
+import pytest
+import torch
+
+from tests.test_utils import assert_expected, fixed_init_model
+from torch import nn
+from torchao.dtypes.nf4tensor import NF4Tensor
+from torchtune import utils
+from torchtune.models.phi3 import phi3, lora_phi3
+from torchtune.models.phi3._component_builders import lora_phi3_self_attention
+from torchtune.modules.peft import LoRALinear
+from torchtune.modules.peft.peft_utils import get_merged_lora_ckpt
+from torchtune.utils.seed import set_seed
+
+RANK = 4
+ALPHA = 1.0
+BSZ = 2
+SEQ_LEN = 32
+EMBED_DIM = 64
+INTER_DIM = 128
+NUM_HEADS = 4
+NUM_KV_HEADS = 2
+MAX_SEQ_LEN = 64
+import pdb
+
+@pytest.fixture(autouse=True)
+def random():
+    set_seed(16)
+
+
+class TestLoRAPhi3SelfAttention:
+    @pytest.fixture
+    def inputs(self) -> torch.Tensor:
+        inputs = torch.randn(BSZ, SEQ_LEN, EMBED_DIM)
+        return inputs
+
+    def get_lora_phi_self_attention(self, lora_modules):
+        lora_phi_sa = lora_phi3_self_attention(
+            lora_modules=lora_modules,
+            embed_dim=EMBED_DIM,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            max_seq_len=MAX_SEQ_LEN,
+            lora_rank=RANK,
+            lora_alpha=ALPHA,
+        )
+        fixed_init_model(lora_phi_sa)
+        return lora_phi_sa
+
+    def test_empty_lora_modules(self):
+        with pytest.raises(ValueError, match="Must pass one or more of"):
+            _ = self.get_lora_phi_self_attention([])
+
+    @pytest.mark.parametrize(
+        "lora_modules, expected",
+        [
+            (["q_proj", "v_proj"], torch.tensor(50.64567)),
+            (["q_proj", "k_proj", "v_proj", "output_proj"], torch.tensor(77.17097)),
+            (["k_proj"], torch.tensor(44.90090)),
+        ],
+    )
+    def test_forward(self, inputs, lora_modules, expected):
+        lora_phi_sa = self.get_lora_phi_self_attention(lora_modules)
+        actual = lora_phi_sa(inputs)
+        assert_expected(actual.shape, (BSZ, SEQ_LEN, EMBED_DIM))
+        assert_expected(actual.mean(), expected, atol=1e-4, rtol=1e-6)
+
+
+class TestLoRAPhi3:
+    @pytest.fixture
+    def vocab_size(self):
+        return 50
+
+    @pytest.fixture
+    def inputs(self, vocab_size):
+        return torch.randint(low=0, high=vocab_size, size=(BSZ, SEQ_LEN))
+
+    def get_lora_phi3(
+        self,
+        lora_modules,
+        apply_lora_to_mlp,
+        apply_lora_to_output,
+        vocab_size,
+        reset_norm=True,
+        quantize_base=False,
+        embed_dim=EMBED_DIM,
+        dtype=None,
+    ):
+        num_layers = 3
+        model = lora_phi3(
+            lora_attn_modules=lora_modules,
+            apply_lora_to_mlp=apply_lora_to_mlp,
+            apply_lora_to_output=apply_lora_to_output,
+            vocab_size=vocab_size,
+            num_layers=num_layers,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            embed_dim=embed_dim,
+            intermediate_dim=INTER_DIM,
+            max_seq_len=MAX_SEQ_LEN,
+            lora_rank=RANK,
+            lora_alpha=ALPHA,
+            quantize_base=quantize_base,
+        )
+        # To make final outputs less trivial
+        if reset_norm:
+            model.norm = nn.Identity()
+
+        # dtype=None means to just read dtype from parameters
+        # in the model. This dtype is set explicitly to bf16 currently
+        # when initializing QLoRA models, as ops such as `arange` aren't
+        # yet supported with the actual nf4 tensor dtype yet.
+        fixed_init_model(model, dtype=dtype)
+
+        return model
+
+    def get_ref_phi3(self, vocab_size, embed_dim=EMBED_DIM):
+        num_layers = 3
+        model = phi3(
+            vocab_size=vocab_size,
+            num_layers=num_layers,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            embed_dim=embed_dim,
+            intermediate_dim=INTER_DIM,
+            max_seq_len=MAX_SEQ_LEN,
+        )
+        return model
+
+    @pytest.mark.parametrize(
+        "lora_modules, apply_lora_to_mlp, apply_lora_to_output, expected",
+        [
+            (["q_proj", "v_proj"], False, False, torch.tensor(2869701.75)),
+            (
+                ["q_proj", "k_proj", "v_proj", "output_proj"],
+                True,
+                False,
+                torch.tensor(10674807.0),
+            ),
+            (["k_proj"], True, True, torch.tensor(16285855.0)),
+        ],
+    )
+    def test_forward(
+        self,
+        vocab_size,
+        inputs,
+        lora_modules,
+        apply_lora_to_mlp,
+        apply_lora_to_output,
+        expected,
+    ):
+        model = self.get_lora_phi3(
+            lora_modules, apply_lora_to_mlp, apply_lora_to_output, vocab_size
+        )
+        actual = model(inputs)
+        assert_expected(actual.shape, (BSZ, SEQ_LEN, vocab_size))
+        assert_expected(actual.mean(), expected, atol=1e-4, rtol=1e-6)
+
+    @pytest.mark.parametrize(
+        "lora_modules, apply_lora_to_mlp, apply_lora_to_output",
+        [
+            (["q_proj", "v_proj"], True, False),
+            (["q_proj", "k_proj", "v_proj", "output_proj"], False, False),
+            (["k_proj"], True, True),
+        ],
+    )
+    def test_lora_phi3_state_dict_parity(
+        self, lora_modules, apply_lora_to_mlp, apply_lora_to_output, vocab_size
+    ):
+        lora_phi = self.get_lora_phi3(
+            lora_modules,
+            apply_lora_to_mlp,
+            apply_lora_to_output,
+            vocab_size,
+            reset_norm=False,
+        )
+        ref_phi = self.get_ref_phi3(vocab_size)
+        # Ensure ref_phi state_dict can be loaded into lora_phi with only "lora"
+        # keys missing.
+        ref_phi_state_dict = ref_phi.state_dict()
+        missing, unexpected = lora_phi.load_state_dict(
+            ref_phi_state_dict, strict=False
+        )
+        assert not unexpected
+        assert all(["lora" in key for key in missing])
+
+    def test_lora_linear_quantize_base(self):
+        model = self.get_lora_phi3(
+            lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
+            apply_lora_to_mlp=True,
+            # quantize_base
+            apply_lora_to_output=False,
+            vocab_size=50,
+            quantize_base=True,
+            embed_dim=512,
+            dtype=torch.bfloat16,
+        )
+        for module in model.modules():
+            if isinstance(module, LoRALinear):
+                assert module._quantize_base
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_qlora_phi3_parity(self, dtype, inputs):
+        with utils.set_default_dtype(dtype):
+            model_ref = self.get_lora_phi3(
+                lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
+                apply_lora_to_mlp=True,
+                apply_lora_to_output=False,
+                vocab_size=50,
+                quantize_base=False,
+                embed_dim=512,
+                dtype=dtype,
+            )
+            qlora = self.get_lora_phi3(
+                lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
+                apply_lora_to_mlp=True,
+                apply_lora_to_output=False,
+                vocab_size=50,
+                quantize_base=True,
+                embed_dim=512,
+                dtype=dtype,
+            )
+        qlora_sd = qlora.state_dict()
+        model_ref.load_state_dict(qlora_sd)
+        # Forward pass of model_ref and qlora should be the same, as QLoRA linear layers should use
+        # a special linear operator that runs the compute in bf16, but only saves the 4 bit tensors
+        # for backward.
+        ref_output = model_ref(inputs)
+        output = qlora(inputs)
+        torch.testing.assert_close(ref_output, output)
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_qlora_phi3_state_dict(self, dtype):
+        with utils.set_default_dtype(dtype):
+            model_ref = self.get_lora_phi3(
+                lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
+                apply_lora_to_mlp=True,
+                apply_lora_to_output=False,
+                vocab_size=50,
+                quantize_base=False,
+                embed_dim=512,
+                dtype=dtype,
+            )
+            high_prec_sd = model_ref.state_dict()
+            for v in high_prec_sd.values():
+                assert v.dtype == dtype
+
+            # ensure quantized LoRA can load a bf16 state_dict
+            qlora = self.get_lora_phi3(
+                lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
+                apply_lora_to_mlp=True,
+                apply_lora_to_output=False,
+                vocab_size=50,
+                quantize_base=True,
+                embed_dim=512,
+                dtype=dtype,
+            )
+            qlora.load_state_dict(high_prec_sd)
+            # LoRALinear base weights should be nf4 still
+            for module in qlora.modules():
+                if isinstance(module, LoRALinear):
+                    assert isinstance(module.weight, NF4Tensor)
+            # saved state_dict should have bf16 weights.
+            qlora_sd = qlora.state_dict()
+            #pdb.set_trace()
+            for v in qlora_sd.values():
+                assert v.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_qlora_phi3_merged_state_dict(self, dtype):
+        with utils.set_default_dtype(dtype):
+            qlora = self.get_lora_phi3(
+                lora_modules=["q_proj", "v_proj", "k_proj", "output_proj"],
+                apply_lora_to_mlp=True,
+                apply_lora_to_output=False,
+                vocab_size=50,
+                quantize_base=True,
+                embed_dim=512,
+                dtype=dtype,
+                reset_norm=False,  # to ensure norm.scale key exists
+            )
+
+        qlora_sd = qlora.state_dict()
+        # Ensure checkpoint merging produces bf16 tensors
+        merged_ckpt = get_merged_lora_ckpt(deepcopy(qlora_sd), rank=RANK, alpha=ALPHA)
+        for k, v in merged_ckpt.items():
+            # paranoid check for both, as NF4Tensor had issue where NF4Tensor.dtype would return bf16
+            assert not isinstance(v, NF4Tensor)
+            if k == "":
+                assert v.dtype == torch.float32
+            else:
+                assert v.dtype == dtype
+
+        # Ensure checkpoint can be loaded into non-LoRA model
+        with utils.set_default_dtype(dtype):
+            phi3 = self.get_ref_phi3(vocab_size=50, embed_dim=512)
+
+        phi3.load_state_dict(merged_ckpt)

--- a/tests/torchtune/models/phi3/test_lora_phi3.py
+++ b/tests/torchtune/models/phi3/test_lora_phi3.py
@@ -28,7 +28,7 @@ INTER_DIM = 128
 NUM_HEADS = 4
 NUM_KV_HEADS = 2
 MAX_SEQ_LEN = 64
-import pdb
+
 
 @pytest.fixture(autouse=True)
 def random():
@@ -269,7 +269,6 @@ class TestLoRAPhi3:
                     assert isinstance(module.weight, NF4Tensor)
             # saved state_dict should have bf16 weights.
             qlora_sd = qlora.state_dict()
-            #pdb.set_trace()
             for v in qlora_sd.values():
                 assert v.dtype == dtype
 

--- a/tests/torchtune/models/phi3/test_lora_phi3.py
+++ b/tests/torchtune/models/phi3/test_lora_phi3.py
@@ -13,7 +13,7 @@ from tests.test_utils import assert_expected, fixed_init_model
 from torch import nn
 from torchao.dtypes.nf4tensor import NF4Tensor
 from torchtune import utils
-from torchtune.models.phi3 import phi3, lora_phi3
+from torchtune.models.phi3 import lora_phi3, phi3
 from torchtune.models.phi3._component_builders import lora_phi3_self_attention
 from torchtune.modules.peft import LoRALinear
 from torchtune.modules.peft.peft_utils import get_merged_lora_ckpt
@@ -185,9 +185,7 @@ class TestLoRAPhi3:
         # Ensure ref_phi state_dict can be loaded into lora_phi with only "lora"
         # keys missing.
         ref_phi_state_dict = ref_phi.state_dict()
-        missing, unexpected = lora_phi.load_state_dict(
-            ref_phi_state_dict, strict=False
-        )
+        missing, unexpected = lora_phi.load_state_dict(ref_phi_state_dict, strict=False)
         assert not unexpected
         assert all(["lora" in key for key in missing])
 

--- a/tests/torchtune/models/phi3/test_phi3.py
+++ b/tests/torchtune/models/phi3/test_phi3.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from tests.test_utils import fixed_init_model
+from torchtune.models.phi3 import phi3
+from torchtune.utils.seed import set_seed
+
+EMBED_DIM = 128
+INTER_DIM = 256
+NUM_LAYERS = 4
+NUM_HEADS = 16
+NUM_KV_HEADS = 8
+VOCAB_SIZE = 32000
+MAX_SEQ_LEN = 2048
+BSZ = 2
+SEQ_LEN = 100
+
+
+@pytest.fixture(autouse=True)
+def random():
+    set_seed(16)
+
+
+class TestPhi3:
+    @pytest.fixture
+    def inputs(self):
+        return torch.randint(0, VOCAB_SIZE, (BSZ, SEQ_LEN))
+
+    def test_forward(self, inputs):
+        model = phi3(
+            vocab_size=VOCAB_SIZE,
+            num_layers=NUM_LAYERS,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            embed_dim=EMBED_DIM,
+            intermediate_dim=INTER_DIM,
+            max_seq_len=MAX_SEQ_LEN,
+        )
+        fixed_init_model(model, min_val=-0.25, max_val=0.5)
+        actual = model(inputs)
+        expected = torch.tensor(3.9763)
+        assert actual.shape == (BSZ, SEQ_LEN, VOCAB_SIZE)
+        torch.testing.assert_close(actual.mean(), expected, atol=1e-4, rtol=1e-4)

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -111,6 +111,14 @@ _ALL_RECIPES = [
                 name="gemma/2B_qlora_single_device",
                 file_path="gemma/2B_qlora_single_device.yaml",
             ),
+            Config(
+                name="phi3/mini_lora_single_device",
+                file_path="phi3/mini_lora_single_device.yaml",
+            ),
+            Config(
+                name="phi3/mini_qlora_single_device",
+                file_path="phi3/mini_qlora_single_device.yaml",
+            ),
         ],
         supports_distributed=False,
     ),
@@ -147,6 +155,7 @@ _ALL_RECIPES = [
             Config(name="llama3/8B_lora", file_path="llama3/8B_lora.yaml"),
             Config(name="mistral/7B_lora", file_path="mistral/7B_lora.yaml"),
             Config(name="gemma/2B_lora", file_path="gemma/2B_lora.yaml"),
+            Config(name="phi3/mini_lora", file_path="phi3/mini_lora.yaml"),
         ],
         supports_distributed=True,
     ),

--- a/torchtune/models/gemma/_component_builders.py
+++ b/torchtune/models/gemma/_component_builders.py
@@ -152,7 +152,7 @@ def lora_gemma(
     quantize_base: bool = False,
 ) -> GemmaTransformerDecoder:
     """
-    Return a version of Gemma with LoRA applied to some of the linear layers in its self-attention modules.
+    Return a version of Gemma with LoRA applied based on the passed in configuration.
     Note: output projection lora is not supported because it is tied to token embeddings
 
     Args:

--- a/torchtune/models/llama2/_component_builders.py
+++ b/torchtune/models/llama2/_component_builders.py
@@ -157,7 +157,7 @@ def lora_llama2(
 ) -> TransformerDecoder:
     """
     Return a version of Llama2 (an instance of :func:`~torchtune.modules.TransformerDecoder`)
-    with LoRA applied to some of the linear layers in its self-attention modules.
+    with LoRA applied based on the passed in configuration.
 
     Args:
         lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -155,7 +155,7 @@ def lora_llama3(
 ) -> TransformerDecoder:
     """
     Return a version of Llama3 (an instance of :func:`~torchtune.modules.TransformerDecoder`)
-    with LoRA applied to some of the linear layers in its self-attention modules.
+    with LoRA applied based on the passed in configuration.
 
     Args:
         lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers

--- a/torchtune/models/mistral/_component_builders.py
+++ b/torchtune/models/mistral/_component_builders.py
@@ -148,7 +148,7 @@ def lora_mistral(
 ) -> TransformerDecoder:
     """
     Return a version of Mistral (an instance of :func:`~torchtune.modules.TransformerDecoder`)
-    with LoRA applied to some of the linear layers in its self-attention modules.
+    with LoRA applied based on the passed in configuration.
 
     Args:
         lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers

--- a/torchtune/models/phi3/__init__.py
+++ b/torchtune/models/phi3/__init__.py
@@ -4,15 +4,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._component_builders import phi3, lora_phi3  # noqa
+from ._component_builders import lora_phi3, phi3  # noqa
 from ._convert_weights import phi3_hf_to_tune, phi3_tune_to_hf  # noqa
-from ._model_builders import phi3_mini, phi3_mini_tokenizer, lora_phi3_mini  # noqa
+from ._model_builders import (  # noqa
+    lora_phi3_mini,
+    phi3_mini,
+    phi3_mini_tokenizer,
+    qlora_phi3_mini,
+)
 from ._position_embeddings import Phi3RotaryPositionalEmbeddings  # noqa
 
 __all__ = [
     "phi3_mini",
     "phi3_mini_tokenizer",
     "lora_phi3_mini",
+    "qlora_phi3_mini",
     "Phi3RotaryPositionalEmbeddings",
     "phi3_hf_to_tune",
     "phi3_tune_to_hf",

--- a/torchtune/models/phi3/__init__.py
+++ b/torchtune/models/phi3/__init__.py
@@ -4,16 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._component_builders import phi3  # noqa
+from ._component_builders import phi3, lora_phi3  # noqa
 from ._convert_weights import phi3_hf_to_tune, phi3_tune_to_hf  # noqa
-from ._model_builders import phi3_mini, phi3_mini_tokenizer  # noqa
+from ._model_builders import phi3_mini, phi3_mini_tokenizer, lora_phi3_mini  # noqa
 from ._position_embeddings import Phi3RotaryPositionalEmbeddings  # noqa
 
 __all__ = [
     "phi3_mini",
     "phi3_mini_tokenizer",
+    "lora_phi3_mini",
     "Phi3RotaryPositionalEmbeddings",
     "phi3_hf_to_tune",
     "phi3_tune_to_hf",
     "phi3",
+    "lora_phi3",
 ]

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -1,3 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
 from typing import List
 
 from torch import nn
@@ -11,6 +18,8 @@ from torchtune.modules import (
     TransformerDecoder,
     TransformerDecoderLayer,
 )
+
+from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
 
 from torchtune.modules.peft import LORA_ATTN_MODULES, LoRALinear
 
@@ -105,3 +114,287 @@ def phi3_mlp(dim: int, hidden_dim: int) -> FeedForward:
     down_proj = nn.Linear(hidden_dim, dim, bias=False)
     up_proj = nn.Linear(dim, hidden_dim, bias=False)
     return FeedForward(gate_proj=gate_proj, down_proj=down_proj, up_proj=up_proj)
+
+
+# ------------------ LoRA Phi3 ------------------
+
+
+def lora_phi3(
+    lora_attn_modules: List[LORA_ATTN_MODULES],
+    apply_lora_to_mlp: bool = False,
+    apply_lora_to_output: bool = False,
+    *,
+    # phi3 args
+    vocab_size: int,
+    num_layers: int,
+    num_heads: int,
+    num_kv_heads: int,
+    embed_dim: int,
+    intermediate_dim: int,
+    max_seq_len: int,
+    attn_dropout: float = 0.0,
+    norm_eps: float = 1e-5,
+    rope_base: float = 500000.0,
+    # LoRA args
+    lora_rank: int,
+    lora_alpha: float,
+    lora_dropout: float = 0.0,
+    # Quantization args
+    quantize_base: bool = False,
+) -> TransformerDecoder:
+    """
+    Return a version of Phi3 (an instance of :func:`~torchtune.modules.TransformerDecoder`)
+    with LoRA applied to some of the linear layers in its self-attention modules.
+
+    Args:
+        lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers
+            LoRA should be applied to in each self-attention block. Options are
+            ``{"q_proj", "k_proj", "v_proj", "output_proj"}``.
+        apply_lora_to_mlp (bool): whether to apply LoRA to the MLP in each transformer layer.
+            Default: False
+        apply_lora_to_output (bool): whether to apply LoRA to the model's final output projection.
+            Default: False
+        vocab_size (int): number of tokens in vocabulary.
+        num_layers (int): number of layers in the transformer decoder.
+        num_heads (int): number of query heads. For MHA this is also the
+            number of heads for key and value
+        num_kv_heads (int): number of key and value heads. If specified,
+            user should ensure `num_heads` % `num_kv_heads` == 0. Default value is
+            `None`, in which case this is the same as MHA
+        embed_dim (int): embedding dimension for self-attention
+        intermediate_dim (int): intermediate dimension for MLP
+        max_seq_len (int): maximum sequence length the model will be run with, as used
+            by :func:`~torchtune.modules.KVCache`
+        attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
+            Default: 0.0
+        norm_eps (float): epsilon in RMS norms.
+        lora_rank (int): rank of each low-rank approximation
+        lora_alpha (float): scaling factor for the low-rank approximation
+        lora_dropout (float): LoRA dropout probability. Default: 0.0
+        quantize_base: (bool): Whether to quantize base model weights or not. Only applied to base
+            weights within linear layers LoRA is applied to. The final output linear projection is not
+            supported for quantization currently.
+
+    Returns:
+        TransformerDecoder: Instantiation of Llama3 model with LoRA applied to
+        a subset of the attention projections in each layer.
+
+    """
+
+    self_attn = lora_phi3_self_attention(
+        lora_modules=lora_attn_modules,
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        max_seq_len=max_seq_len,
+        attn_dropout=attn_dropout,
+        rope_base=rope_base,
+        lora_rank=lora_rank,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        quantize_base=quantize_base,
+    )
+
+    if apply_lora_to_mlp:
+        mlp = lora_phi3_mlp(
+            dim=embed_dim,
+            hidden_dim=intermediate_dim,
+            lora_rank=lora_rank,
+            lora_alpha=lora_alpha,
+            quantize_base=quantize_base,
+        )
+    else:
+        mlp = phi3_mlp(dim=embed_dim, hidden_dim=intermediate_dim)
+
+    layer = TransformerDecoderLayer(
+        attn=self_attn,
+        mlp=mlp,
+        sa_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
+        mlp_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
+    )
+
+    tok_embeddings = nn.Embedding(vocab_size, embed_dim)
+
+    # TODO: quantize_base is not applied to final output_proj currently.
+    output_proj = (
+        LoRALinear(embed_dim, vocab_size, rank=lora_rank, alpha=lora_alpha)
+        if apply_lora_to_output
+        else nn.Linear(embed_dim, vocab_size, bias=False)
+    )
+    model = TransformerDecoder(
+        tok_embeddings=tok_embeddings,
+        layer=layer,
+        num_layers=num_layers,
+        max_seq_len=max_seq_len,
+        num_heads=num_heads,
+        head_dim=(embed_dim // num_heads),
+        norm=RMSNorm(embed_dim, eps=norm_eps),
+        output=output_proj,
+    )
+
+    if quantize_base:
+        # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
+        # so as to not increase peak memory
+        model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook,
+            dtype=tok_embeddings.weight.dtype,
+            offload_to_cpu=True)
+        )
+
+    return model
+
+
+def lora_phi3_self_attention(
+    lora_modules: List[LORA_ATTN_MODULES],
+    *,
+    # CausalSelfAttention args
+    embed_dim: int,
+    num_heads: int,
+    num_kv_heads: int,
+    max_seq_len: int,
+    attn_dropout: float = 0.0,
+    rope_base: float = 500000.0,
+    # LoRA args
+    lora_rank: int,
+    lora_alpha: float,
+    lora_dropout: float = 0.0,
+    quantize_base: bool = False,
+) -> CausalSelfAttention:
+    """
+    Return an instance of :func:`~torchtune.modules.CausalSelfAttention` with LoRA
+    applied to a subset of its linear layers
+
+    Args:
+        lora_modules (List[LORA_ATTN_MODULES]): list of which linear layers
+            LoRA should be applied to. Options are ``{"q_proj", "k_proj", "v_proj",
+            "output_proj"}``.
+        embed_dim (int): embedding dimension for self-attention
+        num_heads (int): number of query heads. For MHA this is also the
+            number of heads for key and value
+        num_kv_heads (int): number of key and value heads. If specified,
+            user should ensure `num_heads` % `num_kv_heads` == 0. Default value is
+            `None`, in which case this is the same as MHA
+        max_seq_len (int): maximum sequence length the model will be run with, as used
+            by :func:`~torchtune.modules.KVCache`
+        attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
+            Default: 0.0
+        lora_rank (int): rank of each low-rank approximation
+        lora_alpha (float): scaling factor for the low-rank approximation
+        lora_dropout (float): LoRA dropout probability. Default: 0.0
+        quantize_base (bool): Whether to quantize base model parameters for linear layers
+            LoRA is being applied to. Default is ``False``.
+
+    Returns:
+        CausalSelfAttention: instantiation of self-attention module with LoRA
+        applied to a subset of Q, K, V, output projections.
+
+    Raises:
+        ValueError: If lora_modules arg is an empty list
+    """
+    if not lora_modules:
+        raise ValueError(
+            f"Must pass one or more of {LORA_ATTN_MODULES} as lora_modules"
+        )
+
+    head_dim = embed_dim // num_heads
+    num_kv_heads = num_kv_heads if num_kv_heads else num_heads
+    q_proj = (
+        LoRALinear(
+            embed_dim,
+            num_heads * head_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+            quantize_base=quantize_base,
+        )
+        if "q_proj" in lora_modules
+        else nn.Linear(embed_dim, num_heads * head_dim, bias=False)
+    )
+    k_proj = (
+        LoRALinear(
+            embed_dim,
+            num_kv_heads * head_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+            quantize_base=quantize_base,
+        )
+        if "k_proj" in lora_modules
+        else nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+    )
+    v_proj = (
+        LoRALinear(
+            embed_dim,
+            num_kv_heads * head_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+            quantize_base=quantize_base,
+        )
+        if "v_proj" in lora_modules
+        else nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+    )
+    output_proj = (
+        LoRALinear(
+            embed_dim,
+            embed_dim,
+            rank=lora_rank,
+            alpha=lora_alpha,
+            quantize_base=quantize_base,
+        )
+        if "output_proj" in lora_modules
+        else nn.Linear(embed_dim, embed_dim, bias=False)
+    )
+    rope = Phi3RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
+    # rope = RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
+    self_attn = CausalSelfAttention(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        q_proj=q_proj,
+        k_proj=k_proj,
+        v_proj=v_proj,
+        output_proj=output_proj,
+        pos_embeddings=rope,
+        max_seq_len=max_seq_len,
+        attn_dropout=attn_dropout,
+    )
+    return self_attn
+
+
+def lora_phi3_mlp(
+    *,
+    dim: int,
+    hidden_dim: int,
+    lora_rank: int,
+    lora_alpha: float,
+    lora_dropout: float = 0.0,
+    quantize_base: bool = False,
+) -> FeedForward:
+    gate_proj = LoRALinear(
+        in_dim=dim,
+        out_dim=hidden_dim,
+        rank=lora_rank,
+        alpha=lora_alpha,
+        dropout=lora_dropout,
+        quantize_base=quantize_base,
+    )
+    down_proj = LoRALinear(
+        in_dim=hidden_dim,
+        out_dim=dim,
+        rank=lora_rank,
+        alpha=lora_alpha,
+        dropout=lora_dropout,
+        quantize_base=quantize_base,
+    )
+    up_proj = LoRALinear(
+        in_dim=dim,
+        out_dim=hidden_dim,
+        rank=lora_rank,
+        alpha=lora_alpha,
+        dropout=lora_dropout,
+        quantize_base=quantize_base,
+    )
+    return FeedForward(
+        gate_proj=gate_proj,
+        down_proj=down_proj,
+        up_proj=up_proj,
+    )

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -71,7 +71,6 @@ def phi3(
     num_kv_heads = num_kv_heads if num_kv_heads else num_heads
 
     rope = Phi3RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
-    # rope = RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
     self_attn = CausalSelfAttention(
         embed_dim=embed_dim,
         num_heads=num_heads,
@@ -144,7 +143,7 @@ def lora_phi3(
 ) -> TransformerDecoder:
     """
     Return a version of Phi3 (an instance of :func:`~torchtune.modules.TransformerDecoder`)
-    with LoRA applied to some of the linear layers in its self-attention modules.
+    with LoRA applied based on the passed in configuration.
 
     Args:
         lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers
@@ -343,7 +342,6 @@ def lora_phi3_self_attention(
         else nn.Linear(embed_dim, embed_dim, bias=False)
     )
     rope = Phi3RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
-    # rope = RotaryPositionalEmbeddings(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
     self_attn = CausalSelfAttention(
         embed_dim=embed_dim,
         num_heads=num_heads,

--- a/torchtune/models/phi3/_model_builders.py
+++ b/torchtune/models/phi3/_model_builders.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from torchtune.models.phi3._component_builders import phi3
+from torchtune.models.phi3._component_builders import phi3, lora_phi3
 from torchtune.models.phi3._sentencepiece import Phi3MiniSentencePieceTokenizer
 
 from torchtune.modules import TransformerDecoder
@@ -62,3 +62,53 @@ def phi3_mini_tokenizer(path: str) -> Phi3MiniSentencePieceTokenizer:
     """
     tokenizer = Phi3MiniSentencePieceTokenizer(path)
     return tokenizer
+
+
+def lora_phi3_mini(
+    lora_attn_modules: List[LORA_ATTN_MODULES],
+    apply_lora_to_mlp: bool = False,
+    apply_lora_to_output: bool = False,
+    lora_rank: int = 8,
+    lora_alpha: float = 16,
+    quantize_base: bool = False,
+) -> TransformerDecoder:
+    """
+    Builder for creating a Phi3 Mini (3.8b) model with LoRA enabled.
+
+    The Phi3 defaults are the same as in :func:`~torchtune.models.phi3.phi3_mini`,
+    while LoRA default params are based on
+    https://github.com/tloen/alpaca-lora/blob/8bb8579e403dc78e37fe81ffbb253c413007323f/finetune.py#L41-L43.
+
+    Args:
+        lora_attn_modules (List[LORA_ATTN_MODULES]): list of which linear layers
+            LoRA should be applied to in each self-attention block. Options are
+            ``{"q_proj", "k_proj", "v_proj", "output_proj"}``.
+        apply_lora_to_mlp (bool): whether to apply LoRA to the MLP in each transformer layer.
+            Default: False
+        apply_lora_to_output (bool): whether to apply LoRA to the model's final output projection.
+            Default: False
+        lora_rank (int): rank of each low-rank approximation
+        lora_alpha (float): scaling factor for the low-rank approximation
+        quantize_base (bool): Whether to quantize base model weights
+
+    Returns:
+        TransformerDecoder: Instantiation of Phi3 Mini model with LoRA applied
+    """
+    return lora_phi3(
+        lora_attn_modules=lora_attn_modules,
+        apply_lora_to_mlp=apply_lora_to_mlp,
+        apply_lora_to_output=apply_lora_to_output,
+        vocab_size=32_064,
+        num_layers=32,
+        num_heads=32,
+        num_kv_heads=32,
+        embed_dim=3072,
+        intermediate_dim=8192,
+        max_seq_len=4096,
+        attn_dropout=0.0,
+        norm_eps=1e-5,
+        lora_rank=lora_rank,
+        lora_alpha=lora_alpha,
+        lora_dropout=0.05,
+        quantize_base=quantize_base,
+    )

--- a/torchtune/models/phi3/_model_builders.py
+++ b/torchtune/models/phi3/_model_builders.py
@@ -112,3 +112,11 @@ def lora_phi3_mini(
         lora_dropout=0.05,
         quantize_base=quantize_base,
     )
+
+
+qlora_phi3_mini = partial(lora_phi3_mini, quantize_base=True)
+qlora_phi3_mini.__doc__ = """
+Builder for creating a Phi3 mini model with QLoRA enabled. Base model weights in linear layers
+that LoRA is applied to are quantized per the QLoRA paper: https://arxiv.org/abs/2305.14314.
+Please see `lora_phi3_mini` for full API arguments.
+"""


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
This PR extends the [Phi3 Mini PR](https://github.com/pytorch/torchtune/pull/923) by adding the lora_phi3 class as well as lora_phi3_mini and qlora_phi3_mini model builders. This PR also introduces a new recipe configs: mini_lora, mini_lora_single_device, and mini_qlora_single_device.


#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
	- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

New Unit tests: Added a unit test for phi3 and for lora and qlora phi3 mini. These tests are a port of the llama2 tests.
New configs: The 3 new configs so far are based off of llama2 and phi2 values. 1 epoch of training is being done now with:

```tune run --nnodes 1 --nproc_per_node 2 lora_finetune_distributed --config phi3/mini_lora```

```tune run lora_finetune_single_device --config phi3/mini_qlora_single_device```

```tune run lora_finetune_single_device --config phi3/mini_lora_single_device```


Similar loss training curves for all three runs
<img width="520" alt="Screenshot 2024-05-08 at 1 51 18 PM" src="https://github.com/pytorch/torchtune/assets/6652398/46551e99-4aca-49f3-b578-2f96219c774d">

TruthfulQA eval was 57% acc. This is the same as the baseline for phi3_mini. This is the same behavior we see for the full finetune where alpaca doesn't improve this benchmark. I will investigate better config options in future work.