### PR TITLE
update eval wrapper to match lm_eval's api change

### DIFF
--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -55,7 +55,7 @@ class _EvalWrapper(HFLM):
         max_seq_length: int = 4096,
         batch_size: int = 32,
     ):
-        super().__init__(device=str(device))
+        super().__init__(pretrained="gpt2", device=str(device))
         self._model = model
         self._tokenizer = tokenizer
         self._max_seq_length = max_seq_length


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
None since I did not create an issue.

#### Changelog
What are the changes made in this PR?
This is a modification to the evaluation script. [A recent change in lm_eval](https://github.com/EleutherAI/lm-evaluation-harness/pull/1775) removed the default value for the `pertained` argument in their `HFLM` class. As a result, directly running the current version of `torchtune` will fail due to the missing argument in `__init__`. In the long term, we should consider modifying this script to comply with their changes.

The current change uses the previous default value for this argument, its value won't affect functionality since `self._model` is overwritten by our model anyway. Alternatively, you could pass `None` or the model directly to this argument. However, `lm_eval` will issue a warning whenever this argument is not a string.

If you have better ideas or suggestions regarding this issue, please feel free to close this PR and create a new one with your proposed changes.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
