### PR TITLE
Update readme table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ Single-GPU recipes expose a number of memory optimizations that aren't available
 
 This table captures the peak memory usage and training speed for recipes in torchtune.
 
-| Example HW Resources | Finetuning Method | Model   | Setting    | Peak Memory per GPU | Training Speed |
+| Example HW Resources | Finetuning Method | Model   | Setting    | Peak Memory per GPU (GB) | Training Speed (tokens/sec) |
 |----------------------|-------------------|---------|------------|---------------------|----------------|
-| 1 x RTX 4090 |     QLoRA         |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 12.3 GB | 1856 tokens/sec |
-| 1 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 21.3 GB | 2582 tokens/sec |
-| 2 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 16.2 GB | 2768 tokens/sec |
-| 1 x RTX 4090 |   Full finetune   |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 24.1 GB | 1388 tokens/sec |
-| 4 x RTX 4090 |   Full finetune   |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 24.1 GB | 702 tokens/sec |
-| 8 x A100     |     LoRA          |  Llama2-70B     |    Batch Size = 4, Context Length = 4096   | 26.4 GB | 3384 tokens/sec |
-| 8 x A100     |   Full Finetune   |  Llama2-70B     |    Batch Size = 4, Context Length = 4096   | 70.4 GB | 2032 tokens/sec |
+| 1 x RTX 4090 |     QLoRA         |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 12.3 GB | 1856  |
+| 1 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 21.3 GB | 2582  |
+| 2 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 16.2 GB | 2768  |
+| 1 x RTX 4090 |   Full finetune   |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 24.1 GB | 1388  |
+| 4 x RTX 4090 |   Full finetune   |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 24.1 GB | 702  |
+| 8 x A100     |     LoRA          |  Llama2-70B     |    Batch Size = 4, Seq Length = 4096   | 26.4 GB | 3384  |
+| 8 x A100     |   Full Finetune   |  Llama2-70B     |    Batch Size = 4, Seq Length = 4096   | 70.4 GB | 2032  |
 
 
 

--- a/README.md
+++ b/README.md
@@ -70,19 +70,21 @@ torchtune provides the following fine-tuning recipes.
 
 Memory efficiency is important to us. All of our recipes are tested on a variety of setups including commodity GPUs with 24GB of VRAM as well as beefier options found in data centers.
 
-Single-GPU recipes expose a number of memory optimizations that aren't available in the distributed versions. These include support for low-precision optimizers from [bitsandbytes](https://huggingface.co/docs/bitsandbytes/main/en/index) and fusing optimizer step with backward to reduce memory footprint from the gradients (see example [config](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama2/7B_full_low_memory.yaml)). For memory-constrained setups, we recommend using the single-device configs as a starting point. For example, our default QLoRA config has a peak memory usage of ``~9.3GB``. Similarly LoRA on single device with ``batch_size=2`` has a peak memory usage of ``~17.1GB``. Both of these are with ``dtype=bf16`` and ``AdamW`` as the optimizer.
+Single-GPU recipes expose a number of memory optimizations that aren't available in the distributed versions. These include support for low-precision optimizers from [bitsandbytes](https://huggingface.co/docs/bitsandbytes/main/en/index) and fusing optimizer step with backward to reduce memory footprint from the gradients (see example [config](https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama2/7B_full_low_memory.yaml)). For memory-constrained setups, we recommend using the single-device configs as a starting point.
 
-This table captures the minimum memory requirements for our different recipes using the associated configs.
+This table captures the peak memory usage and training speed for recipes in torchtune.
 
-| Example HW Resources | Finetuning Method | Config | Model | Peak Memory per GPU
+| Example HW Resources | Finetuning Method | Model | Setting | Peak Memory per GPU | Training Speed |
 |--------------|-------------------|---------|------------|---------------------|
-| 1 x RTX 4090 |     QLoRA          | [qlora_finetune_single_device](recipes/configs/llama2/7B_qlora_single_device.yaml)         |    Llama2-7B      |     8.57 GB            |
-| 2 x RTX 4090 |     LoRA          | [lora_finetune_distributed](recipes/configs/llama2/7B_lora.yaml)         |    Llama2-7B      |    20.95 GB            |
-| 1 x RTX 4090 |     LoRA          | [lora_finetune_single_device](recipes/configs/llama2/7B_lora_single_device.yaml)     |    Llama2-7B      | 17.18 GB           |
-| 1 x RTX 4090 |   Full finetune   | [full_finetune_single_device](recipes/configs/llama2/7B_full_low_memory.yaml)     |    Llama2-7B      |    14.97 GB            |
-| 4 x RTX 4090 |   Full finetune   | [full_finetune_distributed](recipes/configs/llama2/7B_full.yaml)         |    Llama2-7B      |    22.9 GB           |
+| 1 x RTX 4090 |     QLoRA         |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 12.3 GB | 1856 tokens/sec |
+| 1 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 21.3 GB | 2582 tokens/sec |
+| 2 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 16.2 GB | 2768 tokens/sec |
+| 1 x RTX 4090 |   Full finetune   |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 24.1 GB | 1388 tokens/sec |
+| 4 x RTX 4090 |   Full finetune   |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 24.1 GB | 702 tokens/sec |
+| 8 x A100     |     LoRA          |  Llama2-70B     |    Batch Size = 4, Context Length = 4096   | 26.4 GB | 3384 tokens/sec |
+| 8 x A100     |   Full Finetune   |  Llama2-70B     |    Batch Size = 4, Context Length = 4096   | 70.4 GB | 2032 tokens/sec |
 
-* these are averaged over multiple runs, but there might be some variance based on the setup. We'll update this table regularly.
+
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Single-GPU recipes expose a number of memory optimizations that aren't available
 
 This table captures the peak memory usage and training speed for recipes in torchtune.
 
-| Example HW Resources | Finetuning Method | Model | Setting | Peak Memory per GPU | Training Speed |
-|--------------|-------------------|---------|------------|---------------------|
+| Example HW Resources | Finetuning Method | Model   | Setting    | Peak Memory per GPU | Training Speed |
+|----------------------|-------------------|---------|------------|---------------------|----------------|
 | 1 x RTX 4090 |     QLoRA         |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 12.3 GB | 1856 tokens/sec |
 | 1 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 21.3 GB | 2582 tokens/sec |
 | 2 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Context Length = 2048   | 16.2 GB | 2768 tokens/sec |


### PR DESCRIPTION
#### Context

Our current README table is somewhat confusing since the numbers are not immediately comparable and the settings are unclear. Here I update the table to include:
- Tokens/sec and Peak Memory Usage for Llama2 7B models for a BS of 4 and Seq Length of 2048
- Tokens/sec and Peak Memory Usage for Llama2 70B models for a BS of 4 and Seq Length of 4096

These numbers are collected from runs on the right hardware.

#### Changelog

As above

#### Test plan

Eyes

