### PR TITLE
Update documentation tab to point to main instead of stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ torchtune focuses on integrating with popular tools and libraries from the ecosy
 - [Hugging Face Datasets](https://huggingface.co/docs/datasets/en/index) for [access](torchtune/datasets/_instruct.py) to training and evaluation datasets
 - [PyTorch FSDP](https://pytorch.org/docs/stable/fsdp.html) for distributed training
 - [torchao](https://github.com/pytorch-labs/ao) for lower precision dtypes and [post-training quantization](recipes/quantize.py) techniques
-- [Weights & Biases](https://wandb.ai/site) for [logging](https://pytorch.org/torchtune/stable/deep_dives/wandb_logging.html) metrics and checkpoints, and tracking training progress
+- [Weights & Biases](https://wandb.ai/site) for [logging](https://pytorch.org/torchtune/main/deep_dives/wandb_logging.html) metrics and checkpoints, and tracking training progress
 - [ExecuTorch](https://pytorch.org/executorch-overview) for [on-device inference](https://github.com/pytorch/executorch/tree/main/examples/models/llama2#optional-finetuning) using fine-tuned models
 - [bitsandbytes](https://huggingface.co/docs/bitsandbytes/main/en/index) for low memory optimizers for our [single-device recipes](recipes/configs/llama2/7B_full_low_memory.yaml)
 
@@ -93,7 +93,7 @@ This table captures the peak memory usage and training speed for recipes in torc
 
 ## Llama3
 
-torchtune supports fine-tuning for the Llama3 8B and 70B size models. We currently support LoRA, QLoRA and full fine-tune on a single GPU as well as LoRA and full fine-tune on multiple devices for the 8B model, and LoRA on multiple devices for the 70B model. For all the details, take a look at our [tutorial](https://pytorch.org/torchtune/stable/tutorials/llama3.html).
+torchtune supports fine-tuning for the Llama3 8B and 70B size models. We currently support LoRA, QLoRA and full fine-tune on a single GPU as well as LoRA and full fine-tune on multiple devices for the 8B model, and LoRA on multiple devices for the 70B model. For all the details, take a look at our [tutorial](https://pytorch.org/torchtune/main/tutorials/llama3.html).
 
 **Note**: our Llama3 LoRA and QLoRA configs default to the instruct fine-tuned models.
 This is because not all special token embeddings are initialized in the base 8B and 70B models.
@@ -191,7 +191,7 @@ You can also install the latest and greatest torchtune has to offer by [installi
 
 ## Get Started
 
-To get started with fine-tuning your first LLM with torchtune, see our tutorial on [fine-tuning Llama2 7B](https://pytorch.org/torchtune/stable/tutorials/first_finetune_tutorial.html). Our [end-to-end workflow](https://pytorch.org/torchtune/stable/tutorials/e2e_flow.html) tutorial will show you how to evaluate, quantize and run inference with this model. The rest of this section will provide a quick overview of these steps with Llama2.
+To get started with fine-tuning your first LLM with torchtune, see our tutorial on [fine-tuning Llama2 7B](https://pytorch.org/torchtune/main/tutorials/first_finetune_tutorial.html). Our [end-to-end workflow](https://pytorch.org/torchtune/main/tutorials/e2e_flow.html) tutorial will show you how to evaluate, quantize and run inference with this model. The rest of this section will provide a quick overview of these steps with Llama2.
 
 &nbsp;
 
@@ -271,13 +271,13 @@ tune run full_finetune_distributed --config ./my_custom_config.yaml
 
 &nbsp;
 
-Check out `tune --help` for all possible CLI commands and options. For more information on using and updating configs, take a look at our [config deep-dive](https://pytorch.org/torchtune/stable/deep_dives/configs.html).
+Check out `tune --help` for all possible CLI commands and options. For more information on using and updating configs, take a look at our [config deep-dive](https://pytorch.org/torchtune/main/deep_dives/configs.html).
 
 &nbsp;
 
 ## Design Principles
 
-torchtune embodies PyTorch’s design philosophy [[details](https://pytorch.org/docs/stable/community/design.html)], especially "usability over everything else".
+torchtune embodies PyTorch’s design philosophy [[details](https://pytorch.org/docs/main/community/design.html)], especially "usability over everything else".
 
 ### Native PyTorch
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Check out `tune --help` for all possible CLI commands and options. For more info
 
 ## Design Principles
 
-torchtune embodies PyTorch’s design philosophy [[details](https://pytorch.org/docs/main/community/design.html)], especially "usability over everything else".
+torchtune embodies PyTorch’s design philosophy [[details](https://pytorch.org/docs/stable/community/design.html)], especially "usability over everything else".
 
 ### Native PyTorch
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ torchtune now officially supports Meta Llama3! Check out our recipes for Llama3-
 
 # torchtune
 
-[**Introduction**](#introduction) | [**Installation**](#installation) | [**Get Started**](#get-started) |  [**Documentation**](https://pytorch.org/torchtune) | [**Design Principles**](#design-principles) | [**Community Contributions**](#community-contributions) | [**License**](#license)
+[**Introduction**](#introduction) | [**Installation**](#installation) | [**Get Started**](#get-started) |  [**Documentation**](https://pytorch.org/torchtune/main/index.html) | [**Design Principles**](#design-principles) | [**Community Contributions**](#community-contributions) | [**License**](#license)
 
 &nbsp;
 


### PR DESCRIPTION
#### Context

Our current docs point to stable which have bugs and are far from uptodate. Until we figure out pushes, let's point to main.

#### Changelog

Update link to docs

#### Test plan

Eyes
