### PR TITLE
Update README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This table captures the peak memory usage and training speed for recipes in torc
 | 1 x RTX 4090 |     QLoRA **         |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 12.3 GB | 3155  |
 | 1 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 21.3 GB | 2582  |
 | 2 x RTX 4090 |     LoRA          |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 16.2 GB | 2768  |
-| 1 x RTX 4090 |   Full finetune *   |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 24.1 GB | 702  |
+| 1 x RTX 4090 |   Full finetune *   |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 20.2 GB | 702  |
 | 4 x RTX 4090 |   Full finetune   |  Llama2-7B      |    Batch Size = 4, Seq Length = 2048   | 24.1 GB | 1388  |
 | 8 x A100     |     LoRA          |  Llama2-70B     |    Batch Size = 4, Seq Length = 4096   | 26.4 GB | 3384  |
 | 8 x A100     |   Full Finetune *   |  Llama2-70B     |    Batch Size = 4, Seq Length = 4096   | 70.4 GB | 2032  |


### PR DESCRIPTION
#### Context

Can't reproduce 24.1GB on a single device full finetune and instead seeing 20.2 peak memory allocated (and similar for reserved), so updating this table.

To reproduce, I ensured all inputs are seq_len=2048 - 

```
input_ids = torch.zeros((input_ids.shape[0], 2048), dtype=torch.long)
labels = torch.zeros((labels.shape[0], 2048), dtype=torch.long)
```
And ran with batch_size=4 - 

```tune run full_finetune_single_device --config recipes/configs/llama2/7B_full_low_memory.yaml batch_size=4```