### PR TITLE
Updating generation to use custom_generate_next_token for initial token generation

### DIFF
--- a/torchtune/utils/_generation.py
+++ b/torchtune/utils/_generation.py
@@ -120,7 +120,7 @@ def generate(
         custom_generate_next_token = generate_next_token
 
     # generate the first tokens conditioned on the prompt
-    tokens = generate_next_token(
+    tokens = custom_generate_next_token(
         model,
         input_pos=torch.arange(0, prompt_length, device=prompt.device),
         x=prompt,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

I'n using `generate` with a custom `custom_generate_next_token` defined for a model which outputs both the output of `TransformerDecoder` and an additional value head. `generate` fails when making the first call to `generate_next_token` as it encounters an unexpected return signature for `model(...)`.

Let me know if there's a better way for me to do this.

#### Changelog

Updated the initial call to `generate_next_token` to use `custom_generate_next_token`.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
