### PR TITLE
Delete init_weights_with_constant test util

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,11 +66,6 @@ def get_assets_path():
     return Path(__file__).parent / "assets"
 
 
-def init_weights_with_constant(model: nn.Module, constant: float = 1.0) -> None:
-    for p in model.parameters():
-        nn.init.constant_(p, constant)
-
-
 def fixed_init_tensor(
     shape: torch.Size,
     min_val: Union[float, int] = 0.0,

--- a/tests/torchtune/models/llama2/scripts/compare_attention.py
+++ b/tests/torchtune/models/llama2/scripts/compare_attention.py
@@ -8,8 +8,6 @@ import math
 
 import torch
 
-from tests.test_utils import init_weights_with_constant
-
 from torch import nn
 
 from torchtune.modules import CausalSelfAttention, RotaryPositionalEmbeddings
@@ -195,7 +193,8 @@ def compare_attention(
 
     # reference implementation; initialize with constant to compare outputs
     attn_ref = Attention(n_heads=num_heads, n_kv_heads=num_kv_heads, dim=embed_dim)
-    init_weights_with_constant(attn_ref, constant=0.05)
+    for p in attn_ref.parameters():
+        nn.init.constant_(p, 0.05)
 
     with torch.no_grad():
         attn_out_ref = attn_ref(input_t, freq_cis, mask)
@@ -218,7 +217,8 @@ def compare_attention(
         max_seq_len=max_seq_len,
         attn_dropout=0.0,
     )
-    init_weights_with_constant(attn, constant=0.05)
+    for p in attn.parameters():
+        nn.init.constant_(p, 0.05)
 
     with torch.no_grad():
         attn_out = attn(input_t)

--- a/tests/torchtune/models/llama2/scripts/compare_decoder.py
+++ b/tests/torchtune/models/llama2/scripts/compare_decoder.py
@@ -6,8 +6,6 @@
 
 import torch
 
-from tests.test_utils import init_weights_with_constant
-
 from tests.torchtune.models.llama2.scripts.compare_attention import precompute_freqs_cis
 from tests.torchtune.models.llama2.scripts.compare_decoder_layer import (
     RMSNormRef,
@@ -103,7 +101,8 @@ def compare_decoder(
         max_seq_len=max_seq_len,
         n_kv_heads=num_kv_heads,
     )
-    init_weights_with_constant(decoder_ref, constant=0.2)
+    for p in model.parameters():
+        nn.init.constant_(decoder_ref, 0.2)
 
     with torch.no_grad():
         output_ref = decoder_ref(x_input)
@@ -117,7 +116,8 @@ def compare_decoder(
         max_seq_len=max_seq_len,
         num_kv_heads=num_kv_heads,
     )
-    init_weights_with_constant(decoder, constant=0.2)
+    for p in model.parameters():
+        nn.init.constant_(decoder, 0.2)
 
     with torch.no_grad():
         output = decoder(x_input)

--- a/tests/torchtune/models/llama2/scripts/compare_decoder_layer.py
+++ b/tests/torchtune/models/llama2/scripts/compare_decoder_layer.py
@@ -8,8 +8,6 @@ from typing import Optional
 
 import torch
 
-from tests.test_utils import init_weights_with_constant
-
 from tests.torchtune.models.llama2.scripts.compare_attention import (
     Attention,
     precompute_freqs_cis,
@@ -114,7 +112,8 @@ def compare_decoder_layer(
     transformer_block = TransformerBlock(
         n_heads=num_heads, n_kv_heads=num_kv_heads, dim=embed_dim
     )
-    init_weights_with_constant(transformer_block, constant=0.05)
+    for p in transformer_block.parameters():
+        nn.init.constant_(p, 0.05)
 
     with torch.no_grad():
         block_out = transformer_block(x=input_t, freqs_cis=freq_cis, mask=mask)
@@ -148,7 +147,8 @@ def compare_decoder_layer(
         sa_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
         mlp_norm=RMSNorm(dim=embed_dim, eps=norm_eps),
     )
-    init_weights_with_constant(transformer_layer, constant=0.05)
+    for p in transformer_layer.parameters():
+        nn.init.constant_(p, 0.05)
 
     with torch.no_grad():
         layer_out = transformer_layer(input_t)

--- a/tests/torchtune/modules/peft/test_peft_utils.py
+++ b/tests/torchtune/modules/peft/test_peft_utils.py
@@ -9,8 +9,6 @@ from copy import deepcopy
 import pytest
 import torch
 
-from tests.test_utils import init_weights_with_constant
-
 from torch import nn
 from torchtune.models.llama2 import llama2, lora_llama2
 from torchtune.modules.peft import LoRALinear
@@ -459,8 +457,11 @@ class TestDisableAdapter:
             LoRALinear(in_dim=2, out_dim=6, rank=RANK, alpha=ALPHA),
             nn.Linear(6, 3),
         )
-        init_weights_with_constant(model_ori)
-        init_weights_with_constant(model_lora)
+        # TODO: fix weight initialization to use fixed_init_model
+        for p in model_ori.parameters():
+            nn.init.constant_(p, 1.0)
+        for p in model_lora.parameters():
+            nn.init.constant_(p, 1.0)
         return model_ori, model_lora
 
     def test_disable_adapter(self):

--- a/tests/torchtune/modules/test_transformer_decoder.py
+++ b/tests/torchtune/modules/test_transformer_decoder.py
@@ -10,7 +10,7 @@ import pytest
 
 import torch
 
-from tests.test_utils import assert_expected, init_weights_with_constant
+from tests.test_utils import assert_expected
 
 from torch import nn, Tensor
 
@@ -90,7 +90,9 @@ class TestTransformerDecoderLayer:
             sa_norm=RMSNorm(dim=embed_dim),
             mlp_norm=RMSNorm(dim=embed_dim),
         )
-        init_weights_with_constant(transformer_layer, constant=0.05)
+        # TODO: fix weight initialization to use fixed_init_model
+        for p in transformer_layer.parameters():
+            nn.init.constant_(p, 0.05)
         transformer_layer.eval()
         return transformer_layer
 
@@ -178,7 +180,8 @@ class TestTransformerDecoder:
             max_seq_len=max_seq_len,
         )
         # TODO: fix weight initialization to use fixed_init_model
-        init_weights_with_constant(decoder, constant=0.2)
+        for p in decoder.parameters():
+            nn.init.constant_(p, 0.2)
         decoder.eval()
         return decoder
 
@@ -203,7 +206,8 @@ class TestTransformerDecoder:
             max_seq_len=max_seq_len,
         )
         # TODO: fix weight initialization to use fixed_init_model
-        init_weights_with_constant(decoder, constant=0.2)
+        for p in decoder.parameters():
+            nn.init.constant_(p, 0.2)
         decoder.eval()
         decoder.setup_caches(batch_size=4, dtype=torch.float32)
         return decoder


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [X] update tests and/or documentation
- [ ] other (please add here)

#### Changelog

The `init_weights_with_constant` utility is a bad egg. When we use it validating our models against a reference implementation, it gives false parity at a pretty high rate. (To give an extremely simple example, if our model is just `x -> Ax` for `A` an nxn matrix and we accidentally use `A^T` instead, a constant matrix will give the same output.) An example of this actually occurring in practice in our unit tests is referenced in [this comment](https://github.com/pytorch/torchtune/pull/136#issuecomment-1870786503). 

While `init_weights_with_constant` is not a 100% guarantee that we never run into this problem again, it is much much better than the alternative (which I think most folks agree with at this point).

The problem is that a bunch of our tests still use `init_weights_with_constant`, so it's still in our test utils. And since the names are pretty similar, it's easy to mix the two up. So this PR just deletes the `init_weights_with_constant` util altogether. I have not migrated existing callsites to `init_weights_with_constant` yet, but that can be tackled as a follow-up. I have, however, marked anywhere in our unit tests that's using constant initialization (that I'm aware of) with a TODO to fix it.

#### Test plan

CI
