### PR TITLE
Filter out special tokens and placeholder tokens

### DIFF
--- a/torchtune/models/phi3/_sentencepiece.py
+++ b/torchtune/models/phi3/_sentencepiece.py
@@ -114,7 +114,7 @@ class Phi3MiniSentencePieceTokenizer:
         for token_id in ids:
             # Filter out special tokens and the placeholder tokens added
             # by the Phi3 team
-            if token_id >= 32_000 and token_id < 32_064:
+            if token_id >= 32_000 and token_id <= 32_064:
                 continue
             else:
                 ids_for_decode.append(token_id)

--- a/torchtune/models/phi3/_sentencepiece.py
+++ b/torchtune/models/phi3/_sentencepiece.py
@@ -112,7 +112,9 @@ class Phi3MiniSentencePieceTokenizer:
         """
         ids_for_decode = []
         for token_id in ids:
-            if token_id in self.special_tokens.values():
+            # Filter out special tokens and the placeholder tokens added
+            # by the Phi3 team
+            if token_id >= 32_000 and token_id < 32_064:
                 continue
             else:
                 ids_for_decode.append(token_id)


### PR DESCRIPTION
#### Context

The Phi3 team added 10 special tokens for instruction tuning. They round up to the nearest multiple of 64 so the total vocab size for the embedding is 32064. We should filter out ALL of these tokens during decode (however, unlikely it is that they are generated past 32010). 

If the number is greater than 32064, something is seriously wrong with the model and this should crap out completely.

Closes #976 

#### Changelog
* Change the filtering function to be a range from 32k to 32064

#### Test plan

```
from torchtune.models.phi3 import phi3_mini_tokenizer
tokenizer = phi3_mini_tokenizer(PATH_TO_TOKENIZER)
tokenizer.decode([32000, 32064])
""
```
