### PR TITLE
Add better formatting for Eleuther eval results

### DIFF
--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -27,6 +27,7 @@ try:
     from lm_eval.evaluator import evaluate
     from lm_eval.models.huggingface import HFLM
     from lm_eval.tasks import get_task_dict
+    from lm_eval.utils import make_table
 except ImportError:
     logger.error(
         "Recipe requires EleutherAI Eval Harness v0.4. Please install with `pip install lm_eval==0.4.*`"
@@ -187,15 +188,16 @@ class EleutherEvalRecipe(EvalRecipeInterface):
 
         task_dict = get_task_dict(self._tasks)
         logger.info(f"Running evaluation on {self._tasks} tasks.")
-        eleuther_output = evaluate(
+        output = evaluate(
             model_eval_wrapper,
             task_dict,
             limit=self._limit,
         )
 
         logger.info(f"Eval completed in {time.time() - t1:.02f} seconds.")
-        for task, res in eleuther_output["results"].items():
-            logger.info(f"{task}: {res}")
+
+        formatted_output = make_table(output)
+        print(formatted_output)
 
 
 @config.parse

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -20,7 +20,7 @@ from tests.test_utils import CKPT_MODEL_PATHS
 
 class TestEleutherEval:
     @pytest.mark.integration_test
-    def test_torchtune_checkpoint_eval_results(self, caplog, monkeypatch, tmpdir):
+    def test_torchtune_checkpoint_eval_results(self, capsys, monkeypatch, tmpdir):
         ckpt = "small_test_ckpt_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
@@ -47,10 +47,11 @@ class TestEleutherEval:
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        err_log = caplog.messages[-1]
-        log_search_results = re.search(r"'acc,none': (\d+\.\d+)", err_log)
-        assert log_search_results is not None
-        acc_result = float(log_search_results.group(1))
+        out = capsys.readouterr().out
+
+        search_results = re.search(r"acc(?:_norm)?\s*\|?\s*([\d.]+)", out.strip())
+        assert search_results is not None
+        acc_result = float(search_results.group(1))
         assert math.isclose(acc_result, 0.3, abs_tol=0.05)
 
     @pytest.fixture


### PR DESCRIPTION
#### Context

Add better formatting - useful for when evaluating multiple tasks

#### Changelog

* Utilize `make_table` from eleuther ai

#### Test plan

```
(joe-torchtune) [jrcummings@devgpu012.cln5 ~/projects/joe-torchtune (fix-eleuther-output-fmt)]$ tune run eleuther_eval --config eleuther_evaluation device=cuda batch_size=8 tasks=["truthfulqa_mc2","hellaswag"] limit=10
2024-05-15:11:43:02,826 INFO     [_utils.py:34] Running EleutherEvalRecipe with resolved config:

batch_size: 8
checkpointer:
  _component_: torchtune.utils.FullModelHFCheckpointer
  checkpoint_dir: ./phi3
  checkpoint_files:
  - model-00001-of-00002.safetensors
  - model-00002-of-00002.safetensors
  model_type: PHI3_MINI
  output_dir: ./
device: cuda
dtype: bf16
limit: 10
max_seq_length: 4096
model:
  _component_: torchtune.models.phi3.phi3_mini
quantizer: null
seed: 217
tasks:
- truthfulqa_mc2
- hellaswag
tokenizer:
  _component_: torchtune.models.phi3.phi3_mini_tokenizer
  path: ./phi3/tokenizer.model

2024-05-15:11:43:09,818 DEBUG    [seed.py:60] Setting manual seed to local seed 217. Local seed is seed + rank = 217 + 0
2024-05-15:11:43:14,598 INFO     [eleuther_eval.py:169] Model is initialized with precision torch.bfloat16.
2024-05-15:11:43:14,614 INFO     [eleuther_eval.py:153] Tokenizer is initialized from file.
2024-05-15:11:43:15,392 INFO     [huggingface.py:162] Using device 'cuda:0'
/home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
/home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/datasets/load.py:1486: FutureWarning: The repository for hellaswag contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/hellaswag
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
2024-05-15:11:43:31,623 INFO     [eleuther_eval.py:190] Running evaluation on ['truthfulqa_mc2', 'hellaswag'] tasks.
2024-05-15:11:43:31,625 INFO     [task.py:395] Building contexts for hellaswag on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 2284.60it/s]
2024-05-15:11:43:31,635 INFO     [task.py:395] Building contexts for truthfulqa_mc2 on rank 0...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 723.47it/s]
2024-05-15:11:43:31,651 INFO     [evaluator.py:362] Running loglikelihood requests
Running loglikelihood requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 120/120 [00:06<00:00, 17.88it/s]
2024-05-15:11:43:38,452 INFO     [eleuther_eval.py:197] Eval completed in 23.58 seconds.
|    Tasks     |Version|Filter|n-shot| Metric |Value |   |Stderr|
|--------------|------:|------|------|--------|-----:|---|-----:|
|hellaswag     |      1|none  |None  |acc     |0.4000|±  |0.1633|
|              |       |none  |None  |acc_norm|0.5000|±  |0.1667|
|truthfulqa_mc2|      2|none  |0     |acc     |0.8127|±  |0.1046|

```
