### PR TITLE
Llama3-8b memory efficient full finetune

### DIFF
--- a/recipes/configs/llama3/8B_full_single_device.yaml
+++ b/recipes/configs/llama3/8B_full_single_device.yaml
@@ -51,7 +51,7 @@ resume_from_checkpoint: False
 batch_size: 2
 epochs: 3
 optimizer:
-  _component_: bitsandbytes.optim.AdamW8bit
+  _component_: bitsandbytes.optim.PagedAdamW8bit
   lr: 2e-5
 loss:
   _component_: torch.nn.CrossEntropyLoss


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to

- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

**TL;DR: This PR saves ~46% peak memory for llama3-8b single device full finetune while keeping performance at parity to current offering**, just by switching Adamw8bit -> PagedAdamw8bit. @ebsmothers reminded me that this exists after I took a much more complicated approach.

#### Changelog
- Previous experiments using PagedOptimizer from bnb for llama3 workloads resulted in prohibitvely slow QPS (> 6s/it, compared to using paged optim in llama2 workload still providing > 1 it/s QPS). After some debugging, this is primarily due to paging in and out large optimizer states associated with the embedding and output projection. 
- After a chat with @ebsmothers, we realized that we can just try PagedAdamW8bit, which reduces the size of the optimizer states for the output projection and embedding, and experiments using this proved to benefit memory usage at no cost to QPS. A previous version of this PR made output projection and embedding use  Adamw8bit and the others use PagedOptimizer separately, but this approach is much simpler.

#### Test plan

Current 8B full single device: 

```
Step 132 | loss:0.8253529071807861 lr:2e-05 tokens_per_second_per_gpu:335.27384473126125 peak_memory_active:33.644823552 peak_memory_alloc:33.644823552 peak_memory_reserved:36.320575488
1.27it/s
```

8B_full_single_device using PagedAdamW:

```
Step 44 | loss:0.7166110873222351 lr:2e-05 tokens_per_second_per_gpu:23.2328866347064 peak_memory_active:17.456531968 peak_memory_alloc:17.456531968 peak_memory_reserved:19.302187008
7.64s/it
```

8B full single device with this PR (PagedAdamW8bit):
```
Step 44 | loss:0.7101777195930481 lr:2e-05 tokens_per_second_per_gpu:223.38999360355982 peak_memory_active:17.486964224 peak_memory_alloc:17.486964224 peak_memory_reserved:19.333644288
```


For comparison, current llama2-7b 7B_full_low_memory:

```
Step 44 | loss:0.6592501997947693 lr:2e-05 tokens_per_second_per_gpu:326.61038570142404 peak_memory_active:13.924915712 peak_memory_alloc:13.924915712 peak_memory_reserved:14.845739008
1.41it/s
```

TL;DR: This PR reduces peak memory by ~46% while maintaining approximately the same perf, getting us to a < 24 GB full finetune.

Loss curves are the same (comparing today's baseline versus with these changes) - 

<img width="967" alt="image" src="https://github.com/pytorch/torchtune/assets/8039770/7b267b38-85f0-4624-b454-56c2648b87b6">



#### Follow-ups
- Documentation for optimizer in backward and using bnb optimizers - this documentation is sparse, AFAIk we barely mention bitsandbytes in our docs and don't explain running optimizer in backward at all. We should add comprehensive documentation around these full finetuning memory optimizations.
- Update numbers in README table (though I think these are for llama2 at the moment).
