### PR TITLE
Fix position embeddings for Phi3 when packing + nits

### DIFF
--- a/recipes/configs/phi3/mini_full.yaml
+++ b/recipes/configs/phi3/mini_full.yaml
@@ -6,12 +6,12 @@
 #   tune download microsoft/Phi-3-mini-4k-instruct --output-dir /tmp/Phi-3-mini-4k-instruct --hf-token <HF_TOKEN> --ignore-patterns ""
 #
 # Run this config on 4 GPUs using the following:
-#  tune run --nproc_per_node 2 full_finetune_distributed --config phi3/mini_full.yaml
+#  tune run --nproc_per_node 4 full_finetune_distributed --config phi3/mini_full
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run --nproc_per_node 2 full_finetune_distributed --config phi3/mini_full.yaml checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nproc_per_node 4 full_finetune_distributed --config phi3/mini_full checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
 # This config works best when the model is being fine-tuned on 2+ GPUs.
 # Single device full finetuning requires more memory optimizations. It's

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -117,8 +117,8 @@ class PackedDataset(Dataset):
         if rank == 0:
             pbar = tqdm(total=len(self.ds), desc="Packing dataset", dynamic_ncols=True)
 
-        for batch in self.ds:
-            tokens, labels = batch["tokens"], batch["labels"]
+        for sample in self.ds:
+            tokens, labels = sample["tokens"], sample["labels"]
             # If the dataset outputs samples that are larger than the specified
             # max_seq_len and we're unable to split it, user needs to modify
             # one of the two parameters
@@ -205,7 +205,7 @@ class PackedDataset(Dataset):
         padding_idx: int = 0,
         ignore_idx: int = CROSS_ENTROPY_IGNORE_IDX,
     ) -> Dict[str, torch.Tensor]:
-        """Pad a batch of packed sequences to max sequence length in the batch, and
+        """Pad a group of packed sequences to max sequence length in the group, and
         convert integer lists to tensors. Account for attention mask and position
         ids.
 

--- a/torchtune/models/phi3/_position_embeddings.py
+++ b/torchtune/models/phi3/_position_embeddings.py
@@ -96,9 +96,9 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
         )
 
         # reshape the cache for broadcasting
-        # tensor has shape [b, s, 1, h_d] if packed samples,
-        # otherwise has shape [1, s, 1, h_d]
-        rope_cache = rope_cache.view(-1, seq_len, 1, head_dim)
+        # tensor has shape [b, s, 1, h_d * 2] if packed samples,
+        # otherwise has shape [1, s, 1, h_d * 2]
+        rope_cache = rope_cache.view(-1, seq_len, 1, head_dim * 2)
 
         # [b, s, 1, h_d]
         cos = rope_cache[..., :head_dim]
@@ -110,7 +110,5 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
 
         # cos: [b, s, 1, h_d]
         # x: [b, s, n_h, h_d]
-        # For the matrix multiplication to line up, transpose the input
-        # and the rotated input
-        x_out = (x.transpose(1, 2) * cos) + (rotated.transpose(1, 2) * sin)
-        return x_out.transpose(1, 2).type_as(x)
+        x_out = (x * cos) + (rotated * sin)
+        return x_out.type_as(x)

--- a/torchtune/models/phi3/_position_embeddings.py
+++ b/torchtune/models/phi3/_position_embeddings.py
@@ -69,9 +69,12 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
         """
         Args:
             x (Tensor): input tensor with shape
-                [bsz, seq_len, num_heads, head_dim]
-            input_pos (Optional[Tensor]): Optional tensor which contains the position
-                of the current token. This is only used during inference. Default is None
+                [b, s, n_h, h_d]
+            input_pos (Optional[Tensor]): Optional tensor which contains the position ids
+                of each token. During training, this is used to indicate the positions
+                of each token relative to its sample when packed, shape [b, s].
+                During inference, this indicates the position of the current token.
+                If none, assume the index of the token is its position id. Default is None.
 
         Returns:
             Tensor: output tensor with RoPE applied

--- a/torchtune/modules/position_embeddings.py
+++ b/torchtune/modules/position_embeddings.py
@@ -95,7 +95,7 @@ class RotaryPositionalEmbeddings(nn.Module):
         TODO: The implementation below can be made more efficient
         for inference.
         """
-        # input tensor has shape [b, s, n_h, n_d]
+        # input tensor has shape [b, s, n_h, h_d]
         seq_len = x.size(1)
 
         # extract the values based on whether input_pos is set or not
@@ -105,15 +105,15 @@ class RotaryPositionalEmbeddings(nn.Module):
 
         # reshape input; the last dimension is used for computing the output.
         # Cast to float to match the reference implementation
-        # tensor has shape [b, s, n_h, n_d // 2, 2]
+        # tensor has shape [b, s, n_h, h_d // 2, 2]
         xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
 
         # reshape the cache for broadcasting
-        # tensor has shape [b, s, 1, n_d // 2, 2] if packed samples,
-        # otherwise has shape [1, s, 1, n_d // 2, 2]
+        # tensor has shape [b, s, 1, h_d // 2, 2] if packed samples,
+        # otherwise has shape [1, s, 1, h_d // 2, 2]
         rope_cache = rope_cache.view(-1, xshaped.size(1), 1, xshaped.size(3), 2)
 
-        # tensor has shape [b, s, n_h, n_d // 2, 2]
+        # tensor has shape [b, s, n_h, h_d // 2, 2]
         x_out = torch.stack(
             [
                 xshaped[..., 0] * rope_cache[..., 0]
@@ -124,6 +124,6 @@ class RotaryPositionalEmbeddings(nn.Module):
             -1,
         )
 
-        # tensor has shape [b, s, n_h, n_d]
+        # tensor has shape [b, s, n_h, h_d]
         x_out = x_out.flatten(3)
         return x_out.type_as(x)

--- a/torchtune/modules/position_embeddings.py
+++ b/torchtune/modules/position_embeddings.py
@@ -76,10 +76,10 @@ class RotaryPositionalEmbeddings(nn.Module):
         """
         Args:
             x (Tensor): input tensor with shape
-                [bsz, seq_len, num_heads, head_dim]
+                [b, s, n_h, h_d]
             input_pos (Optional[Tensor]): Optional tensor which contains the position ids
                 of each token. During training, this is used to indicate the positions
-                of each token relative to its sample when packed, shape [bsz, seq_len].
+                of each token relative to its sample when packed, shape [b, s].
                 During inference, this indicates the position of the current token.
                 If none, assume the index of the token is its position id. Default is None.
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
- Ensure position embeddings in phi3 can handle a batch of `input_pos` when packing
- Update incorrect commands in phi3 configs
- minor variable renaming and comment nits

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

Test runs to make sure phi3 runs with packing and loss is comparable to unpacked before changes.

`tune run --nproc_per_node 8 full_finetune_distributed --config phi3/mini_full`

<img width="423" alt="image" src="https://github.com/pytorch/torchtune/assets/33648637/8fa5f7b7-17cd-4654-89ff-e399d9a3212d">
