### PR TITLE
fix: different rope base between phi3 and lora_phi3

### DIFF
--- a/tests/torchtune/models/phi3/test_lora_phi3.py
+++ b/tests/torchtune/models/phi3/test_lora_phi3.py
@@ -137,14 +137,14 @@ class TestLoRAPhi3:
     @pytest.mark.parametrize(
         "lora_modules, apply_lora_to_mlp, apply_lora_to_output, expected",
         [
-            (["q_proj", "v_proj"], False, False, torch.tensor(2869701.75)),
+            (["q_proj", "v_proj"], False, False, torch.tensor(2869687.75)),
             (
                 ["q_proj", "k_proj", "v_proj", "output_proj"],
                 True,
                 False,
-                torch.tensor(10674807.0),
+                torch.tensor(10674772.0),
             ),
-            (["k_proj"], True, True, torch.tensor(16285855.0)),
+            (["k_proj"], True, True, torch.tensor(16285834.0)),
         ],
     )
     def test_forward(

--- a/tests/torchtune/models/phi3/test_lora_phi3.py
+++ b/tests/torchtune/models/phi3/test_lora_phi3.py
@@ -61,9 +61,9 @@ class TestLoRAPhi3SelfAttention:
     @pytest.mark.parametrize(
         "lora_modules, expected",
         [
-            (["q_proj", "v_proj"], torch.tensor(50.64567)),
-            (["q_proj", "k_proj", "v_proj", "output_proj"], torch.tensor(77.17097)),
-            (["k_proj"], torch.tensor(44.90090)),
+            (["q_proj", "v_proj"], torch.tensor(51.88655)),
+            (["q_proj", "k_proj", "v_proj", "output_proj"], torch.tensor(75.80934)),
+            (["k_proj"], torch.tensor(44.00425)),
         ],
     )
     def test_forward(self, inputs, lora_modules, expected):

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -45,7 +45,7 @@ def phi3(
     max_seq_len: int,
     attn_dropout: float = 0.0,
     norm_eps: float = 1e-5,
-    rope_base: int = 10000,
+    rope_base: int = 10_000,
 ) -> TransformerDecoder:
     """
     Args:
@@ -133,7 +133,7 @@ def lora_phi3(
     max_seq_len: int,
     attn_dropout: float = 0.0,
     norm_eps: float = 1e-5,
-    rope_base: int = 10000,
+    rope_base: int = 10_000,
     # LoRA args
     lora_rank: int,
     lora_alpha: float,

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -45,7 +45,7 @@ def phi3(
     max_seq_len: int,
     attn_dropout: float = 0.0,
     norm_eps: float = 1e-5,
-    rope_base: int = 10000.0,
+    rope_base: int = 10000,
 ) -> TransformerDecoder:
     """
     Args:
@@ -133,7 +133,7 @@ def lora_phi3(
     max_seq_len: int,
     attn_dropout: float = 0.0,
     norm_eps: float = 1e-5,
-    rope_base: float = 10000.0,
+    rope_base: int = 10000,
     # LoRA args
     lora_rank: int,
     lora_alpha: float,
@@ -167,6 +167,8 @@ def lora_phi3(
         attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
             Default: 0.0
         norm_eps (float): epsilon in RMS norms.
+        rope_base (int): base value for Rotary Position Embeddings.
+            Default: 10000
         lora_rank (int): rank of each low-rank approximation
         lora_alpha (float): scaling factor for the low-rank approximation
         lora_dropout (float): LoRA dropout probability. Default: 0.0
@@ -252,7 +254,7 @@ def lora_phi3_self_attention(
     num_kv_heads: int,
     max_seq_len: int,
     attn_dropout: float = 0.0,
-    rope_base: float = 500000.0,
+    rope_base: int = 10_000,
     # LoRA args
     lora_rank: int,
     lora_alpha: float,
@@ -277,6 +279,8 @@ def lora_phi3_self_attention(
             by :func:`~torchtune.modules.KVCache`
         attn_dropout (float): dropout value passed onto scaled_dot_product_attention.
             Default: 0.0
+        rope_base (int): base value for Rotary Position Embeddings.
+            Default: 10000
         lora_rank (int): rank of each low-rank approximation
         lora_alpha (float): scaling factor for the low-rank approximation
         lora_dropout (float): LoRA dropout probability. Default: 0.0

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -45,7 +45,7 @@ def phi3(
     max_seq_len: int,
     attn_dropout: float = 0.0,
     norm_eps: float = 1e-5,
-    rope_base: int = 10_000,
+    rope_base: int = 10000.0,
 ) -> TransformerDecoder:
     """
     Args:
@@ -133,7 +133,7 @@ def lora_phi3(
     max_seq_len: int,
     attn_dropout: float = 0.0,
     norm_eps: float = 1e-5,
-    rope_base: float = 500000.0,
+    rope_base: float = 10000.0,
     # LoRA args
     lora_rank: int,
     lora_alpha: float,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

This is related to: #982 

#### Changelog
I have set the same default parameter `rope_base` to both lora and non lora version. I chose 10000.0 to match the `rope_theta` from hugging face : https://huggingface.co/microsoft/Phi-3-mini-128k-instruct/blob/main/config.json

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
