### PR TITLE
Fix Gemma 2B model forward call

### DIFF
--- a/torchtune/models/gemma/transformer.py
+++ b/torchtune/models/gemma/transformer.py
@@ -134,7 +134,7 @@ class GemmaTransformerDecoder(nn.Module):
 
         for layer in self.layers:
             # shape: [b, s, d]
-            h = layer(h, mask, input_pos)
+            h = layer(h, mask=mask, input_pos=input_pos)
 
         # shape: [b, s, d]
         h = self.norm(h)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
* Add proper kwarg spec for gemma forward call

#### Test plan
```
(joe-torchtune) [jrcummings@devgpu012.cln5 ~/projects/joe-torchtune (fix-gemma-2b-ootb)]$ tune run full_finetune_single_device --config gemma/2B_full
2024-05-17:07:04:38,856 INFO     [_utils.py:34] Running FullFinetuneRecipeSingleDevice with resolved config:

batch_size: 2
checkpointer:
  _component_: torchtune.utils.FullModelHFCheckpointer
  checkpoint_dir: ./gemma2b
  checkpoint_files:
  - model-00001-of-00002.safetensors
  - model-00002-of-00002.safetensors
  model_type: GEMMA
  output_dir: /tmp/gemma
  recipe_checkpoint: null
compile: false
dataset:
  _component_: torchtune.datasets.alpaca_dataset
  train_on_input: true
device: cuda
dtype: bf16
enable_activation_checkpointing: true
epochs: 3
gradient_accumulation_steps: 1
log_every_n_steps: 1
log_peak_memory_stats: false
loss:
  _component_: torch.nn.CrossEntropyLoss
max_steps_per_epoch: null
memory_efficient_fsdp_wrap: false
metric_logger:
  _component_: torchtune.utils.metric_logging.DiskLogger
  log_dir: /tmp/alpaca-gemma-finetune
model:
  _component_: torchtune.models.gemma.gemma_2b
optimizer:
  _component_: torch.optim.AdamW
  lr: 2.0e-05
optimizer_in_bwd: false
output_dir: /tmp/alpaca-gemma-finetune
resume_from_checkpoint: false
seed: null
shuffle: true
tokenizer:
  _component_: torchtune.models.gemma.gemma_tokenizer
  path: ./gemma2b/tokenizer.model

2024-05-17:07:04:45,571 DEBUG    [seed.py:60] Setting manual seed to local seed 260787381. Local seed is seed + rank = 260787381 + 0
Writing logs to /tmp/alpaca-gemma-finetune/log_1715954685.txt
2024-05-17:07:04:47,510 INFO     [full_finetune_single_device.py:259] Model is initialized with precision torch.bfloat16.
2024-05-17:07:04:47,511 INFO     [memory.py:223] Memory stats after model init:
        GPU peak memory allocation: 5.39 GB
        GPU peak memory reserved: 5.52 GB
        GPU peak memory active: 5.39 GB
2024-05-17:07:04:47,647 INFO     [full_finetune_single_device.py:197] Tokenizer is initialized from file.
2024-05-17:07:04:47,649 INFO     [full_finetune_single_device.py:311] Optimizer is initialized.
2024-05-17:07:04:47,650 INFO     [full_finetune_single_device.py:210] Loss is initialized.
2024-05-17:07:04:50,314 INFO     [full_finetune_single_device.py:356] Dataset and Sampler are initialized.
1|12|Loss: 1.1577736139297485:   0%|                                                                                                                               | 12/26001 [00:27<10:47:32,  1.49s/it]
```