### PR TITLE
[#970] Guide Users to Fine-Tune with Their Own Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ Full 8B
 tune run full_finetune_single_device --config llama3/8B_full_single_device
 ```
 
+QLoRA 8B with Custom Instruct Dataset
+
+```bash
+tune run lora_finetune_single_device --config llama3/8B_qlora_single_device_custom_instruct
+```
+
+Make sure to place your dataset in **./train.json**. The train.json file should follow the format of a list of dictionaries, with each dictionary containing the keys: instruction, input, and output.
+
+
 ### Multi GPU
 
 Full 8B

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ QLoRA 8B with Custom Instruct Dataset
 tune run lora_finetune_single_device --config llama3/8B_qlora_single_device_custom_instruct
 ```
 
-Make sure to place your dataset in **./train.json**. The train.json file should follow the format of a list of dictionaries, with each dictionary containing the keys: instruction, input, and output.
+Make sure to place your dataset in **/tmp/train.json**. The train.json file should follow the format of a list of dictionaries, with each dictionary containing the keys: instruction, input, and output.
 
 
 ### Multi GPU

--- a/recipes/configs/llama3/8B_qlora_single_device_custom_instruct.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device_custom_instruct.yaml
@@ -27,11 +27,11 @@ model:
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.llama3.llama3_tokenizer
-  path: /home/jeff_yang/tune/llmav3_instruct/original/tokenizer.model
+  path: /tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model
 
 checkpointer:
   _component_: torchtune.utils.FullModelMetaCheckpointer
-  checkpoint_dir: /home/jeff_yang/tune/llmav3_instruct/original/
+  checkpoint_dir: /tmp/Meta-Llama-3-8B-Instruct/original/
   checkpoint_files: [
     consolidated.00.pth
   ]
@@ -44,7 +44,7 @@ resume_from_checkpoint: False
 dataset:
   _component_: torchtune.datasets.custom_instruct_dataset
   train_on_input: True
-  dataset_path: /home/jeff_yang/tune/dataset/yoga_beginner/train.json
+  dataset_path: ./train.json
 seed: null
 shuffle: True
 batch_size: 2

--- a/recipes/configs/llama3/8B_qlora_single_device_custom_instruct.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device_custom_instruct.yaml
@@ -1,0 +1,86 @@
+# Config for single device QLoRA with lora_finetune_single_device.py
+# using a Llama3 8B Instruct model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download meta-llama/Meta-Llama-3-8B-Instruct --output-dir /tmp/Meta-Llama-3-8B-Instruct --hf-token <HF_TOKEN>
+#
+# To launch on a single device, run the following command from root:
+#   tune run lora_finetune_single_device --config llama3/8B_qlora_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run lora_finetune_single_device --config llama3/8B_qlora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3.qlora_llama3_8b
+  lora_attn_modules: ['q_proj', 'v_proj', 'k_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 8
+  lora_alpha: 16
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /home/jeff_yang/tune/llmav3_instruct/original/tokenizer.model
+
+checkpointer:
+  _component_: torchtune.utils.FullModelMetaCheckpointer
+  checkpoint_dir: /home/jeff_yang/tune/llmav3_instruct/original/
+  checkpoint_files: [
+    consolidated.00.pth
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/Meta-Llama-3-8B-Instruct/
+  model_type: LLAMA3
+resume_from_checkpoint: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.custom_instruct_dataset
+  train_on_input: True
+  dataset_path: /home/jeff_yang/tune/dataset/yoga_beginner/train.json
+seed: null
+shuffle: True
+batch_size: 2
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.modules.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torch.nn.CrossEntropyLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 16
+compile: False
+
+# Logging
+output_dir: /tmp/qlora_finetune_output/
+metric_logger:
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
+log_every_n_steps: 1
+log_peak_memory_stats: False
+
+# Environment
+device: cuda
+dtype: bf16
+enable_activation_checkpointing: True
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.utils.profiler
+  enabled: False

--- a/recipes/configs/llama3/8B_qlora_single_device_custom_instruct.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device_custom_instruct.yaml
@@ -44,7 +44,7 @@ resume_from_checkpoint: False
 dataset:
   _component_: torchtune.datasets.custom_instruct_dataset
   train_on_input: True
-  dataset_path: ./train.json
+  dataset_path: /tmp/train.json
 seed: null
 shuffle: True
 batch_size: 2

--- a/tests/torchtune/datasets/test_custom_instruct_dataset.py
+++ b/tests/torchtune/datasets/test_custom_instruct_dataset.py
@@ -1,0 +1,126 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import pytest
+from datasets import Dataset
+
+from tests.test_utils import get_assets_path
+from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
+from torchtune.datasets import custom_instruct_dataset
+from torchtune.modules.tokenizers import SentencePieceTokenizer
+
+
+class TestCustomInstructDataset:
+    @pytest.fixture
+    def tokenizer(self):
+        # m.model is a pretrained Sentencepiece model using the following command:
+        # spm.SentencePieceTrainer.train('--input=<TRAIN_FILE> --model_prefix=m --vocab_size=2000')
+        return SentencePieceTokenizer(str(get_assets_path() / "m.model"))
+
+    @patch("torchtune.datasets._instruct.load_dataset")
+    def test_label_no_masking(self, load_dataset, tokenizer):
+        """
+        Test whether the input and the labels are correctly created when the input is not masked.
+        """
+
+        # mock the call to HF datasets
+        load_dataset.return_value = Dataset.from_list(
+            [
+                {
+                    "instruction": "Give three tips for staying healthy.",
+                    "input": "",
+                    "output": (
+                        "1.Eat a balanced diet and make sure to include plenty of fruits and vegetables."
+                        "2. Exercise regularly to keep your body active and strong."
+                        "3. Get enough sleep and maintain a consistent sleep schedule."
+                    ),
+                }
+            ]
+        )
+
+        alpaca_ds = custom_instruct_dataset(
+            tokenizer=tokenizer, dataset_path="path/to/saved/dataset.json"
+        )
+        input, labels = alpaca_ds[0]["tokens"], alpaca_ds[0]["labels"]
+
+        assert len(input) == len(labels)
+        assert labels[-1] == tokenizer.eos_id
+        assert input[0] == tokenizer.bos_id
+        assert CROSS_ENTROPY_IGNORE_IDX not in labels
+
+    @patch("torchtune.datasets._instruct.load_dataset")
+    def test_label_masking(self, load_dataset, tokenizer):
+        """
+        Test whether the input and the labels are correctly created when the input is masked.
+        """
+
+        # mock the call to HF datasets
+        load_dataset.return_value = Dataset.from_list(
+            [
+                {
+                    "instruction": "Give three tips for staying healthy.",
+                    "input": "",
+                    "output": (
+                        "1.Eat a balanced diet and make sure to include plenty of fruits and vegetables."
+                        "2. Exercise regularly to keep your body active and strong."
+                        "3. Get enough sleep and maintain a consistent sleep schedule."
+                    ),
+                }
+            ]
+        )
+
+        alpaca_ds = custom_instruct_dataset(
+            tokenizer=tokenizer,
+            dataset_path="path/to/saved/dataset.json",
+            train_on_input=False,
+        )
+
+        # Extract the prompt and tokenize it; we'll need this to test whether we're masking the
+        # input correctly
+        sample = alpaca_ds._data[0]
+        prompt = alpaca_ds.template.format(sample=sample)
+        encoded_prompt = tokenizer.encode(text=prompt, add_bos=True, add_eos=False)
+
+        # Generate the input and labels
+        input, labels = alpaca_ds[0]["tokens"], alpaca_ds[0]["labels"]
+
+        assert len(input) == len(labels)
+        assert labels[-1] == tokenizer.eos_id
+        assert input[0] == tokenizer.bos_id
+        assert labels.count(CROSS_ENTROPY_IGNORE_IDX) == len(encoded_prompt)
+
+    @patch("torchtune.datasets._instruct.load_dataset")
+    def test_alpaca_clean(self, load_dataset, tokenizer):
+        """
+        Test whether the input and the labels are correctly created when the input is not masked.
+        """
+
+        # mock the call to HF datasets
+        load_dataset.return_value = Dataset.from_list(
+            [
+                {
+                    "instruction": "Give three tips for staying healthy.",
+                    "input": "",
+                    "output": (
+                        "1.Eat a balanced diet and make sure to include plenty of fruits and vegetables."
+                        "2. Exercise regularly to keep your body active and strong."
+                        "3. Get enough sleep and maintain a consistent sleep schedule."
+                    ),
+                }
+            ]
+        )
+
+        alpaca_ds = custom_instruct_dataset(
+            tokenizer=tokenizer, dataset_path="path/to/saved/dataset.json"
+        )
+        input, labels = alpaca_ds[0]["tokens"], alpaca_ds[0]["labels"]
+
+        assert len(input) == len(labels)
+        assert labels[-1] == tokenizer.eos_id
+        assert input[0] == tokenizer.bos_id
+        assert CROSS_ENTROPY_IGNORE_IDX not in labels

--- a/tests/torchtune/datasets/test_instruct_dataset.py
+++ b/tests/torchtune/datasets/test_instruct_dataset.py
@@ -148,3 +148,21 @@ class TestInstructDataset:
             prompt, label = dataset[i]["tokens"], dataset[i]["labels"]
             assert prompt == self.expected_tokenized_prompts[i]
             assert label == expected_labels[i]
+
+    @mock.patch("torchtune.datasets._instruct.load_dataset")
+    def test_get_item_json_source(self, mock_load_dataset):
+        mock_load_dataset.return_value = Dataset.from_list(self.get_samples())
+        dataset = InstructDataset(
+            tokenizer=DummyTokenizer(),
+            source="dataset.json",
+            template=self.template,
+            transform=dummy_transform,
+            train_on_input=True,
+        )
+        assert len(dataset) == 2
+        mock_load_dataset.assert_called_once_with("json", data_files="dataset.json")
+
+        for i in range(len(dataset)):
+            prompt, label = dataset[i]["tokens"], dataset[i]["labels"]
+            assert prompt == self.expected_tokenized_prompts[i]
+            assert label == self.expected_tokenized_prompts[i]

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -92,6 +92,10 @@ _ALL_RECIPES = [
                 file_path="llama3/8B_qlora_single_device.yaml",
             ),
             Config(
+                name="llama3/8B_qlora_single_device_custom_instruct",
+                file_path="llama3/8B_qlora_single_device_custom_instruct.yaml",
+            ),
+            Config(
                 name="llama2/13B_qlora_single_device",
                 file_path="llama2/13B_qlora_single_device.yaml",
             ),

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -7,6 +7,7 @@
 from torchtune.datasets._alpaca import alpaca_cleaned_dataset, alpaca_dataset
 from torchtune.datasets._chat import chat_dataset, ChatDataset
 from torchtune.datasets._concat import ConcatDataset
+from torchtune.datasets._custom_instruct import custom_instruct_dataset
 from torchtune.datasets._grammar import grammar_dataset
 from torchtune.datasets._instruct import instruct_dataset, InstructDataset
 from torchtune.datasets._packed import PackedDataset
@@ -27,4 +28,5 @@ __all__ = [
     "chat_dataset",
     "PackedDataset",
     "ConcatDataset",
+    "custom_instruct_dataset",
 ]

--- a/torchtune/datasets/_custom_instruct.py
+++ b/torchtune/datasets/_custom_instruct.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+from torchtune.datasets._instruct import instruct_dataset, InstructDataset
+from torchtune.modules.tokenizers import Tokenizer
+
+
+def custom_instruct_dataset(
+    tokenizer: Tokenizer,
+    *,
+    dataset_path: str,
+    train_on_input: bool = True,
+    max_seq_len: int = 512,
+    packed: bool = False,
+) -> InstructDataset:
+    """
+    Custom dataset loader for Alpaca-style datasets from a local path.
+
+    Masking of the prompt during training is controlled by the `train_on_input` flag, which is
+    set to `True` by default.
+    - If `train_on_input` is True, the prompt is used during training and
+    contributes to the loss.
+    - If `train_on_input` is False, the prompt is masked out (tokens replaced with -100)
+
+    Args:
+        tokenizer (Tokenizer): Tokenizer used to encode data. Tokenizer must implement an `encode` and `decode` method.
+        dataset_path (str): Path to the local directory where the dataset is saved in JSON format.
+        train_on_input (bool): Whether the model is trained on the prompt or not. Default is True.
+        max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
+            Default is 512, but we recommend setting this to the highest you can fit in memory and
+            is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
+        packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
+
+    Returns:
+        InstructDataset: dataset configured with source data and template
+
+    Example:
+        >>> custom_ds = custom_dataset(tokenizer=tokenizer, dataset_path="path/to/saved/dataset.json")
+        >>> for batch in DataLoader(custom_ds, batch_size=8):
+        >>>     print(f"Batch size: {len(batch)}")
+        >>> Batch size: 8
+    """
+
+    return instruct_dataset(
+        tokenizer=tokenizer,
+        source=dataset_path,
+        template="AlpacaInstructTemplate",
+        train_on_input=train_on_input,
+        max_seq_len=max_seq_len,
+        packed=packed,
+        split="train",
+    )
+
+
+# Example usage:
+custom_cleaned_dataset = partial(
+    custom_instruct_dataset, dataset_path="path/to/save/dataset.json"
+)

--- a/torchtune/datasets/_instruct.py
+++ b/torchtune/datasets/_instruct.py
@@ -66,7 +66,11 @@ class InstructDataset(Dataset):
         **load_dataset_kwargs: Dict[str, Any],
     ) -> None:
         self._tokenizer = tokenizer
-        self._data = load_dataset(source, **load_dataset_kwargs)
+        if source.endswith(".json"):
+            self._data = load_dataset("json", data_files=source, **load_dataset_kwargs)
+        else:
+            self._data = load_dataset(source, **load_dataset_kwargs)
+
         self.template = template
         self._transform = transform
         self._column_map = column_map


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
- This PR addresses issue #970.

#### Changelog
What are the changes made in this PR?
- Added a new feature that allows users to fine-tune their own dataset by running `tune run lora_finetune_single_device --config llama3/8B_qlora_single_device_custom_instruct`.
- Updated the documentation to include instructions for placing a custom dataset in `./train.json` and the required format for `train.json`.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
	- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
  
**Commands and Artifacts:**
- Ran the command `tune run lora_finetune_single_device --config llama3/8B_qlora_single_device_custom_instruct` with a custom `train.json`.