### PR TITLE
[LoRA] del logits to save peak memory

### DIFF
--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -590,6 +590,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 logits = logits.transpose(1, 2)
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
+                # free logits otherwise it peaks backward memory
+                del logits
 
                 loss = loss / self._gradient_accumulation_steps
                 running_loss += loss


### PR DESCRIPTION
`logits.shape=(bs, seq_len, vocab_size)`. In my snapshot, logits.shape=(2, 512, 32000) in float32, 6% of peak memory, see blue chunk

`del logits` could lower peak memory otherwise it won't be freed util the end of the inner for loop

**Snapshot** of memory traces showing logits
<img width="902" alt="Screenshot 2024-06-04 at 11 24 33 AM" src="https://github.com/pytorch/torchtune/assets/134637289/81105559-c539-4fde-b7d9-41bae15281bc">
