### PR TITLE
update checkpoint paths in llama3 tutorial

### DIFF
--- a/docs/source/tutorials/llama3.rst
+++ b/docs/source/tutorials/llama3.rst
@@ -157,7 +157,7 @@ Next, we modify ``custom_eval_config.yaml`` to include the fine-tuned checkpoint
       # checkpoint files for the fine-tuned model. These will be logged
       # at the end of your fine-tune
       checkpoint_files: [
-        consolidated.00.pth
+        meta_model_0.pt
       ]
 
       output_dir: <checkpoint_dir>
@@ -209,7 +209,7 @@ Now we modify ``custom_generation_config.yaml`` to point to our checkpoint and t
       # checkpoint files for the fine-tuned model. These will be logged
       # at the end of your fine-tune
       checkpoint_files: [
-        consolidated.00.pth
+        meta_model_0.pt
       ]
 
       output_dir: <checkpoint_dir>
@@ -267,7 +267,7 @@ And update ``custom_quantization_config.yaml`` with the following:
       # checkpoint files for the fine-tuned model. These will be logged
       # at the end of your fine-tune
       checkpoint_files: [
-        consolidated.00.pth
+        meta_model_0.pt
       ]
 
       output_dir: <checkpoint_dir>


### PR DESCRIPTION
The checkpoint files provided in the Llama3 tutorial generation, eval, and quantization configs are incorrect. They currently point to `consolidated.00.pth` which is the raw checkpoint prior to any fine-tuning. Instead they should point to the filename after fine-tuning, which is `meta_model_0.pt`.