### PR TITLE
[QLoRA][FSDP2] check is_fbcode before checking torchao version

### DIFF
--- a/torchtune/modules/low_precision/_register_nf4_dispatch_ops.py
+++ b/torchtune/modules/low_precision/_register_nf4_dispatch_ops.py
@@ -10,6 +10,10 @@ import torch
 from torchao.dtypes.nf4tensor import implements as nf4_tensor_impl, to_nf4
 
 
+def is_fbcode():
+    return not hasattr(torch.version, "git_version")
+
+
 @nf4_tensor_impl([torch.ops.aten.clone.default])
 def clone(func, *args, **kwargs):
     """
@@ -21,7 +25,7 @@ def clone(func, *args, **kwargs):
     return to_nf4(args[0][0].get_original_weight())
 
 
-if version("torchao") < "0.2.0":
+if is_fbcode() or version("torchao") < "0.2.0":
     # TorchAO have `NF4.copy_` starting from `0.2.0`
     # it's a superset of `inplace_copy` since it covers `NF4.copy_(NF4)`
     @nf4_tensor_impl([torch.ops.aten.copy_.default])


### PR DESCRIPTION
Summary:
fixes torchtune diff train

check `is_fbcode` before calling `version(torchao)`. since python package version only works in OSS

Reviewed By: SLR722

Differential Revision: D58310877
