### PR TITLE
[logger] added flush to DiskLogger

### DIFF
--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -97,12 +97,14 @@ class DiskLogger(MetricLoggerInterface):
 
     def log(self, name: str, data: Scalar, step: int) -> None:
         self._file.write(f"Step {step} | {name}:{data}\n")
+        self._file.flush()
 
     def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         self._file.write(f"Step {step} | ")
         for name, data in payload.items():
             self._file.write(f"{name}:{data} ")
         self._file.write("\n")
+        self._file.flush()
 
     def __del__(self) -> None:
         self._file.close()


### PR DESCRIPTION
#### Context

issue: https://github.com/pytorch/torchtune/issues/1040

What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

If some part of the pipeline breaks, the logger may not have a chance to flush whats in the buffer. By adding flush after every .log, we can avoid it. A better solution would be to try to gracefully shutdown if something breaks, and then call .flush there, but this should be more complex.

It does increase latency by a few ms, but it shouldn't be a problem if we are only logging a few times per step:
```
without flush: 0.00066
with flush: 0.0051
```

#### Changelog
Just added .flush

#### Test plan
pytest

<img width="1222" alt="image" src="https://github.com/pytorch/torchtune/assets/23004953/d576ef1b-ec23-466a-8d46-dbc428c35fc1">


- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
