### PR TITLE
Fix WandBLogger to allow resuming runs with updated config values

### DIFF
--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -200,8 +200,8 @@ class WandBLogger(MetricLoggerInterface):
         if getattr(self._wandb, "define_metric", None):
             self._wandb.define_metric("global_step")
             self._wandb.define_metric("*", step_metric="global_step", step_sync=True)
-        
-        self.config_allow_val_change = kwargs.get('allow_val_change', False)
+
+        self.config_allow_val_change = kwargs.get("allow_val_change", False)
 
     def log_config(self, config: DictConfig) -> None:
         """Saves the config locally and also logs the config to W&B. The config is
@@ -214,7 +214,9 @@ class WandBLogger(MetricLoggerInterface):
         """
         if self._wandb.run:
             resolved = OmegaConf.to_container(config, resolve=True)
-            self._wandb.config.update(resolved, allow_val_change=self.config_allow_val_change)
+            self._wandb.config.update(
+                resolved, allow_val_change=self.config_allow_val_change
+            )
             try:
                 output_config_fname = Path(
                     os.path.join(

--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -200,6 +200,10 @@ class WandBLogger(MetricLoggerInterface):
         if getattr(self._wandb, "define_metric", None):
             self._wandb.define_metric("global_step")
             self._wandb.define_metric("*", step_metric="global_step", step_sync=True)
+        
+        self.config_allow_val_change = kwargs.get('allow_val_change', False)
+
+       
 
     def log_config(self, config: DictConfig) -> None:
         """Saves the config locally and also logs the config to W&B. The config is
@@ -212,7 +216,7 @@ class WandBLogger(MetricLoggerInterface):
         """
         if self._wandb.run:
             resolved = OmegaConf.to_container(config, resolve=True)
-            self._wandb.config.update(resolved)
+            self._wandb.config.update(resolved, allow_val_change=self.config_allow_val_change)
             try:
                 output_config_fname = Path(
                     os.path.join(

--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -203,8 +203,6 @@ class WandBLogger(MetricLoggerInterface):
         
         self.config_allow_val_change = kwargs.get('allow_val_change', False)
 
-       
-
     def log_config(self, config: DictConfig) -> None:
         """Saves the config locally and also logs the config to W&B. The config is
         stored in the same directory as the checkpoint. You can


### PR DESCRIPTION
#### Context
This PR aims to:
- [x] fix a bug

It addresses the issue #1080 where the `WandBLogger` fails to resume a run with an updated config file when `allow_val_change` is set to `True` in the config.

#### Changelog
The changes made in this PR are:
1. Added `self.config_allow_val_change = kwargs.get('allow_val_change', False)` in the `__init__` method of the `WandBLogger` class to retrieve the value of `allow_val_change` from the `kwargs` dictionary and store it as an instance variable.
2. Modified the line `self._wandb.config.update(resolved)` to `self._wandb.config.update(resolved, allow_val_change=self.config_allow_val_change)` in the `log_config` method to pass the `allow_val_change` option to the `update` method based on the value provided during the initialization of the `WandBLogger`.

#### Test plan
 Tested the modified `WandBLogger` by resuming a run with an updated config file where `allow_val_change` was set to `True`. The run resumed successfully without any errors, and the config values were updated as expected.