### PR TITLE
Fix precision + QLoRA state dict tests, DTensor init

### DIFF
--- a/tests/torchtune/utils/test_distributed.py
+++ b/tests/torchtune/utils/test_distributed.py
@@ -12,6 +12,7 @@ from itertools import chain
 import pytest
 import torch
 import torch.nn as nn
+import torchao
 from tests.test_utils import gpu_test, single_box_init
 from torch.distributed import launcher
 

--- a/tests/torchtune/utils/test_distributed.py
+++ b/tests/torchtune/utils/test_distributed.py
@@ -397,6 +397,10 @@ class TestFullyShardState(FSDPTest):
         for key, value in sharded_model_sd.items():
             self.assertEqual(value, expected_sharded_model_sd[key])
 
+    # torchao does not have __version__ defined for < 0.3
+    @pytest.mark.skipif(
+        "__version__" not in dir(torchao), reason="torchao>=0.3 required"
+    )
     @gpu_test(gpu_count=2)
     def test_qlora_state_dict(self):
         self.run_subtests(

--- a/tests/torchtune/utils/test_distributed.py
+++ b/tests/torchtune/utils/test_distributed.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torchao
+from packaging import version
 from tests.test_utils import gpu_test, single_box_init
 from torch.distributed import launcher
 
@@ -401,6 +402,10 @@ class TestFullyShardState(FSDPTest):
     # torchao does not have __version__ defined for < 0.3
     @pytest.mark.skipif(
         "__version__" not in dir(torchao), reason="torchao>=0.3 required"
+    )
+    @pytest.mark.skipif(
+        version.parse(torch.__version__).base_version < "2.4.0",
+        reason="torch >= 2.4 required",
     )
     @gpu_test(gpu_count=2)
     def test_qlora_state_dict(self):

--- a/tests/torchtune/utils/test_precision.py
+++ b/tests/torchtune/utils/test_precision.py
@@ -68,7 +68,7 @@ class TestPrecisionUtils:
 
         _set_float32_precision("high")
         setattr(  # noqa: B010
-            torch.backends, "__allow_nonbracketed_mutation_flag", True
+            torch.backends, "__allow_nonbracketed_mutation_flag", False
         )
         assert torch.get_float32_matmul_precision() == "high"
         assert torch.backends.cudnn.allow_tf32

--- a/tests/torchtune/utils/test_precision.py
+++ b/tests/torchtune/utils/test_precision.py
@@ -58,12 +58,18 @@ class TestPrecisionUtils:
 
     @pytest.mark.skipif(not cuda_available, reason="The test requires GPUs to run.")
     def test_set_float32_precision(self) -> None:
+        setattr(  # noqa: B010
+            torch.backends, "__allow_nonbracketed_mutation_flag", True
+        )
         _set_float32_precision("highest")
         assert torch.get_float32_matmul_precision() == "highest"
         assert not torch.backends.cudnn.allow_tf32
         assert not torch.backends.cuda.matmul.allow_tf32
 
         _set_float32_precision("high")
+        setattr(  # noqa: B010
+            torch.backends, "__allow_nonbracketed_mutation_flag", True
+        )
         assert torch.get_float32_matmul_precision() == "high"
         assert torch.backends.cudnn.allow_tf32
         assert torch.backends.cuda.matmul.allow_tf32

--- a/torchtune/modules/low_precision/_register_nf4_dispatch_ops.py
+++ b/torchtune/modules/low_precision/_register_nf4_dispatch_ops.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 import torch
 from torchao.dtypes.nf4tensor import implements as nf4_tensor_impl, to_nf4
@@ -25,7 +25,20 @@ def clone(func, *args, **kwargs):
     return to_nf4(args[0][0].get_original_weight())
 
 
-if is_fbcode() or version("torchao") < "0.2.0":
+should_define_inplace_copy = True
+if not is_fbcode():
+    try:
+        ao_version = version("torchao")
+        should_define_inplace_copy = ao_version < "0.2.0"
+    # For importlib metadata, need to check nightly separately
+    except PackageNotFoundError:
+        ao_version = version("torchao-nightly")
+        should_define_inplace_copy = ao_version < "2024.5.20"
+    except Exception as e:
+        raise PackageNotFoundError("Could not find torchao version") from e
+
+
+if should_define_inplace_copy:
     # TorchAO have `NF4.copy_` starting from `0.2.0`
     # it's a superset of `inplace_copy` since it covers `NF4.copy_(NF4)`
     @nf4_tensor_impl([torch.ops.aten.copy_.default])

--- a/torchtune/utils/_distributed.py
+++ b/torchtune/utils/_distributed.py
@@ -321,6 +321,7 @@ def load_from_full_model_state_dict(
             sharded_param = full_tensor.new_zeros(chunk.size())
             sharded_param[: chunk.size(0)].copy_(chunk)
             # BC-breaking change to DTensor API in https://github.com/pytorch/pytorch/pull/128112
+            # TODO: change to from_local API (need to add view support for NF4)
             if version.parse(torch.__version__) >= version.parse("2.4.0.dev20240606"):
                 sharded_tensor = DTensor(
                     local_tensor=sharded_param,

--- a/torchtune/utils/_distributed.py
+++ b/torchtune/utils/_distributed.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, cast, Dict, Set, Tuple, Type
 
 import torch
 import torch.distributed as dist
+from packaging import version
 from torch import nn
 
 from torch.distributed._tensor import distribute_tensor, DTensor
@@ -319,19 +320,32 @@ def load_from_full_model_state_dict(
             chunk = list(torch.chunk(full_tensor, shard_world_size, dim=0))[shard_rank]
             sharded_param = full_tensor.new_zeros(chunk.size())
             sharded_param[: chunk.size(0)].copy_(chunk)
-            sharded_tensor = DTensor(
-                local_tensor=sharded_param,
-                spec=DTensorSpec(
-                    mesh=sharded_meta_param.device_mesh,
-                    placements=sharded_meta_param.placements,
-                    tensor_meta=TensorMeta(
-                        shape=sharded_meta_param.size(),
-                        dtype=sharded_meta_param.dtype,
-                        stride=sharded_meta_param.stride(),
+            # BC-breaking change to DTensor API in https://github.com/pytorch/pytorch/pull/128112
+            if version.parse(torch.__version__) >= version.parse("2.4.0.dev"):
+                sharded_tensor = DTensor(
+                    local_tensor=sharded_param,
+                    spec=DTensorSpec(
+                        mesh=sharded_meta_param.device_mesh,
+                        placements=sharded_meta_param.placements,
+                        tensor_meta=TensorMeta(
+                            shape=sharded_meta_param.size(),
+                            dtype=sharded_meta_param.dtype,
+                            stride=sharded_meta_param.stride(),
+                        ),
                     ),
-                ),
-                requires_grad=sharded_meta_param.requires_grad,
-            )
+                    requires_grad=sharded_meta_param.requires_grad,
+                )
+            else:
+                sharded_tensor = DTensor(
+                    sharded_param,
+                    sharded_meta_param.device_mesh,
+                    sharded_meta_param.placements,
+                    shape=sharded_meta_param.size(),
+                    dtype=sharded_meta_param.dtype,
+                    requires_grad=sharded_meta_param.requires_grad,
+                    stride=sharded_meta_param.stride(),
+                )
+
         else:
             sharded_tensor = distribute_tensor(
                 full_tensor,

--- a/torchtune/utils/_distributed.py
+++ b/torchtune/utils/_distributed.py
@@ -321,7 +321,7 @@ def load_from_full_model_state_dict(
             sharded_param = full_tensor.new_zeros(chunk.size())
             sharded_param[: chunk.size(0)].copy_(chunk)
             # BC-breaking change to DTensor API in https://github.com/pytorch/pytorch/pull/128112
-            if version.parse(torch.__version__) >= version.parse("2.4.0.dev"):
+            if version.parse(torch.__version__) >= version.parse("2.4.0.dev20240606"):
                 sharded_tensor = DTensor(
                     local_tensor=sharded_param,
                     spec=DTensorSpec(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [X] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
After #855 added usage of FSDPTest we cannot set `torch.backends.cudnn` in the same test env as an `FSDPTest`. The fix it to set `torch.backends.__allow_nonbracketed_mutation_flag` to True inside the test, similar to what was done in #855. Unfortunately we missed this test case because our unit tests that require GPUs do not currently run in CI. 

Also `test_qlora_state_dict` is failing as it requires a newer version of torchao. Current `torchao` does not have `__version__` defined, so we add the wonderful check `"__version__" not in dir(torchao)`. Separately, there is an issue where the `DTensor` API changed in a BC-breaking way. I bisected to the appropriate nightly and for now I gate based on that torch version. Once 2.4 releases we should be able to remove this check.

Oh also the way we were checking `version("torchao")` in `_register_nf4_dispatch_ops.py` doesn't really account for the possibility of having `torchao-nightly` installed (increasingly prevalent lately..). So I updated that bit of code to account for possible nightly torchao install. Once torchao has a version and we are on 0.3 all of this can go.

Follow-ups:
- Test GPU unit tests in our CI (there are quite a few of them and rn we have no signal on these, many of which are for more bleeding-edge features)
- Define proper version-based gating across our various dependencies and apply it consistently across the repo

#### Test plan

Prior to these changes:

```
pytest tests/
...
FAILED tests/torchtune/utils/test_distributed.py::TestFullyShardState::test_qlora_state_dict - RuntimeError: Process 0 exited with error code 10 and exception:
FAILED tests/torchtune/utils/test_precision.py::TestPrecisionUtils::test_set_float32_precision - RuntimeError: not allowed to set torch.backends.cudnn flags after disable_global_flags; please use flags() context manager instead
============== 2 failed, 242 passed, 34 skipped, 2 warnings in 55.96s ======================
```

After these changes (and on a nightly version of torchao)

```
pytest tests/
...
===== 244 passed, 34 skipped, 2 warnings in 63.99s (0:01:03) ========
```