### PR TITLE
Fix the Gemma generation

### DIFF
--- a/torchtune/models/gemma/transformer.py
+++ b/torchtune/models/gemma/transformer.py
@@ -25,7 +25,7 @@ class GemmaTransformerDecoder(nn.Module):
 
     Args:
         tok_embeddings (nn.Embedding): PyTorch embedding layer, to be used to move
-            tokens to an embedding space and as the output projectionnv.
+            tokens to an embedding space and as the output projection.
         layer (TransformerDecoderLayer): Transformer Decoder layer.
         num_layers (int): Number of Transformer Decoder layers.
         max_seq_len (int): maximum sequence length the model will be run with, as used

--- a/torchtune/models/gemma/transformer.py
+++ b/torchtune/models/gemma/transformer.py
@@ -17,15 +17,11 @@ from torchtune.modules.transformer import _get_clones, TransformerDecoderLayer
 
 class GemmaTransformerDecoder(nn.Module):
     """
-    Transformer Decoder derived from the Gemma architecture. A key difference between
-    the Gemma transformer decoder and :class:`~torchtune.modules.TransformerDecoder`
-    is that the output projection is replaced instead with a reverse projection
-    using the transposed token embedding weights from output dim to input dim
-    (see https://github.com/keras-team/keras-nlp/blob/master/keras_nlp/layers/modeling/reversible_embedding.py#L21).
+    GemmaTransformer Decoder derived from the TransformerDecoder.
 
     Args:
         tok_embeddings (nn.Embedding): PyTorch embedding layer, to be used to move
-            tokens to an embedding space and as the output projection.
+            tokens to an embedding space.
         layer (TransformerDecoderLayer): Transformer Decoder layer.
         num_layers (int): Number of Transformer Decoder layers.
         max_seq_len (int): maximum sequence length the model will be run with, as used
@@ -37,8 +33,8 @@ class GemmaTransformerDecoder(nn.Module):
             to setup the :func:`~torchtune.modules.KVCache`
         norm (nn.Module): Callable that applies normalization to the output of the decoder,
             before final MLP.
-        norm_embeddings (bool): Whether to normalize the embeddings before passing them
-            through the decoder layers. Defaults to False.
+        output (nn.Linear): Callable that applies a linear transformation to the output of
+            the decoder.
 
     Note:
         Arg values are checked for correctness (eg: ``attn_dropout`` belongs to [0,1])
@@ -68,6 +64,12 @@ class GemmaTransformerDecoder(nn.Module):
         self.norm_embeddings = norm_embeddings
 
     def setup_caches(self, batch_size: int, dtype: torch.dtype) -> None:
+        """Setup key value caches for attention calculation.
+
+        Args:
+            batch_size (int): batch size for the caches.
+            dtype (torch.dtype): dtype for the caches.
+        """
         for layer in self.layers:
             layer.attn.kv_cache = KVCache(
                 batch_size=batch_size,
@@ -93,10 +95,21 @@ class GemmaTransformerDecoder(nn.Module):
         """
         Args:
             tokens (Tensor): input tensor with shape [b x s]
-            mask (Optional[Tensor]): Optional tensor which contains the attention mask.
-                Default is None
-            input_pos (Optional[Tensor]): Optional tensor which contains the position
-                of the current token. This is only used during inference. Default is None
+            mask (Optional[Tensor]): Optional boolean tensor which contains the attention mask
+                with shape [b x s x s]. This is applied after the query-key multiplication and
+                before the softmax. A value of True in row i and column j means token i attends
+                to token j. A value of False means token i does not attend to token j. If no
+                mask is specified, a causal mask is used by default. Default is None.
+            input_pos (Optional[Tensor]): Optional tensor which contains the position ids
+                of each token. During training, this is used to indicate the positions
+                of each token relative to its sample when packed, shape [b x s].
+                During inference, this indicates the position of the current token.
+                If none, assume the index of the token is its position id. Default is None.
+
+        Note: At the very first step of inference, when the model is provided with a prompt,
+        ``input_pos`` would contain the positions of all of the tokens in the prompt
+        (eg: ``torch.arange(prompt_length)``). This is because we will need to compute the
+        KV values for each position.
 
         Returns:
             Tensor: output tensor with shape [b x s x v]
@@ -109,6 +122,7 @@ class GemmaTransformerDecoder(nn.Module):
             - s: sequence length
             - v: vocab size
             - d: embed dim
+            - m_s: max seq len
         """
         # input tensor of shape [b, s]
         bsz, seq_len = tokens.shape

--- a/torchtune/models/gemma/transformer.py
+++ b/torchtune/models/gemma/transformer.py
@@ -17,11 +17,15 @@ from torchtune.modules.transformer import _get_clones, TransformerDecoderLayer
 
 class GemmaTransformerDecoder(nn.Module):
     """
-    GemmaTransformer Decoder derived from the TransformerDecoder.
+    GemmaTransformer Decoder derived from Gemma architecture. A key difference between
+    the Gemma transformer decoder and :class:`~torchtune.modules.TransformerDecoder`
+    is that the output projection is replaced instead with a reverse projection
+    using the transposed token embedding weights from output dim to input dim
+    (see https://github.com/keras-team/keras-nlp/blob/master/keras_nlp/layers/modeling/reversible_embedding.py#L21).
 
     Args:
         tok_embeddings (nn.Embedding): PyTorch embedding layer, to be used to move
-            tokens to an embedding space.
+            tokens to an embedding space and as the output projectionnv.
         layer (TransformerDecoderLayer): Transformer Decoder layer.
         num_layers (int): Number of Transformer Decoder layers.
         max_seq_len (int): maximum sequence length the model will be run with, as used
@@ -33,8 +37,8 @@ class GemmaTransformerDecoder(nn.Module):
             to setup the :func:`~torchtune.modules.KVCache`
         norm (nn.Module): Callable that applies normalization to the output of the decoder,
             before final MLP.
-        output (nn.Linear): Callable that applies a linear transformation to the output of
-            the decoder.
+        norm_embeddings (bool): Whether to normalize the embeddings before passing them
+            through the decoder layers. Defaults to False.
 
     Note:
         Arg values are checked for correctness (eg: ``attn_dropout`` belongs to [0,1])

--- a/torchtune/models/gemma/transformer.py
+++ b/torchtune/models/gemma/transformer.py
@@ -127,7 +127,7 @@ class GemmaTransformerDecoder(nn.Module):
                 )
             # shape: [1, input_pos_len, m_s]
             # in most cases input_pos_len should be 1
-            mask = self.causal_mask[None, None, input_pos]
+            mask = self.causal_mask[None, input_pos]
 
         if self.norm_embeddings:
             hidden_dim = h.size(-1)


### PR DESCRIPTION
Fix the problem in generation.
Aligned with https://github.com/pytorch/torchtune/blob/main/torchtune/modules/transformer.py .

#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?

- Change `mask = self.causal_mask[None, None, input_pos]` to `mask = self.causal_mask[None, input_pos]`.
Make `GemmaTransformerDecoder` aligned with `TransformerDecoder` in [TransformerDecoder.py](https://github.com/pytorch/torchtune/blob/main/torchtune/modules/transformer.py) .

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
