### PR TITLE
Run unit tests on GPUs in CI

### DIFF
--- a/.github/workflows/gpu_test.yaml
+++ b/.github/workflows/gpu_test.yaml
@@ -1,4 +1,4 @@
-name: Multi-GPU Recipe Tests
+name: GPU tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: recipe-test-multi-gpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: gpu-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -19,7 +19,7 @@ defaults:
     shell: bash -l -eo pipefail {0}
 
 jobs:
-  recipe_test_multi_gpu:
+  gpu_test:
     runs-on: linux.8xlarge.nvidia.gpu
     strategy:
       matrix:
@@ -47,7 +47,7 @@ jobs:
         run: |
           python -m pip install -e ".[dev]"
           python -m pip install lm-eval==0.4.*
-      - name: Run recipe tests with coverage
-        run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
+      - name: Run recipe and unit tests with coverage
+        run: pytest tests --with-integration --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [X] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
We have a lot of unit tests that rely on GPUs that are not currently running in our CI. I'd been avoiding running all our unit tests on the GPU runners cause it's slightly overkill, but ultimately the runtime of the unit tests is an order of magnitude smaller than the queue time + recipe test runtime anyways. So I think it's worth adding them to the job since it would've caught several recent breakages.

#### Test plan
CI
