### PR TITLE
Add 'on-the-fly' sample packing

### DIFF
--- a/tests/torchtune/datasets/test_packed_dataset.py
+++ b/tests/torchtune/datasets/test_packed_dataset.py
@@ -232,7 +232,7 @@ class TestPackedDataset:
 
     def test_pad_pack(self):
         padding_idx = -8
-        ignore_idx = -9
+        ignore_idx = -100  # Same as CROSS_ENTROPY_IGNORE_IDX
         pack = {
             "tokens": [2, 5],
             "labels": [3, 7],
@@ -250,7 +250,7 @@ class TestPackedDataset:
         )
 
         pack = packed._convert_to_tensors(pack)
-        padded = packed._pad_pack(pack, padding_idx=padding_idx, ignore_idx=ignore_idx)
+        padded = packed._pad_pack(pack, padding_idx=padding_idx)
 
         padded_input = padded["tokens"]
         padded_label = padded["labels"]

--- a/tests/torchtune/datasets/test_packed_dataset.py
+++ b/tests/torchtune/datasets/test_packed_dataset.py
@@ -263,3 +263,11 @@ class TestPackedDataset:
             padded_label, torch.tensor([3, 7, ignore_idx, ignore_idx])
         )
         torch.testing.assert_close(padded_input_pos, torch.tensor([8, 0, 1, 2]))
+
+    def test_pack_errors_if_sample_too_long(self):
+        dataset = DummyDataset(8)
+        with pytest.raises(ValueError, match="Dataset sample is too long"):
+            PackedDataset(
+                dataset,
+                max_seq_len=4,
+            )

--- a/torchtune/datasets/_chat.py
+++ b/torchtune/datasets/_chat.py
@@ -185,4 +185,8 @@ def chat_dataset(
         train_on_input=train_on_input,
         **load_dataset_kwargs,
     )
-    return PackedDataset(ds, max_seq_len=max_seq_len) if packed else ds
+    return (
+        PackedDataset(ds, max_seq_len=max_seq_len, padding_idx=tokenizer.pad_id)
+        if packed
+        else ds
+    )

--- a/torchtune/datasets/_instruct.py
+++ b/torchtune/datasets/_instruct.py
@@ -177,4 +177,8 @@ def instruct_dataset(
         max_seq_len=max_seq_len,
         **load_dataset_kwargs,
     )
-    return PackedDataset(ds, max_seq_len=max_seq_len) if packed else ds
+    return (
+        PackedDataset(ds, max_seq_len=max_seq_len, padding_idx=tokenizer.pad_id)
+        if packed
+        else ds
+    )

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -118,11 +118,21 @@ class PackedDataset(Dataset):
         for sample in self.ds:
             tokens, labels = sample["tokens"], sample["labels"]
 
+            # If the dataset outputs samples that are larger than the specified
+            # max_seq_len and we're unable to split it, user needs to modify
+            # one of the two parameters
+            seq_len = len(tokens)
+            if seq_len > self.max_seq_len and not self.split_across_pack:
+                raise ValueError(
+                    f"Dataset sample is too long ({seq_len} > {self.max_seq_len}). "
+                    "Please set `split_across_pack=True` or increase `max_seq_len`."
+                )
+
             # Update the current pack
             current_pack["tokens"] += tokens
             current_pack["labels"] += labels
-            current_pack["input_pos"] += list(range(len(tokens)))
-            current_pack["seq_lens"] += [len(tokens)]
+            current_pack["input_pos"] += list(range(seq_len))
+            current_pack["seq_lens"] += [seq_len]
 
             # If the current pack is long enough, add it to self.packs and retain
             # any truncated or bumped samples for next pack

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 from torch.nn import functional as F
@@ -86,7 +86,7 @@ class PackedDataset(Dataset):
         self,
         ds: Dataset,
         max_seq_len: int,
-        max_packs: int = -1,
+        max_packs: Optional[int] = None,
         split_across_pack: bool = False,
     ) -> None:
         self.ds = ds
@@ -136,11 +136,15 @@ class PackedDataset(Dataset):
             self.previous_sample_boundary = len(current_pack["tokens"])
 
             # If max packs is set, stop packing when we reach that number
-            if len(self.packs) == self.max_packs:
+            if self.max_packs is not None and len(self.packs) == self.max_packs:
                 break
 
         # Handle the last pack if there's leftover and we haven't filled up the max packs
-        if len(current_pack["tokens"]) > 0 and len(self.packs) < self.max_packs:
+        if (
+            len(current_pack["tokens"]) > 0
+            and self.max_packs is not None
+            and len(self.packs) < self.max_packs
+        ):
             current_pack = self._add_pack(current_pack)
 
     def _convert_to_tensors(self, pack: PACK_TYPE) -> PACK_TYPE:

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -14,7 +14,7 @@ from torchtune.data import CROSS_ENTROPY_IGNORE_IDX
 from torchtune.utils import get_world_size_and_rank
 from tqdm import tqdm
 
-PACK_TYPE: Dict[str, Union[torch.Tensor, List[int]]]
+PACK_TYPE = Dict[str, Union[torch.Tensor, List[int]]]
 
 
 class PackedDataset(Dataset):

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import torch
 from torch.nn import functional as F
@@ -85,12 +85,15 @@ class PackedDataset(Dataset):
     def __init__(
         self,
         ds: Dataset,
+        *,
         max_seq_len: int,
+        padding_idx: int = 0,
         max_packs: Optional[int] = None,
         split_across_pack: bool = False,
     ) -> None:
         self.ds = ds
         self.max_seq_len = max_seq_len
+        self.padding_idx = padding_idx
         self.max_packs = max_packs
         self.split_across_pack = split_across_pack
         # Where final samples will be held
@@ -134,10 +137,10 @@ class PackedDataset(Dataset):
             current_pack["input_pos"] += list(range(seq_len))
             current_pack["seq_lens"] += [seq_len]
 
-            # If the current pack is long enough, add it to self.packs and retain
-            # any truncated or bumped samples for next pack
-            if len(current_pack["tokens"]) >= self.max_seq_len:
-                current_pack = self._add_pack(current_pack)
+            # If the current pack is over the max_seq_len, add it to self.packs and
+            # retain any truncated or bumped samples for next pack
+            if len(current_pack["tokens"]) > self.max_seq_len:
+                current_pack = self._split_and_add_pack(current_pack)
 
             if rank == 0:
                 pbar.update()
@@ -150,12 +153,56 @@ class PackedDataset(Dataset):
                 break
 
         # Handle the last pack if there's leftover and we haven't filled up the max packs
-        if (
-            len(current_pack["tokens"]) > 0
-            and self.max_packs is not None
-            and len(self.packs) < self.max_packs
+        if len(current_pack["tokens"]) > 0 and (
+            self.max_packs is None or len(self.packs) < self.max_packs
         ):
-            current_pack = self._add_pack(current_pack)
+            # No need to handle splitting at this point so we can just add the current pack
+            self._add_pack(current_pack)
+
+    def _split_and_add_pack(self, current_pack: PACK_TYPE) -> PACK_TYPE:
+        """Splits the current pack at the boundary, processes it, adds it to ``self.packs`` and
+        returns the start of the next pack."""
+
+        if self.split_across_pack:
+            boundary = self.max_seq_len
+            # The last elem in ``seq_lens`` ensures that ``sum(seq_lens) == self.max_seq_len``
+            seq_len_padding = [self.max_seq_len - sum(current_pack["seq_lens"][:-1])]
+        else:
+            boundary = self.previous_sample_boundary
+            # If we aren't splitting across packs, we leave out the last sample b/c
+            # it will go into the next pack
+            seq_len_padding = []
+
+        pack = {
+            "tokens": current_pack["tokens"][:boundary],
+            "labels": current_pack["labels"][:boundary],
+            "input_pos": current_pack["input_pos"][:boundary],
+            "seq_lens": current_pack["seq_lens"][:-1] + seq_len_padding,
+        }
+
+        # Process and add the pack
+        self._add_pack(pack)
+
+        # Return the length of the first sample in next pack if we are splitting across packs,
+        # otherwise return the length of the last sample in the current pack
+        next_seq_len = (
+            len(current_pack["tokens"][boundary:])
+            if self.split_across_pack
+            else current_pack["seq_lens"][-1]
+        )
+
+        return {
+            "tokens": current_pack["tokens"][boundary:],
+            "labels": current_pack["labels"][boundary:],
+            "input_pos": current_pack["input_pos"][boundary:],
+            "seq_lens": [next_seq_len],
+        }
+
+    def _add_pack(self, pack: PACK_TYPE) -> None:
+        """Processes, pads and adds a pack to ``self.packs``."""
+        pack = self._convert_to_tensors(pack)
+        pack = self._pad_pack(pack, padding_idx=self.padding_idx)
+        self.packs.append(pack)
 
     def _convert_to_tensors(self, pack: PACK_TYPE) -> PACK_TYPE:
         """Converts a pack into tensors. Pack comes in as a dict of lists and is converted to tensors.
@@ -168,68 +215,7 @@ class PackedDataset(Dataset):
             "seq_lens": pack["seq_lens"],
         }
 
-    def _add_pack(self, current_pack: PACK_TYPE) -> None:
-        """Processes the current pack and adds it to ``self.packs``."""
-
-        # Handle the case where we want to split across packs
-        if self.split_across_pack:
-            pack = {
-                "tokens": current_pack["tokens"][: self.max_seq_len],
-                "labels": current_pack["labels"][: self.max_seq_len],
-                "input_pos": current_pack["input_pos"][: self.max_seq_len],
-                # The last elem in ``seq_lens`` ensures that ``sum(seq_lens) == self.max_seq_len``
-                "seq_lens": current_pack["seq_lens"][:-1]
-                + [self.max_seq_len - sum(current_pack["seq_lens"][:-1])],
-            }
-
-            # Convert to tensors and add to the pack
-            pack = self._convert_to_tensors(pack)
-            self.packs.append(pack)
-
-            return {
-                "tokens": current_pack["tokens"][self.max_seq_len :],
-                "labels": current_pack["labels"][self.max_seq_len :],
-                "input_pos": current_pack["input_pos"][self.max_seq_len :],
-                "seq_lens": [len(current_pack["tokens"][self.max_seq_len :])],
-            }
-        # Handle the case where we DO NOT want to split across packs,
-        else:
-            # First, we check to see if the sample fits perfectly,
-            # in which case our job is easy
-            if len(current_pack["tokens"]) == self.max_seq_len:
-                pack = self._convert_to_tensors(current_pack)
-                self.packs.append(pack)
-                return {"tokens": [], "labels": [], "input_pos": [], "seq_lens": []}
-
-            # If it doesn't fit perfectly, we have to bump the last sample into the next one
-            else:
-                pack = {
-                    "tokens": current_pack["tokens"][: self.previous_sample_boundary],
-                    "labels": current_pack["labels"][: self.previous_sample_boundary],
-                    "input_pos": current_pack["input_pos"][
-                        : self.previous_sample_boundary
-                    ],
-                    # We can guarantee that the last sample is the one that pushed the current pack over the limit
-                    # therefore we just drop the last element from seq_lens and add it to the next pack
-                    "seq_lens": current_pack["seq_lens"][:-1],
-                }
-
-                # Convert to tensors, pad, and add to the pack
-                # We have to pad b/c now the pack is lt ``self.max_seq_len``
-                pack = self._convert_to_tensors(pack)
-                pack = self._pad_pack(pack)
-                self.packs.append(pack)
-
-                return {
-                    "tokens": current_pack["tokens"][self.previous_sample_boundary :],
-                    "labels": current_pack["labels"][self.previous_sample_boundary :],
-                    "input_pos": current_pack["input_pos"][
-                        self.previous_sample_boundary :
-                    ],
-                    "seq_lens": [current_pack["seq_lens"][-1]],
-                }
-
-    def _pad_pack(self, pack, padding_idx=0, ignore_idx=CROSS_ENTROPY_IGNORE_IDX):
+    def _pad_pack(self, pack: PACK_TYPE, padding_idx: int) -> PACK_TYPE:
         """Pads a pack to ``self.max_seq_len``."""
         # Pad tokens
         padded_tokens = F.pad(
@@ -242,24 +228,19 @@ class PackedDataset(Dataset):
         padded_labels = F.pad(
             pack["labels"],
             (0, self.max_seq_len - len(pack["labels"])),
-            value=ignore_idx,
+            value=CROSS_ENTROPY_IGNORE_IDX,
         )
 
         # Pad input_pos continuing the sequence from last value
         # in input_pos
         # e.g. [0 1 2] -> [0 1 2 3 4 5] for self.max_seq_len = 6
-        padded_input_pos = torch.cat(
-            [
-                pack["input_pos"],
-                torch.arange(
-                    pack["input_pos"][-1] + 1,
-                    pack["input_pos"][-1]
-                    + self.max_seq_len
-                    - len(pack["input_pos"])
-                    + 1,
-                ),
-            ]
+        num_range = torch.arange(
+            pack["input_pos"][-1] + 1,
+            pack["input_pos"][-1] + self.max_seq_len - len(pack["input_pos"]) + 1,
         )
+        # Clamp to max_seq_len - 1 to avoid out of bounds error
+        clamped_num_range = torch.clamp(num_range, 0, self.max_seq_len - 1)
+        padded_input_pos = torch.cat([pack["input_pos"], clamped_num_range])
 
         return {
             "tokens": padded_tokens,
@@ -268,10 +249,10 @@ class PackedDataset(Dataset):
             "seq_lens": pack["seq_lens"],  # seq_len is untouched
         }
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.packs)
 
-    def __getitem__(self, idx: int) -> Dict[str, Any]:
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
         """Constructs the attention mask on-the-fly and returns whole sample."""
         current_pack = self.packs[idx]
 

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -73,6 +73,7 @@ class PackedDataset(Dataset):
         ds (Dataset): dataset to sample pack. This should return a dictionary with field
             "tokens" and "labels" containing the tokenized and label samples.
         max_seq_len (int): Maximum number of tokens to pack
+        padding_idx (int): padding index for the tokenizer. Default is 0.
         max_packs (Optional[int]): Maximum number of packs. Default is None, which will create as many
             packs as possible.
         split_across_pack (bool): if the last sample in a pack does not fit in ``max_seq_len``,

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Union
 
 import torch
 from torch.nn import functional as F
@@ -13,6 +13,8 @@ from torch.utils.data import Dataset
 from torchtune.data import CROSS_ENTROPY_IGNORE_IDX
 from torchtune.utils import get_world_size_and_rank
 from tqdm import tqdm
+
+PACK_TYPE: Dict[str, Union[torch.Tensor, List[int]]]
 
 
 class PackedDataset(Dataset):
@@ -71,7 +73,7 @@ class PackedDataset(Dataset):
         ds (Dataset): dataset to sample pack. This should return a dictionary with field
             "tokens" and "labels" containing the tokenized and label samples.
         max_seq_len (int): Maximum number of tokens to pack
-        max_packs (Optional[int]): maximum number of packs. Default is None, which will create as many
+        max_packs (int): maximum number of packs. Default is -1, which will create as many
             packs as possible.
         split_across_pack (bool): if the last sample in a pack does not fit in ``max_seq_len``,
             split the sample into the next pack, or move it entirely to the beginning of the next pack.
@@ -84,33 +86,29 @@ class PackedDataset(Dataset):
         self,
         ds: Dataset,
         max_seq_len: int,
-        max_packs: Optional[int] = None,
+        max_packs: int = -1,
         split_across_pack: bool = False,
     ) -> None:
         self.ds = ds
         self.max_seq_len = max_seq_len
         self.max_packs = max_packs
         self.split_across_pack = split_across_pack
-        # where final samples will be held
-        self.packs: List[Dict[str, List[int]]] = []
+        # Where final samples will be held
+        self.packs: List[PACK_TYPE] = []
+        self.previous_sample_boundary: int = 0
         self._pack()
 
     def _pack(self) -> None:
-        """
-        Iterate through the dataset. Use a buffer to hold samples until max_seq_len,
+        """Iterate through the dataset. Use a buffer to hold samples until max_seq_len,
         then append the buffer to self.packs as a single "packed" sample. Continue
-        until max_packs or end of dataset.
-        """
-        # buffer to hold samples until they are long enough to be added to self.packs
+        until max_packs or end of dataset."""
+        # Buffer to hold samples until they are long enough to be added to self.packs
         current_pack = {
             "tokens": [],
             "labels": [],
-            "mask": [],
             "input_pos": [],
+            "seq_lens": [],
         }
-        # Keep track of what index the previous sample ends in case we need
-        # to end a pack early
-        previous_sample_boundary = 0
 
         # Only show progress bar on rank 0
         _, rank = get_world_size_and_rank()
@@ -119,156 +117,178 @@ class PackedDataset(Dataset):
 
         for sample in self.ds:
             tokens, labels = sample["tokens"], sample["labels"]
-            # If the dataset outputs samples that are larger than the specified
-            # max_seq_len and we're unable to split it, user needs to modify
-            # one of the two parameters
-            seq_len = len(tokens)
-            if seq_len > self.max_seq_len and not self.split_across_pack:
-                raise ValueError(
-                    f"Dataset sample is too long ({len(tokens)} > {self.max_seq_len}). "
-                    "Please set `split_across_pack=True` or increase `max_seq_len`."
-                )
 
-            # Create integer mask and position ids for current sample and extend
-            # current pack
-            current_sample = {
-                "tokens": tokens,
-                "labels": labels,
-                # Mask is simply a causal mask within this sample length
-                "mask": [torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))],
-                "input_pos": list(range(seq_len)),
-            }
-            current_pack = {k: v + current_sample[k] for k, v in current_pack.items()}
+            # Update the current pack
+            current_pack["tokens"] += tokens
+            current_pack["labels"] += labels
+            current_pack["input_pos"] += list(range(len(tokens)))
+            current_pack["seq_lens"] += [len(tokens)]
 
             # If the current pack is long enough, add it to self.packs and retain
-            # any truncated samples for next pack, if splitting samples
-            if len(current_pack["tokens"]) > self.max_seq_len:
-                current_pack = self._add_pack(
-                    current_pack=current_pack,
-                    boundary=self.max_seq_len
-                    if self.split_across_pack
-                    else previous_sample_boundary,
-                )
+            # any truncated or bumped samples for next pack
+            if len(current_pack["tokens"]) >= self.max_seq_len:
+                current_pack = self._add_pack(current_pack)
 
             if rank == 0:
                 pbar.update()
-            previous_sample_boundary = len(current_pack["tokens"])
-            if self.max_packs is not None and len(self.packs) >= self.max_packs:
+
+            # Keep track of previous sample boundary
+            self.previous_sample_boundary = len(current_pack["tokens"])
+
+            # If max packs is set, stop packing when we reach that number
+            if len(self.packs) == self.max_packs:
                 break
 
-        # Add the last pack with remaining samples that did not fit in previous
-        if len(current_pack["tokens"]) > 0 and (
-            self.max_packs is None or len(self.packs) < self.max_packs
-        ):
-            current_pack = self._add_pack(
-                current_pack=current_pack, boundary=len(current_pack["tokens"])
-            )
-            assert len(current_pack["tokens"]) == 0
+        # Handle the last pack if there's leftover and we haven't filled up the max packs
+        if len(current_pack["tokens"]) > 0 and len(self.packs) < self.max_packs:
+            current_pack = self._add_pack(current_pack)
 
-    def _add_pack(
-        self, current_pack: Dict[str, List[int]], boundary: int
-    ) -> Dict[str, List[int]]:
+    def _convert_to_tensors(self, pack: PACK_TYPE) -> PACK_TYPE:
+        """Converts a pack into tensors. Pack comes in as a dict of lists and is converted to tensors.
+        The only key that does not get converted is ``seq_lens``.
         """
-        Pad and add the current pack to self.packs and return what's remaining.
-        """
-        # So far we've kept a list of causal masks, one for each sample in the pack.
-        # Now we need to combine them into a single mask for the entire pack.
-        packing_mask = torch.block_diag(*current_pack["mask"])
-        pack = {
-            "tokens": current_pack["tokens"][:boundary],
-            "labels": current_pack["labels"][:boundary],
-            "mask": packing_mask[:boundary, :boundary],
-            "input_pos": current_pack["input_pos"][:boundary],
+        return {
+            "tokens": torch.tensor(pack["tokens"]),
+            "labels": torch.tensor(pack["labels"]),
+            "input_pos": torch.tensor(pack["input_pos"]),
+            "seq_lens": pack["seq_lens"],
         }
 
-        # Resultant shapes after padding
-        # tokens: [max_seq_len, ]
-        # labels: [max_seq_len, ]
-        # mask: [max_seq_len, max_seq_len]
-        # input_pos: [max_seq_len, ]
-        padded_pack = self._pad_pack(pack)
-        self.packs.append(padded_pack)
+    def _add_pack(self, current_pack: PACK_TYPE) -> None:
+        """Processes the current pack and adds it to ``self.packs``."""
 
-        # Keep sample that did not fit or got truncated for the next pack
-        updated_pack = {
-            "tokens": current_pack["tokens"][boundary:],
-            "labels": current_pack["labels"][boundary:],
-            "mask": [packing_mask[boundary:, boundary:]],
-            "input_pos": current_pack["input_pos"][boundary:],
-        }
-
-        return updated_pack
-
-    def _pad_pack(
-        self,
-        sample: Dict[str, Any],
-        padding_idx: int = 0,
-        ignore_idx: int = CROSS_ENTROPY_IGNORE_IDX,
-    ) -> Dict[str, torch.Tensor]:
-        """Pad a group of packed sequences to max sequence length in the group, and
-        convert integer lists to tensors. Account for attention mask and position
-        ids.
-
-        This is a sample-wise collator and should not be used with the dataloader.
-
-        Sample should look like::
-            {
-                "tokens": List[int],
-                "labels": List[int],
-                "mask": Tensor,
-                "input_pos": List[int],
+        # Handle the case where we want to split across packs
+        if self.split_across_pack:
+            pack = {
+                "tokens": current_pack["tokens"][: self.max_seq_len],
+                "labels": current_pack["labels"][: self.max_seq_len],
+                "input_pos": current_pack["input_pos"][: self.max_seq_len],
+                # The last elem in ``seq_lens`` ensures that ``sum(seq_lens) == self.max_seq_len``
+                "seq_lens": current_pack["seq_lens"][:-1]
+                + [self.max_seq_len - sum(current_pack["seq_lens"][:-1])],
             }
 
-        Args:
-            sample (Dict[str, Any]): A dictionary containing tokens, labels, mask,
-                and position ids
-            padding_idx (int): Padding index for input ids. Defaults to 0.
-            ignore_idx (int): Padding index for labels. Defaults to -100.
+            # Convert to tensors and add to the pack
+            pack = self._convert_to_tensors(pack)
+            self.packs.append(pack)
 
-        Returns:
-            Collated tokens, labels, mask, and position ids.
-        """
-        tokens = sample["tokens"]
-        labels = sample["labels"]
-        mask = sample["mask"]
-        input_pos = sample["input_pos"]
+            return {
+                "tokens": current_pack["tokens"][self.max_seq_len :],
+                "labels": current_pack["labels"][self.max_seq_len :],
+                "input_pos": current_pack["input_pos"][self.max_seq_len :],
+                "seq_lens": [len(current_pack["tokens"][self.max_seq_len :])],
+            }
+        # Handle the case where we DO NOT want to split across packs,
+        else:
+            # First, we check to see if the sample fits perfectly,
+            # in which case our job is easy
+            if len(current_pack["tokens"]) == self.max_seq_len:
+                pack = self._convert_to_tensors(current_pack)
+                self.packs.append(pack)
+                return {"tokens": [], "labels": [], "input_pos": [], "seq_lens": []}
 
-        # Pad to max sequence length
-        tokens = F.pad(
-            torch.tensor(tokens), (0, self.max_seq_len - len(tokens)), value=padding_idx
+            # If it doesn't fit perfectly, we have to bump the last sample into the next one
+            else:
+                pack = {
+                    "tokens": current_pack["tokens"][: self.previous_sample_boundary],
+                    "labels": current_pack["labels"][: self.previous_sample_boundary],
+                    "input_pos": current_pack["input_pos"][
+                        : self.previous_sample_boundary
+                    ],
+                    # We can guarantee that the last sample is the one that pushed the current pack over the limit
+                    # therefore we just drop the last element from seq_lens and add it to the next pack
+                    "seq_lens": current_pack["seq_lens"][:-1],
+                }
+
+                # Convert to tensors, pad, and add to the pack
+                # We have to pad b/c now the pack is lt ``self.max_seq_len``
+                pack = self._convert_to_tensors(pack)
+                pack = self._pad_pack(pack)
+                self.packs.append(pack)
+
+                return {
+                    "tokens": current_pack["tokens"][self.previous_sample_boundary :],
+                    "labels": current_pack["labels"][self.previous_sample_boundary :],
+                    "input_pos": current_pack["input_pos"][
+                        self.previous_sample_boundary :
+                    ],
+                    "seq_lens": [current_pack["seq_lens"][-1]],
+                }
+
+    def _pad_pack(self, pack, padding_idx=0, ignore_idx=CROSS_ENTROPY_IGNORE_IDX):
+        """Pads a pack to ``self.max_seq_len``."""
+        # Pad tokens
+        padded_tokens = F.pad(
+            pack["tokens"],
+            (0, self.max_seq_len - len(pack["tokens"])),
+            value=padding_idx,
         )
-        labels = F.pad(
-            torch.tensor(labels), (0, self.max_seq_len - len(labels)), value=ignore_idx
+
+        # Pad labels
+        padded_labels = F.pad(
+            pack["labels"],
+            (0, self.max_seq_len - len(pack["labels"])),
+            value=ignore_idx,
         )
-        # For attention mask, simply use identity matrix for the pad tokens
-        mask_pad = torch.eye(self.max_seq_len - mask.shape[0], dtype=torch.bool)
-        mask = torch.block_diag(mask, mask_pad)
-        # For position ids, continue to increment for pad tokens
-        next_pos = input_pos[-1] + 1
-        input_pos_pad = torch.arange(
-            next_pos, next_pos + self.max_seq_len - len(input_pos)
-        )
-        # Do not go beyond max_seq_len - 1
-        input_pos_pad = input_pos_pad.clamp(max=self.max_seq_len - 1)
-        input_pos = torch.cat(
+
+        # Pad input_pos continuing the sequence from last value
+        # in input_pos
+        # e.g. [0 1 2] -> [0 1 2 3 4 5] for self.max_seq_len = 6
+        padded_input_pos = torch.cat(
             [
-                torch.tensor(input_pos),
-                input_pos_pad,
+                pack["input_pos"],
+                torch.arange(
+                    pack["input_pos"][-1] + 1,
+                    pack["input_pos"][-1]
+                    + self.max_seq_len
+                    - len(pack["input_pos"])
+                    + 1,
+                ),
             ]
         )
 
-        assert tokens.shape == labels.shape == input_pos.shape
-        assert tokens.shape[0] == mask.shape[0]
-
         return {
-            "tokens": tokens,
-            "labels": labels,
-            "mask": mask,
-            "input_pos": input_pos,
+            "tokens": padded_tokens,
+            "labels": padded_labels,
+            "input_pos": padded_input_pos,
+            "seq_lens": pack["seq_lens"],  # seq_len is untouched
         }
 
     def __len__(self):
         return len(self.packs)
 
-    def __getitem__(self, index: int) -> Dict[str, List[int]]:
-        return self.packs[index]
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """Constructs the attention mask on-the-fly and returns whole sample."""
+        current_pack = self.packs[idx]
+
+        num_samples_in_pack = len(current_pack["seq_lens"])
+        total_seq_len = 0
+
+        block_attn_masks = []
+
+        for i, seq_len in enumerate(current_pack["seq_lens"]):
+            total_seq_len += seq_len
+
+            # Append lower triangular matrix for causal mask
+            block_attn_masks.append(
+                torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))
+            )
+
+            # If we're at the last sample and the total seq len is less than the max seq len,
+            # we need to pad with identity matrix for the remainder
+            if i == num_samples_in_pack - 1 and total_seq_len < self.max_seq_len:
+                block_attn_masks.append(
+                    torch.eye(
+                        self.max_seq_len - total_seq_len,
+                        self.max_seq_len - total_seq_len,
+                        dtype=torch.bool,
+                    )
+                )
+
+        return {
+            "tokens": current_pack["tokens"],
+            "labels": current_pack["labels"],
+            "input_pos": current_pack["input_pos"],
+            # Assemble the mask into a block causal matrix
+            "mask": torch.block_diag(*block_attn_masks),
+        }

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -73,7 +73,7 @@ class PackedDataset(Dataset):
         ds (Dataset): dataset to sample pack. This should return a dictionary with field
             "tokens" and "labels" containing the tokenized and label samples.
         max_seq_len (int): Maximum number of tokens to pack
-        max_packs (int): maximum number of packs. Default is -1, which will create as many
+        max_packs (Optional[int]): Maximum number of packs. Default is None, which will create as many
             packs as possible.
         split_across_pack (bool): if the last sample in a pack does not fit in ``max_seq_len``,
             split the sample into the next pack, or move it entirely to the beginning of the next pack.

--- a/torchtune/datasets/_text_completion.py
+++ b/torchtune/datasets/_text_completion.py
@@ -122,4 +122,8 @@ def text_completion_dataset(
         max_seq_len=max_seq_len,
         **load_dataset_kwargs,
     )
-    return PackedDataset(ds, max_seq_len=max_seq_len) if packed else ds
+    return (
+        PackedDataset(ds, max_seq_len=max_seq_len, padding_idx=tokenizer.pad_id)
+        if packed
+        else ds
+    )


### PR DESCRIPTION
#### Context
As investigated in #1097, it was shown that the offline approach to constructing the mask consumed waaaaaay too much memory. Therefore, this approach constructs tokens, labels, and input_pos offline and then constructs the mask during access (training). For a max_seq_len of 4096 (default for many models), we can expect the memory of a single pack to look like the following offline:

```
tokens: 88 (fixed size of Python object) + 8 (size of torch.int64) * 4096 = 32,896
labels: 88 + 8 * 4096 = 32,896
input_pos: 88 + 8 * 4096 = 32,896
seq_lens: 226 <-- varies based on num of samples that we do, but this is avg based on experiments
----------------------------------------
98,984 bytes ~= 0.1 MB
```

To provide a real-world example, let's use the [Web Instruct Dataset from Tiger Labs](https://huggingface.co/datasets/TIGER-Lab/WebInstructSub). It comes in at 3.51 GB of size with 2.3 million samples. The average sample length (with instruct template applied) is about 100 tokens. This means that 40 samples fit in each pack if we don't split across packs. Therefore we can expect there to be about 57,500 packs. This number times 0.1MB is **5.75GB** additional memory bringing the total on-disk memory needed to load (before training) this dataset is **9.26GB**, well within reasonable bounds.

**Why do we need `seq_lens`?**: Technically we could calculate this using the `input_pos`, but this would save us negligible memory and increase processing time during training, which is undesirable.

**Why are you using this dataset?** It's a large dataset downloaded 33,026 times in the last month. Good a baseline as any.

**Why did you update the signature to take in a padding_idx and hardcode in CROSS_ENTROPY_IGNORE_IDX?** Excellent question. So before, the packed dataset made the assumption that padding_idx = 0 and to use the CROSS_ENTROPY_IGNORE_IDX. The former is NOT an assumption we can make therefore it should be actually configurable and the latter IS a reasonable assumption so we should just hardcore it instead of defaulting the param (which won't get used). 

#### Changelog
* Add `PACK_TYPE` so I don't have to keep typing it
* Add `seq_lens` to offline variables to hold information on each seq len in the pack (useful for calculating mask on the fly)
* Added method specifically to convert to tensor
* Cleaned up logic of how to handle splitting packs
* Updated __getitem__ method to construct masks on the fly
* Updated test to include testing on a larger max_packs
* Modified chat, instruct, and text completion datasets to take pass in the tokenizer pad id to the packed dataset

#### Test plan

1. Unit tests

All are passing
```
(joe-torchtune) [jrcummings@devvm050.nha0 ~/projects/joe-torchtune (pack-mask-on-the-fly)]$ pytest tests/torchtune/datasets/test_packed_dataset.py
================================================================ test session starts =================================================================
platform linux -- Python 3.11.9, pytest-8.1.1, pluggy-1.5.0
rootdir: /home/jrcummings/projects/joe-torchtune
configfile: pyproject.toml
plugins: integration-0.2.3, mock-3.14.0, cov-5.0.0, hypothesis-6.103.1
collected 11 items

tests/torchtune/datasets/test_packed_dataset.py ...........                                                                                    [100%]

================================================================= 11 passed in 5.03s =================================================================
```


2. Direct memory / speed comparisons with old version

Using this gist: https://gist.github.com/joecummings/05586af0a08eef0714c7da3c56ee7365

Only packing 1% of the dataset which is 23k samples. Using our calculation from above we expect memory usage with the new implementation to take an additional 0.58GB.

> Memory is an estimate based on psutil monitoring of virtual memory used. There are more things that affect this than just the dataset, but I think it gives us a good feel for memory usage. Also, I didn't want to go through and figure out how to zero out the psutil memory management in the same script so in between runs I just commented out the code I didn't care about in order to get memory estimates.

|impl|additional memory used for packing|total additional memory used|
|----|----|----|
|old (all offline)|27 GB|27 GB|
|new (mask on the fly)|0.62 GB|1.14 GB|

Our calculation looks pretty spot on for how much memory the new implementation should take. And it makes sense that there would be a little more memory used when the mask is constructed during dataloading. 

|impl|time for packing|
|----|----|
|old (all offline)|134 s|
|new (mask on the fly)|22 s|

Not surprising that the old packing takes much longer than the new masking.

3. Compare iterations e2e during training

**Why do we need to do this?** Well, the above "loading" is not a true measurement of how packing a dataset will affect the training time. For instance, we are now passing in a constructed mask for attention instead of relying on SPDA to construct one for us. 

CMD: 
```
tune run lora_finetune_single_device \
    --config llama3/8B_lora_single_device \
    dataset._component_=torchtune.datasets.instruct_dataset \
    dataset.source=TIGER-LAB/WebInstructSub \
    template=torchtune.data.AlpacaInstructTemplate \
    column_map={"instruction":"question","output":"answer"} \
    max_seq_len=4096 \
    packed=True \
    split=train[:1%]
```

|impl|total time|
|----|----|
|old (all offline)| 39 mins|
|new (mask on the fly)| 48 mins|
|no packing| 1 hr 58 mins|

**YAY, it's just (kinda) as fast as the old implementation in waaaaaay less memory.**
