### PR TITLE
Pin setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ version = {attr = "torchtune.__version__"}
 
 # ---- Explicit project build information ---- #
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools==69.5.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
As pointed out in #1111, there is an import error when importing the setuptools `packaging` API in versions >= 70.0. This is discussed on the setuptools repo [here](https://github.com/pypa/setuptools/issues/4376) and on other downstream repos as well (see e.g. [here](https://github.com/pytorch/serve/issues/3176)). Going with the recommended solution from the second link and just pinning to 69.5.1 to resolve the issue.