### PR TITLE
Dynamic Batch size

### DIFF
--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -384,14 +384,16 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         dataloader = DataLoader(
             dataset=ds,
             sampler=sampler,
-            batch_size=batch_size,
+            batch_size=None,
+            batch_sampler=None,
+            # batch_size=batch_size,
             collate_fn=partial(
                 utils.padded_collate,
                 padding_idx=self._tokenizer.pad_id,
                 ignore_idx=self._loss_fn.ignore_index,
             )
-            if not packed
-            else None,
+            # if not packed
+            # else None,
         )
 
         log.info("Dataset and Sampler are initialized.")

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -17,6 +17,8 @@ from tqdm import tqdm
 
 class PackedDataset(Dataset):
     """
+    DEMO: This demonstrates performance but does not preserve randomness yet!!!!!!!!!!!!!!!
+
     Performs greedy sample packing on a provided dataset. This is done as a single
     preprocessing step before training begins. Shuffling is done outside of this
     class on packed samples with a ``Sampler`` as part of the dataloader. Currently,
@@ -43,26 +45,6 @@ class PackedDataset(Dataset):
             ...,
         ]
 
-    To prevent cross-contamination, the following mask would be returned for the
-    first pack in the example::
-
-        mask = [
-            [1, 0, 0, 0, 0, 0],
-            [1, 1, 0, 0, 0, 0],
-            [1, 1, 1, 0, 0, 0],
-            [0, 0, 0, 1, 0, 0],
-            [0, 0, 0, 1, 1, 0],
-            [0, 0, 0, 0, 0, 1],
-        ]
-
-    The position ids would be::
-
-        input_pos = [
-            [0, 1, 2, 0, 1, 2],
-            [0, 1, 0, 1, 2, 3],
-            ...,
-        ]
-
     The identity matrix is used in the mask for pad tokens instead of a causal mask.
     For position ids for pad tokens, we simply continue to increment from the previous
     sample normally.
@@ -84,41 +66,43 @@ class PackedDataset(Dataset):
         self,
         ds: Dataset,
         max_seq_len: int,
-        max_packs: Optional[int] = None,
-        split_across_pack: bool = False,
+        max_toks_per_batch: int = 1024,  # TODO: remove default
+        num_bins: int = 4,  # TODO: set to 1
+        scale_factor: float = 1.0,
+        **kwargs,  # TODO: remove kwargs
     ) -> None:
+        assert (
+            max_seq_len % num_bins == 0
+        ), "max_seq_len must be divisible by the number of bins"
+        assert scale_factor >= 1.0, "scale_factor must be > 1.0"
         self.ds = ds
         self.max_seq_len = max_seq_len
-        self.max_packs = max_packs
-        self.split_across_pack = split_across_pack
-        # where final samples will be held
-        self.packs: List[Dict[str, List[int]]] = []
-        self._pack()
+        self.max_toks_per_batch = max_toks_per_batch
+        self.num_bins = num_bins
+        self.bin_size = max_seq_len // num_bins
+        self.scale_factor = scale_factor
 
-    def _pack(self) -> None:
+        # where final samples will be held
+        self.batches: List[List[Dict[str, List[int]]]] = []
+        self._batch()
+
+    def _batch(self) -> None:
         """
         Iterate through the dataset. Use a buffer to hold samples until max_seq_len,
         then append the buffer to self.packs as a single "packed" sample. Continue
         until max_packs or end of dataset.
         """
-        # buffer to hold samples until they are long enough to be added to self.packs
-        current_pack = {
-            "tokens": [],
-            "labels": [],
-            "mask": [],
-            "input_pos": [],
-        }
-        # Keep track of what index the previous sample ends in case we need
-        # to end a pack early
-        previous_sample_boundary = 0
+        current_batches = [[]] * self.num_bins
+        batch_meta_data = [{"samples": 0, "max_seq": 0}] * self.num_bins
 
         # Only show progress bar on rank 0
         _, rank = get_world_size_and_rank()
         if rank == 0:
             pbar = tqdm(total=len(self.ds), desc="Packing dataset", dynamic_ncols=True)
 
+        # TODO: should binned once and then rebatched every epoch to be random
         for sample in self.ds:
-            tokens, labels = sample["tokens"], sample["labels"]
+            tokens = sample["tokens"]
             # If the dataset outputs samples that are larger than the specified
             # max_seq_len and we're unable to split it, user needs to modify
             # one of the two parameters
@@ -126,149 +110,298 @@ class PackedDataset(Dataset):
             if seq_len > self.max_seq_len and not self.split_across_pack:
                 raise ValueError(
                     f"Dataset sample is too long ({len(tokens)} > {self.max_seq_len}). "
-                    "Please set `split_across_pack=True` or increase `max_seq_len`."
+                    "Please increase `max_seq_len`."
                 )
 
-            # Create integer mask and position ids for current sample and extend
-            # current pack
-            current_sample = {
-                "tokens": tokens,
-                "labels": labels,
-                # Mask is simply a causal mask within this sample length
-                "mask": [torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))],
-                "input_pos": list(range(seq_len)),
-            }
-            current_pack = {k: v + current_sample[k] for k, v in current_pack.items()}
+            batch = max(seq_len - 1, 0) // self.bin_size
+            current_batches[batch].append(sample)
 
-            # If the current pack is long enough, add it to self.packs and retain
-            # any truncated samples for next pack, if splitting samples
-            if len(current_pack["tokens"]) > self.max_seq_len:
-                current_pack = self._add_pack(
-                    current_pack=current_pack,
-                    boundary=self.max_seq_len
-                    if self.split_across_pack
-                    else previous_sample_boundary,
-                )
+            # Compute new batch size
+            batch_meta_data[batch]["samples"] += 1
+            if batch_meta_data[batch]["max_seq"] < seq_len:
+                batch_meta_data[batch]["max_seq"] = seq_len
+
+            # Check if new batch is complete
+            batch_toks = (
+                batch_meta_data[batch]["samples"] * batch_meta_data[batch]["max_seq"]
+            )
+            # Shorter sequences use less memory per token depending on model architecture
+            max_batch_len = self.bin_size * (batch + 1)
+            batch_scale = (1 - max_batch_len // self.max_seq_len) * (
+                self.scale_factor - 1.0
+            ) + 1.0
+            max_toks = batch_scale * self.max_toks_per_batch
+            if batch_toks > max_toks - self.bin_size:
+                self.batches.append(current_batches[batch])
+                current_batches[batch] = []
+                batch_meta_data[batch] = {"samples": 0, "max_seq": 0}
 
             if rank == 0:
                 pbar.update()
-            previous_sample_boundary = len(current_pack["tokens"])
-            if self.max_packs is not None and len(self.packs) >= self.max_packs:
-                break
 
-        # Add the last pack with remaining samples that did not fit in previous
-        if len(current_pack["tokens"]) > 0 and (
-            self.max_packs is None or len(self.packs) < self.max_packs
-        ):
-            current_pack = self._add_pack(
-                current_pack=current_pack, boundary=len(current_pack["tokens"])
-            )
-            assert len(current_pack["tokens"]) == 0
-
-    def _add_pack(
-        self, current_pack: Dict[str, List[int]], boundary: int
-    ) -> Dict[str, List[int]]:
-        """
-        Pad and add the current pack to self.packs and return what's remaining.
-        """
-        # So far we've kept a list of causal masks, one for each sample in the pack.
-        # Now we need to combine them into a single mask for the entire pack.
-        packing_mask = torch.block_diag(*current_pack["mask"])
-        pack = {
-            "tokens": current_pack["tokens"][:boundary],
-            "labels": current_pack["labels"][:boundary],
-            "mask": packing_mask[:boundary, :boundary],
-            "input_pos": current_pack["input_pos"][:boundary],
-        }
-
-        # Resultant shapes after padding
-        # tokens: [max_seq_len, ]
-        # labels: [max_seq_len, ]
-        # mask: [max_seq_len, max_seq_len]
-        # input_pos: [max_seq_len, ]
-        padded_pack = self._pad_pack(pack)
-        self.packs.append(padded_pack)
-
-        # Keep sample that did not fit or got truncated for the next pack
-        updated_pack = {
-            "tokens": current_pack["tokens"][boundary:],
-            "labels": current_pack["labels"][boundary:],
-            "mask": [packing_mask[boundary:, boundary:]],
-            "input_pos": current_pack["input_pos"][boundary:],
-        }
-
-        return updated_pack
-
-    def _pad_pack(
-        self,
-        sample: Dict[str, Any],
-        padding_idx: int = 0,
-        ignore_idx: int = CROSS_ENTROPY_IGNORE_IDX,
-    ) -> Dict[str, torch.Tensor]:
-        """Pad a group of packed sequences to max sequence length in the group, and
-        convert integer lists to tensors. Account for attention mask and position
-        ids.
-
-        This is a sample-wise collator and should not be used with the dataloader.
-
-        Sample should look like::
-            {
-                "tokens": List[int],
-                "labels": List[int],
-                "mask": Tensor,
-                "input_pos": List[int],
-            }
-
-        Args:
-            sample (Dict[str, Any]): A dictionary containing tokens, labels, mask,
-                and position ids
-            padding_idx (int): Padding index for input ids. Defaults to 0.
-            ignore_idx (int): Padding index for labels. Defaults to -100.
-
-        Returns:
-            Collated tokens, labels, mask, and position ids.
-        """
-        tokens = sample["tokens"]
-        labels = sample["labels"]
-        mask = sample["mask"]
-        input_pos = sample["input_pos"]
-
-        # Pad to max sequence length
-        tokens = F.pad(
-            torch.tensor(tokens), (0, self.max_seq_len - len(tokens)), value=padding_idx
-        )
-        labels = F.pad(
-            torch.tensor(labels), (0, self.max_seq_len - len(labels)), value=ignore_idx
-        )
-        # For attention mask, simply use identity matrix for the pad tokens
-        mask_pad = torch.eye(self.max_seq_len - mask.shape[0], dtype=torch.bool)
-        mask = torch.block_diag(mask, mask_pad)
-        # For position ids, continue to increment for pad tokens
-        next_pos = input_pos[-1] + 1
-        input_pos_pad = torch.arange(
-            next_pos, next_pos + self.max_seq_len - len(input_pos)
-        )
-        # Do not go beyond max_seq_len - 1
-        input_pos_pad = input_pos_pad.clamp(max=self.max_seq_len - 1)
-        input_pos = torch.cat(
-            [
-                torch.tensor(input_pos),
-                input_pos_pad,
-            ]
-        )
-
-        assert tokens.shape == labels.shape == input_pos.shape
-        assert tokens.shape[0] == mask.shape[0]
-
-        return {
-            "tokens": tokens,
-            "labels": labels,
-            "mask": mask,
-            "input_pos": input_pos,
-        }
+        # TODO: Add logic to consolidate incomplete batches after loop
 
     def __len__(self):
-        return len(self.packs)
+        return len(self.batches)
 
     def __getitem__(self, index: int) -> Dict[str, List[int]]:
-        return self.packs[index]
+        return self.batches[index]
+
+
+# class PackedDataset(Dataset):
+#     """
+#     Performs greedy sample packing on a provided dataset. This is done as a single
+#     preprocessing step before training begins. Shuffling is done outside of this
+#     class on packed samples with a ``Sampler`` as part of the dataloader. Currently,
+#     this only supports in-memory map-style datasets.
+
+#     The class loads, tokenizes, and packs examples on initialization - no tokenization is done during training.
+
+#     The general flow on initialization is: load tokenized sample -> add to buffer ->
+#     when buffer is long enough, add to ``self.packs``.
+
+#     During training, returns self.packs[idx] as input, label, attention mask, and
+#     position ids. The attention mask is a lower triangular block mask to prevent
+#     samples from cross-attending within a pack. The position ids indicate the position
+#     of each token relative to its sample within a pack. These are all padded to max
+#     sequence length, so a batch-wise collator is not needed.
+
+#     A packed sample is made up of individual smaller sequence length samples jammed together
+#     within ``max_seq_len``. For example, if max_seq_len is 6 and there are varied
+#     length samples::
+
+#         tokens = [
+#             [S1, S1, S1, S2, S2, pad],
+#             [S3, S3, S4, S4, pad, pad],
+#             ...,
+#         ]
+
+#     To prevent cross-contamination, the following mask would be returned for the
+#     first pack in the example::
+
+#         mask = [
+#             [1, 0, 0, 0, 0, 0],
+#             [1, 1, 0, 0, 0, 0],
+#             [1, 1, 1, 0, 0, 0],
+#             [0, 0, 0, 1, 0, 0],
+#             [0, 0, 0, 1, 1, 0],
+#             [0, 0, 0, 0, 0, 1],
+#         ]
+
+#     The position ids would be::
+
+#         input_pos = [
+#             [0, 1, 2, 0, 1, 2],
+#             [0, 1, 0, 1, 2, 3],
+#             ...,
+#         ]
+
+#     The identity matrix is used in the mask for pad tokens instead of a causal mask.
+#     For position ids for pad tokens, we simply continue to increment from the previous
+#     sample normally.
+
+#     Args:
+#         ds (Dataset): dataset to sample pack. This should return a dictionary with field
+#             "tokens" and "labels" containing the tokenized and label samples.
+#         max_seq_len (int): Maximum number of tokens to pack
+#         max_packs (Optional[int]): maximum number of packs. Default is None, which will create as many
+#             packs as possible.
+#         split_across_pack (bool): if the last sample in a pack does not fit in ``max_seq_len``,
+#             split the sample into the next pack, or move it entirely to the beginning of the next pack.
+#             For pre-training, typically this is set to True for general text completion. For
+#             fine-tuning, typically this is set to False to avoid truncating sentences in instruct
+#             tuning. Default is False.
+#     """
+
+#     def __init__(
+#         self,
+#         ds: Dataset,
+#         max_seq_len: int,
+#         max_packs: Optional[int] = None,
+#         split_across_pack: bool = False,
+#     ) -> None:
+#         self.ds = ds
+#         self.max_seq_len = max_seq_len
+#         self.max_packs = max_packs
+#         self.split_across_pack = split_across_pack
+#         # where final samples will be held
+#         self.packs: List[Dict[str, List[int]]] = []
+#         self._pack()
+
+#     def _pack(self) -> None:
+#         """
+#         Iterate through the dataset. Use a buffer to hold samples until max_seq_len,
+#         then append the buffer to self.packs as a single "packed" sample. Continue
+#         until max_packs or end of dataset.
+#         """
+#         # buffer to hold samples until they are long enough to be added to self.packs
+#         current_pack = {
+#             "tokens": [],
+#             "labels": [],
+#             "mask": [],
+#             "input_pos": [],
+#         }
+#         # Keep track of what index the previous sample ends in case we need
+#         # to end a pack early
+#         previous_sample_boundary = 0
+
+#         # Only show progress bar on rank 0
+#         _, rank = get_world_size_and_rank()
+#         if rank == 0:
+#             pbar = tqdm(total=len(self.ds), desc="Packing dataset", dynamic_ncols=True)
+
+#         for sample in self.ds:
+#             tokens, labels = sample["tokens"], sample["labels"]
+#             # If the dataset outputs samples that are larger than the specified
+#             # max_seq_len and we're unable to split it, user needs to modify
+#             # one of the two parameters
+#             seq_len = len(tokens)
+#             if seq_len > self.max_seq_len and not self.split_across_pack:
+#                 raise ValueError(
+#                     f"Dataset sample is too long ({len(tokens)} > {self.max_seq_len}). "
+#                     "Please set `split_across_pack=True` or increase `max_seq_len`."
+#                 )
+
+#             # Create integer mask and position ids for current sample and extend
+#             # current pack
+#             current_sample = {
+#                 "tokens": tokens,
+#                 "labels": labels,
+#                 # Mask is simply a causal mask within this sample length
+#                 "mask": [torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))],
+#                 "input_pos": list(range(seq_len)),
+#             }
+#             current_pack = {k: v + current_sample[k] for k, v in current_pack.items()}
+
+#             # If the current pack is long enough, add it to self.packs and retain
+#             # any truncated samples for next pack, if splitting samples
+#             if len(current_pack["tokens"]) > self.max_seq_len:
+#                 current_pack = self._add_pack(
+#                     current_pack=current_pack,
+#                     boundary=self.max_seq_len
+#                     if self.split_across_pack
+#                     else previous_sample_boundary,
+#                 )
+
+#             if rank == 0:
+#                 pbar.update()
+#             previous_sample_boundary = len(current_pack["tokens"])
+#             if self.max_packs is not None and len(self.packs) >= self.max_packs:
+#                 break
+
+#         # Add the last pack with remaining samples that did not fit in previous
+#         if len(current_pack["tokens"]) > 0 and (
+#             self.max_packs is None or len(self.packs) < self.max_packs
+#         ):
+#             current_pack = self._add_pack(
+#                 current_pack=current_pack, boundary=len(current_pack["tokens"])
+#             )
+#             assert len(current_pack["tokens"]) == 0
+
+#     def _add_pack(
+#         self, current_pack: Dict[str, List[int]], boundary: int
+#     ) -> Dict[str, List[int]]:
+#         """
+#         Pad and add the current pack to self.packs and return what's remaining.
+#         """
+#         # So far we've kept a list of causal masks, one for each sample in the pack.
+#         # Now we need to combine them into a single mask for the entire pack.
+#         packing_mask = torch.block_diag(*current_pack["mask"])
+#         pack = {
+#             "tokens": current_pack["tokens"][:boundary],
+#             "labels": current_pack["labels"][:boundary],
+#             "mask": packing_mask[:boundary, :boundary],
+#             "input_pos": current_pack["input_pos"][:boundary],
+#         }
+
+#         # Resultant shapes after padding
+#         # tokens: [max_seq_len, ]
+#         # labels: [max_seq_len, ]
+#         # mask: [max_seq_len, max_seq_len]
+#         # input_pos: [max_seq_len, ]
+#         padded_pack = self._pad_pack(pack)
+#         self.packs.append(padded_pack)
+
+#         # Keep sample that did not fit or got truncated for the next pack
+#         updated_pack = {
+#             "tokens": current_pack["tokens"][boundary:],
+#             "labels": current_pack["labels"][boundary:],
+#             "mask": [packing_mask[boundary:, boundary:]],
+#             "input_pos": current_pack["input_pos"][boundary:],
+#         }
+
+#         return updated_pack
+
+#     def _pad_pack(
+#         self,
+#         sample: Dict[str, Any],
+#         padding_idx: int = 0,
+#         ignore_idx: int = CROSS_ENTROPY_IGNORE_IDX,
+#     ) -> Dict[str, torch.Tensor]:
+#         """Pad a group of packed sequences to max sequence length in the group, and
+#         convert integer lists to tensors. Account for attention mask and position
+#         ids.
+
+#         This is a sample-wise collator and should not be used with the dataloader.
+
+#         Sample should look like::
+#             {
+#                 "tokens": List[int],
+#                 "labels": List[int],
+#                 "mask": Tensor,
+#                 "input_pos": List[int],
+#             }
+
+#         Args:
+#             sample (Dict[str, Any]): A dictionary containing tokens, labels, mask,
+#                 and position ids
+#             padding_idx (int): Padding index for input ids. Defaults to 0.
+#             ignore_idx (int): Padding index for labels. Defaults to -100.
+
+#         Returns:
+#             Collated tokens, labels, mask, and position ids.
+#         """
+#         tokens = sample["tokens"]
+#         labels = sample["labels"]
+#         mask = sample["mask"]
+#         input_pos = sample["input_pos"]
+
+#         # Pad to max sequence length
+#         tokens = F.pad(
+#             torch.tensor(tokens), (0, self.max_seq_len - len(tokens)), value=padding_idx
+#         )
+#         labels = F.pad(
+#             torch.tensor(labels), (0, self.max_seq_len - len(labels)), value=ignore_idx
+#         )
+#         # For attention mask, simply use identity matrix for the pad tokens
+#         mask_pad = torch.eye(self.max_seq_len - mask.shape[0], dtype=torch.bool)
+#         mask = torch.block_diag(mask, mask_pad)
+#         # For position ids, continue to increment for pad tokens
+#         next_pos = input_pos[-1] + 1
+#         input_pos_pad = torch.arange(
+#             next_pos, next_pos + self.max_seq_len - len(input_pos)
+#         )
+#         # Do not go beyond max_seq_len - 1
+#         input_pos_pad = input_pos_pad.clamp(max=self.max_seq_len - 1)
+#         input_pos = torch.cat(
+#             [
+#                 torch.tensor(input_pos),
+#                 input_pos_pad,
+#             ]
+#         )
+
+#         assert tokens.shape == labels.shape == input_pos.shape
+#         assert tokens.shape[0] == mask.shape[0]
+
+#         return {
+#             "tokens": tokens,
+#             "labels": labels,
+#             "mask": mask,
+#             "input_pos": input_pos,
+#         }
+
+#     def __len__(self):
+#         return len(self.packs)
+
+#     def __getitem__(self, index: int) -> Dict[str, List[int]]:
+#         return self.packs[index]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

This is a demo of using binned dynamic batch sizes as an alternative to sample packing. Sample packing packs short sequences together so that you maximize the number of trainable tokens per batch which speeds up training. The downside is it adds both extra complexity, through having to mask different sequences, and long sequences take up more memory per token than short sequences due to attention layers. What dynamic batch size does is allow you to select a number of "bins" that groups together similar length tokens, this helps minimize the amount of padding needed. It then allows batches of short sequences to be bigger to maintain a uniform "token per batch".

This is a proof of concept and minimally modifies the current PackedDataset class to test this alternate form of packing. In testing on Cleaned Alpaca, using max_seq_len=512 and max_toks_per_batch=1024 (conventional bs=2), llama3/8B_qlora_single_device took 4:34 minutes using sample packing, and took 4 hours with dynamic batching.

This approach requires further testing on different scenarios. It's also possible that it's more memory efficient given it uses shorter sequences and could allow for even more tokens per batch than sample packing.

Finally, for a official implementation I'd recommend that we implemented this as a custom BatchSampler that runs online instead of pre-batching everything. This would remove the need to create the batches each epoch.

#### Changelog
Overwrote PackedDataset and hardcoded some test changes into lora_finetune_single_device.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
