### PR TITLE
Pin ao==0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "omegaconf",
 
     # Quantization
-    "torchao==0.1",
+    "torchao==0.3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "blobfile>=2",
 
     # Miscellaneous
-    "numpy",
+    "numpy<=1.26.4", # Pin here until https://github.com/tensorflow/tensorboard/issues/6869 is addressed
     "tqdm",
     "omegaconf",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "blobfile>=2",
 
     # Miscellaneous
-    "numpy<=1.26.4", # Pin here until https://github.com/tensorflow/tensorboard/issues/6869 is addressed
+    "numpy",
     "tqdm",
     "omegaconf",
 

--- a/recipes/configs/dev/llama2/13B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/13B_lora_fsdp2.yaml
@@ -1,6 +1,10 @@
 # Config for multi-device LoRA with FSDP2 in lora_finetune_fsdp2.py
 # using a Llama2 13B model
 #
+# This config requires PyTorch nightlies to run.
+# See https://github.com/pytorch/torchtune/blob/main/recipes/dev/fsdp2_recipes.md
+# for setup instructions.
+#
 # This config assumes that you've run the following command before launching
 # this run:
 #   tune download meta-llama/Llama-2-13b-hf --output-dir /tmp/Llama-2-13b-hf --hf-token <HF_TOKEN>

--- a/recipes/configs/dev/llama2/70B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_lora_fsdp2.yaml
@@ -1,6 +1,10 @@
 # Config for multi-device LoRA with FSDP2 lora_finetune_fsdp2.py
 # using a Llama2 70B model
 #
+# This config requires PyTorch nightlies to run.
+# See https://github.com/pytorch/torchtune/blob/main/recipes/dev/fsdp2_recipes.md
+# for setup instructions.
+#
 # This config assumes that you've run the following command before launching
 # this run:
 #   tune download meta-llama/Llama-2-70b-hf --output-dir /tmp/Llama-2-70b-hf --hf-token <HF_TOKEN>

--- a/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
@@ -1,6 +1,10 @@
 # Config for multi-device QLoRA in lora_finetune_fsdp2.py
 # using a Llama2 70B model
 #
+# This config requires PyTorch nightlies to run.
+# See https://github.com/pytorch/torchtune/blob/main/recipes/dev/fsdp2_recipes.md
+# for setup instructions.
+#
 # This config assumes that you've run the following command before launching
 # this run:
 #   tune download meta-llama/Llama-2-70b-hf --output-dir /tmp/Llama-2-70b-hf --hf-token <HF_TOKEN>

--- a/recipes/configs/dev/llama2/7B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/7B_lora_fsdp2.yaml
@@ -1,6 +1,10 @@
 # Config for multi-device LoRA finetuning with FSDP2 in lora_finetune_fsdp2.py
 # using a Llama2 7B model
 #
+# This config requires PyTorch nightlies to run.
+# See https://github.com/pytorch/torchtune/blob/main/recipes/dev/fsdp2_recipes.md
+# for setup instructions.
+#
 # This config assumes that you've run the following command before launching
 # this run:
 #   tune download meta-llama/Llama-2-7b-hf --output-dir /tmp/Llama-2-7b-hf --hf-token <HF_TOKEN>

--- a/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
@@ -1,6 +1,10 @@
 # Config for single device QLoRA with lora_finetune_fsdp2.py
 # using a Llama2 7B model
 #
+# This config requires PyTorch nightlies to run.
+# See https://github.com/pytorch/torchtune/blob/main/recipes/dev/fsdp2_recipes.md
+# for setup instructions.
+#
 # This config assumes that you've run the following command before launching
 # this run:
 #   tune download meta-llama/Llama-2-7b-hf --output-dir /tmp/Llama-2-7b-hf --hf-token <HF_TOKEN>

--- a/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
@@ -9,15 +9,17 @@
 # this run:
 #   tune download meta-llama/Llama-2-7b-hf --output-dir /tmp/Llama-2-7b-hf --hf-token <HF_TOKEN>
 #
-# To launch on a single device, run the following command from root:
-#   tune run lora_finetune_fsdp2 --config llama2/7B_qlora
+# To launch on 2 devices, run the following command from root:
+#   tune run --nnodes 1 --nproc_per_node 2 lora_finetune_fsdp2 --config llama2/7B_qlora
 #
 # You can add specific overrides through the command line. For example
 # to override the checkpointer directory while launching training
 # you can run:
-#   tune run lora_finetune_fsdp2 --config llama2/7B_qlora checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#   tune run --nnodes 1 --nproc_per_node 2 lora_finetune_fsdp2 --config llama2/7B_qlora checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
 #
-# This config works only for training on single device.
+# This config works best when the model is being fine-tuned on 2+ GPUs.
+# For single device LoRA finetuning please use 7B_lora_single_device.yaml
+# or 7B_qlora_single_device.yaml
 
 # Model Arguments
 model:
@@ -71,7 +73,7 @@ fsdp:
 # Training
 epochs: 1
 max_steps_per_epoch: null
-gradient_accumulation_steps: 16
+gradient_accumulation_steps: 2
 compile: False
 
 # Logging

--- a/recipes/dev/fsdp2_recipes.md
+++ b/recipes/dev/fsdp2_recipes.md
@@ -1,6 +1,6 @@
 ## FSDP2 Recipes
 
-This directory contains training recipes for LoRA and QLoRA using FSDP2.
+This directory contains distributed training recipes for LoRA and QLoRA using [FSDP2](https://github.com/pytorch/pytorch/issues/114299).
 Currently FSDP2 is only available in PyTorch nightly releases.
 
 To set up your environment to run these recipes, you should first install torchtune dependencies,

--- a/recipes/dev/fsdp2_recipes.md
+++ b/recipes/dev/fsdp2_recipes.md
@@ -1,0 +1,12 @@
+## FSDP2 Recipes
+
+This directory contains training recipes for LoRA and QLoRA using FSDP2.
+Currently FSDP2 is only available in PyTorch nightly releases.
+
+To set up your environment to run these recipes, you should first install torchtune dependencies,
+then install PyTorch nightlies. E.g.
+
+```
+pip install torchtune
+pip3 install --upgrade --pre torch --index-url https://download.pytorch.org/whl/nightly/cu124
+```

--- a/tests/torchtune/utils/test_distributed.py
+++ b/tests/torchtune/utils/test_distributed.py
@@ -12,7 +12,6 @@ from itertools import chain
 import pytest
 import torch
 import torch.nn as nn
-import torchao
 from packaging import version
 from tests.test_utils import gpu_test, single_box_init
 from torch.distributed import launcher
@@ -399,10 +398,6 @@ class TestFullyShardState(FSDPTest):
         for key, value in sharded_model_sd.items():
             self.assertEqual(value, expected_sharded_model_sd[key])
 
-    # torchao does not have __version__ defined for < 0.3
-    @pytest.mark.skipif(
-        "__version__" not in dir(torchao), reason="torchao>=0.3 required"
-    )
     @pytest.mark.skipif(
         version.parse(torch.__version__).base_version < "2.4.0",
         reason="torch >= 2.4 required",

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -8,19 +8,16 @@ from typing import Any, Callable, Optional
 
 import torch
 from torchao.quantization.quant_api import (
-    apply_weight_only_int8_quant,
     Int4WeightOnlyGPTQQuantizer,
     Int4WeightOnlyQuantizer,
+    quantize,
     Quantizer,
 )
 
 # importing TORCH_VERSION_AFTER_2_3 because `Int8DynActInt4WeightQuantizer`
 # is only available after 2.3 so we have to guard the pytorch versions to decide
 # the list of supported quantizers
-try:
-    from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
-except Exception:
-    from torchao.utils import TORCH_VERSION_AFTER_2_3
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 
 __all__ = [
     "Int4WeightOnlyQuantizer",
@@ -34,7 +31,7 @@ class Int8WeightOnlyQuantizer(Quantizer):
     def quantize(
         self, model: torch.nn.Module, *args: Any, **kwargs: Any
     ) -> torch.nn.Module:
-        apply_weight_only_int8_quant(model)
+        return quantize(model, "int8_weight_only")
         return model
 
 


### PR DESCRIPTION
PR to upgrade ao to 0.3. Clean up a couple ao version checks in the code that are no longer needed. We also need to provide more explicit guidance to users on how to run our FSDP2 recipes using stable ao + pytorch nightlies

Tested 

```
tune run --nnodes 1 --nproc_per_node 2 lora_finetune_fsdp2 --config llama2/7B_qlora
...
1|14|Loss: 1.9024205207824707:   0%|▎                                                                                                                                                | 14/6470 [01:02<7:35:25,  4.23s/it]
```