### PR TITLE
add metadata format to save_file in `FullModelHFCheckpointer`

### DIFF
--- a/torchtune/utils/_checkpointing/_checkpointer.py
+++ b/torchtune/utils/_checkpointing/_checkpointer.py
@@ -522,7 +522,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     self._output_dir,
                     f"model-0{cpt_idx}-of-0{list(split_state_dicts.keys())[-1]}_{epoch}",
                 ).with_suffix(".safetensors")
-                save_file(model_state_dict, output_path)
+                save_file(model_state_dict, output_path, metadata={'format': 'pt'})
             logger.info(
                 "Model checkpoint of size "
                 f"{os.path.getsize(output_path) / 1000**3:.2f} GB "

--- a/torchtune/utils/_checkpointing/_checkpointer.py
+++ b/torchtune/utils/_checkpointing/_checkpointer.py
@@ -522,7 +522,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     self._output_dir,
                     f"model-0{cpt_idx}-of-0{list(split_state_dicts.keys())[-1]}_{epoch}",
                 ).with_suffix(".safetensors")
-                save_file(model_state_dict, output_path, metadata={'format': 'pt'})
+                save_file(model_state_dict, output_path, metadata={"format": "pt"})
             logger.info(
                 "Model checkpoint of size "
                 f"{os.path.getsize(output_path) / 1000**3:.2f} GB "


### PR DESCRIPTION
`AutoModel.xx` classes from hf's transformers do not work otherwise, and we get an error because the metadata is `None` while loading the model here: https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L518-L522

That said, I only have very basic knowledge of this so might be wrong here. I personally had to re-save the model files with metadata added for them to work with `AutoModel...` classes.

#### Context
What is the purpose of this PR? Is it to
- [x ] add a new feature
- [x ] fix a bug (ish??)
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
Adds pt metadata while saving safetensors in `FullModelHFCheckpointer`.

#### Test plan
Let me know if I have to do any of these? Also how 😅 ?

Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
