### PR TITLE
update ao to latest patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "omegaconf",
 
     # Quantization
-    "torchao==0.3",
+    "torchao==0.3.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Now that ao 0.3.1 is on PyPI we can point to it. This should resolve the issue of forced downgrades from PyTorch nightlies when pip installing torchtune

Test plan (besides green CI):

Confirm that our default install does not override PyTorch nightlies

```
conda install pytorch pytorch-cuda=12.4 -c pytorch-nightly -c nvidia
pip install -e ".[dev]"
pip list

Package                 Version           Editable project location
----------------------- ----------------- -----------------------------
absl-py                 2.1.0
aiohttp                 3.9.5
aiosignal               1.3.1
antlr4-python3-runtime  4.9.3
attrs                   23.2.0
bitsandbytes            0.43.1
blobfile                2.1.1
certifi                 2024.6.2
cfgv                    3.4.0
charset-normalizer      3.3.2
click                   8.1.7
coverage                7.5.4
datasets                2.20.0
dill                    0.3.8
distlib                 0.3.8
docker-pycreds          0.4.0
expecttest              0.2.1
filelock                3.15.4
frozenlist              1.4.1
fsspec                  2024.5.0
gitdb                   4.0.11
GitPython               3.1.43
gmpy2                   2.1.2
grpcio                  1.64.1
huggingface-hub         0.23.4
identify                2.5.36
idna                    3.7
iniconfig               2.0.0
Jinja2                  3.1.4
lxml                    4.9.4
Markdown                3.6
MarkupSafe              2.1.3
mpmath                  1.2.1
multidict               6.0.5
multiprocess            0.70.16
networkx                3.2.1
nodeenv                 1.9.1
numpy                   1.26.4
omegaconf               2.3.0
packaging               24.1
pandas                  2.2.2
pip                     24.0
platformdirs            4.2.2
pluggy                  1.5.0
pre-commit              3.7.1
protobuf                4.25.3
psutil                  6.0.0
pyarrow                 16.1.0
pyarrow-hotfix          0.6
pycryptodomex           3.20.0
pytest                  7.4.0
pytest-cov              5.0.0
pytest-integration      0.2.3
pytest-mock             3.14.0
python-dateutil         2.9.0.post0
pytz                    2024.1
PyYAML                  6.0.1
regex                   2024.5.15
requests                2.32.3
safetensors             0.4.3
sentencepiece           0.2.0
sentry-sdk              2.7.1
setproctitle            1.3.3
setuptools              69.5.1
six                     1.16.0
smmap                   5.0.1
sympy                   1.12
tensorboard             2.17.0
tensorboard-data-server 0.7.2
tiktoken                0.7.0
torch                   2.5.0.dev20240701
torchao                 0.3.1
torchtune               0.0.0             /data/users/ebs/ebs-torchtune
tqdm                    4.66.4
typing_extensions       4.11.0
tzdata                  2024.1
urllib3                 2.2.2
virtualenv              20.26.3
wandb                   0.17.3
Werkzeug                3.0.3
wheel                   0.43.0
xxhash                  3.4.1
yarl                    1.9.4
```

Confirm that FSDP2 QLoRA recipe runs:

```
tune run --nnodes 1 --nproc_per_node 2 lora_finetune_fsdp2 --config llama2/7B_qlora
...
1|2|Loss: 1.240362286567688:   0%|                                                                                                                                                                                                                           | 2/6470 [00:14<11:47:26,  6.56s/it]
```