### PR TITLE
Fix RegEx to parse out acc numbers for eval recipe test

### DIFF
--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -49,7 +49,7 @@ class TestEleutherEval:
 
         out = capsys.readouterr().out
 
-        search_results = re.search(r"acc(?:_norm)?\s*\|?\s*([\d.]+)", out.strip())
+        search_results = re.search(r"acc\s*\|\s*\↑\s*\|?\s*(\d+\.\d+)", out.strip())
         assert search_results is not None
         acc_result = float(search_results.group(1))
         assert math.isclose(acc_result, 0.3, abs_tol=0.05)

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -49,7 +49,20 @@ class TestEleutherEval:
 
         out = capsys.readouterr().out
 
-        search_results = re.search(r"acc\s*\|\s*\↑\s*\|?\s*(\d+\.\d+)", out.strip())
+        # v0.4.2 format
+        # |    Tasks     |Version|Filter|n-shot|Metric|Value |   |Stderr|
+        # |--------------|------:|------|-----:|------|-----:|---|-----:|
+        # |truthfulqa_mc2|      2|none  |     0|acc   |0.3469|±  |0.1444|
+
+        # v0.4.3 format
+        # |    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
+        # |--------------|------:|------|-----:|------|---|-----:|---|-----:|
+        # |truthfulqa_mc2|      2|none  |     0|acc   |↑  |0.3469|±  |0.1444|
+
+        # The below RegEx command will pick up both formats
+        search_results = re.search(
+            r"acc(?:_norm)?\s*\|?\s*(?:\↑\s*\|?)?([\d.]+)", out.strip()
+        )
         assert search_results is not None
         acc_result = float(search_results.group(1))
         assert math.isclose(acc_result, 0.3, abs_tol=0.05)


### PR DESCRIPTION
#### Context
With the [release of EleutherAI's Eval Harness v0.4.3](https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/v0.4.3), there was an addition of a column in the default eval output. Since we parse the eval output in our integration recipe test, it started failing b/c of this change. The results are still the same, this just resulted in our CI being red. 

#### Changelog

* Change RegEx to account for the new up arrow in eval output

#### Test plan

<details>

<summary>Test on lm_eval==v0.4.2</summary>

```
(joe-torchtune) [jrcummings@devvm050.nha0 ~/projects/joe-torchtune (fix-lm-eval-0.4.3)]$ pip install lm_eval==0.4.2 && pytest tests/recipes/test_eleuther_eval.py --with-integration
Collecting lm_eval==0.4.2
  Using cached lm_eval-0.4.2-py3-none-any.whl.metadata (30 kB)
Requirement already satisfied: accelerate>=0.21.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (0.30.0)
Requirement already satisfied: evaluate in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (0.4.2)
Requirement already satisfied: datasets>=2.16.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (2.19.0)
Requirement already satisfied: jsonlines in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (4.0.0)
Requirement already satisfied: numexpr in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (2.10.0)
Requirement already satisfied: peft>=0.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (0.10.0)
Requirement already satisfied: pybind11>=2.6.2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (2.12.0)
Requirement already satisfied: pytablewriter in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (1.2.0)
Requirement already satisfied: rouge-score>=0.0.4 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (0.1.2)
Requirement already satisfied: sacrebleu>=1.5.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (2.4.2)
Requirement already satisfied: scikit-learn>=0.24.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (1.4.2)
Requirement already satisfied: sqlitedict in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (2.1.0)
Requirement already satisfied: torch>=1.8 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (2.2.2)
Requirement already satisfied: tqdm-multiprocess in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (0.0.11)
Requirement already satisfied: transformers>=4.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (4.41.2)
Requirement already satisfied: zstandard in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (0.22.0)
Requirement already satisfied: dill in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (0.3.8)
Requirement already satisfied: word2number in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (1.1)
Requirement already satisfied: more-itertools in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.2) (10.2.0)
Requirement already satisfied: numpy>=1.17 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.21.0->lm_eval==0.4.2) (1.26.4)
Requirement already satisfied: packaging>=20.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.21.0->lm_eval==0.4.2) (24.0)
Requirement already satisfied: psutil in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.21.0->lm_eval==0.4.2) (5.9.8)
Requirement already satisfied: pyyaml in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.21.0->lm_eval==0.4.2) (6.0.1)
Requirement already satisfied: huggingface-hub in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.21.0->lm_eval==0.4.2) (0.23.3)
Requirement already satisfied: safetensors>=0.3.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.21.0->lm_eval==0.4.2) (0.4.3)
Requirement already satisfied: filelock in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (3.13.4)
Requirement already satisfied: pyarrow>=12.0.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (16.0.0)
Requirement already satisfied: pyarrow-hotfix in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (0.6)
Requirement already satisfied: pandas in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (2.2.2)
Requirement already satisfied: requests>=2.19.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (2.31.0)
Requirement already satisfied: tqdm>=4.62.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (4.66.2)
Requirement already satisfied: xxhash in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (3.4.1)
Requirement already satisfied: multiprocess in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (0.70.16)
Requirement already satisfied: fsspec<=2024.3.1,>=2023.1.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from fsspec[http]<=2024.3.1,>=2023.1.0->datasets>=2.16.0->lm_eval==0.4.2) (2024.3.1)
Requirement already satisfied: aiohttp in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.2) (3.9.5)
Requirement already satisfied: absl-py in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from rouge-score>=0.0.4->lm_eval==0.4.2) (2.1.0)
Requirement already satisfied: nltk in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from rouge-score>=0.0.4->lm_eval==0.4.2) (3.8.1)
Requirement already satisfied: six>=1.14.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from rouge-score>=0.0.4->lm_eval==0.4.2) (1.16.0)
Requirement already satisfied: portalocker in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.2) (2.8.2)
Requirement already satisfied: regex in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.2) (2024.4.16)
Requirement already satisfied: tabulate>=0.8.9 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.2) (0.9.0)
Requirement already satisfied: colorama in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.2) (0.4.6)
Requirement already satisfied: lxml in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.2) (4.9.4)
Requirement already satisfied: scipy>=1.6.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from scikit-learn>=0.24.1->lm_eval==0.4.2) (1.13.0)
Requirement already satisfied: joblib>=1.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from scikit-learn>=0.24.1->lm_eval==0.4.2) (1.4.2)
Requirement already satisfied: threadpoolctl>=2.0.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from scikit-learn>=0.24.1->lm_eval==0.4.2) (3.5.0)
Requirement already satisfied: typing-extensions>=4.8.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (4.11.0)
Requirement already satisfied: sympy in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (1.12)
Requirement already satisfied: networkx in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (3.3)
Requirement already satisfied: jinja2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (3.1.3)
Requirement already satisfied: nvidia-cuda-nvrtc-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (12.1.105)
Requirement already satisfied: nvidia-cuda-runtime-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (12.1.105)
Requirement already satisfied: nvidia-cuda-cupti-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (12.1.105)
Requirement already satisfied: nvidia-cudnn-cu12==8.9.2.26 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (8.9.2.26)
Requirement already satisfied: nvidia-cublas-cu12==12.1.3.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (12.1.3.1)
Requirement already satisfied: nvidia-cufft-cu12==11.0.2.54 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (11.0.2.54)
Requirement already satisfied: nvidia-curand-cu12==10.3.2.106 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (10.3.2.106)
Requirement already satisfied: nvidia-cusolver-cu12==11.4.5.107 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (11.4.5.107)
Requirement already satisfied: nvidia-cusparse-cu12==12.1.0.106 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (12.1.0.106)
Requirement already satisfied: nvidia-nccl-cu12==2.19.3 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (2.19.3)
Requirement already satisfied: nvidia-nvtx-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (12.1.105)
Requirement already satisfied: triton==2.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.2) (2.2.0)
Requirement already satisfied: nvidia-nvjitlink-cu12 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from nvidia-cusolver-cu12==11.4.5.107->torch>=1.8->lm_eval==0.4.2) (12.4.127)
Requirement already satisfied: tokenizers<0.20,>=0.19 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from transformers>=4.1->lm_eval==0.4.2) (0.19.1)
Requirement already satisfied: attrs>=19.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from jsonlines->lm_eval==0.4.2) (23.2.0)
Requirement already satisfied: setuptools>=38.3.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.2) (68.2.2)
Requirement already satisfied: DataProperty<2,>=1.0.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.2) (1.0.1)
Requirement already satisfied: mbstrdecoder<2,>=1.0.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.2) (1.1.3)
Requirement already satisfied: pathvalidate<4,>=2.3.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.2) (3.2.0)
Requirement already satisfied: tabledata<2,>=1.3.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.2) (1.3.3)
Requirement already satisfied: tcolorpy<1,>=0.0.5 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.2) (0.1.6)
Requirement already satisfied: typepy<2,>=1.3.2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from typepy[datetime]<2,>=1.3.2->pytablewriter->lm_eval==0.4.2) (1.3.2)
Requirement already satisfied: aiosignal>=1.1.2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.2) (1.3.1)
Requirement already satisfied: frozenlist>=1.1.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.2) (1.4.1)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.2) (6.0.5)
Requirement already satisfied: yarl<2.0,>=1.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.2) (1.9.4)
Requirement already satisfied: chardet<6,>=3.0.4 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from mbstrdecoder<2,>=1.0.0->pytablewriter->lm_eval==0.4.2) (5.2.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.2) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.2) (3.7)
Requirement already satisfied: urllib3<3,>=1.21.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.2) (2.2.1)
Requirement already satisfied: certifi>=2017.4.17 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.2) (2024.2.2)
Requirement already satisfied: python-dateutil<3.0.0,>=2.8.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from typepy[datetime]<2,>=1.3.2->pytablewriter->lm_eval==0.4.2) (2.9.0.post0)
Requirement already satisfied: pytz>=2018.9 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from typepy[datetime]<2,>=1.3.2->pytablewriter->lm_eval==0.4.2) (2024.1)
Requirement already satisfied: MarkupSafe>=2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from jinja2->torch>=1.8->lm_eval==0.4.2) (2.1.5)
Requirement already satisfied: click in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from nltk->rouge-score>=0.0.4->lm_eval==0.4.2) (8.1.7)
Requirement already satisfied: tzdata>=2022.7 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pandas->datasets>=2.16.0->lm_eval==0.4.2) (2024.1)
Requirement already satisfied: mpmath>=0.19 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sympy->torch>=1.8->lm_eval==0.4.2) (1.3.0)
Using cached lm_eval-0.4.2-py3-none-any.whl (1.4 MB)
Installing collected packages: lm_eval
  Attempting uninstall: lm_eval
    Found existing installation: lm_eval 0.4.3
    Uninstalling lm_eval-0.4.3:
      Successfully uninstalled lm_eval-0.4.3
Successfully installed lm_eval-0.4.2
Expected artifacts for test run are:
small-ckpt-tune-03082024.pt
small-ckpt-meta-03082024.pt
small-ckpt-hf-03082024.pt
small-ckpt-tune-llama3-05052024.pt
tokenizer.model
tokenizer_llama3.model
File already exists locally: /tmp/test-artifacts/small-ckpt-tune-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-meta-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-hf-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-tune-llama3-05052024.pt
File already exists locally: /tmp/test-artifacts/tokenizer.model
File already exists locally: /tmp/test-artifacts/tokenizer_llama3.model
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.11.9, pytest-8.1.1, pluggy-1.5.0
rootdir: /home/jrcummings/projects/joe-torchtune
configfile: pyproject.toml
plugins: integration-0.2.3, mock-3.14.0, cov-5.0.0, hypothesis-6.103.1
collected 2 items

tests/recipes/test_eleuther_eval.py ..                                                                                                                                                                                                                                   [100%]

=============================================================================================================================== warnings summary ===============================================================================================================================
tests/recipes/test_eleuther_eval.py::TestEleutherEval::test_torchtune_checkpoint_eval_results
  /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================================== 2 passed, 1 warning in 11.68s =========================================================================================================================
```
</details>


<details>

<summary>Testing on lm_eval==0.4.3 </summary>
```
(joe-torchtune) [jrcummings@devvm050.nha0 ~/projects/joe-torchtune (fix-lm-eval-0.4.3)]$ pip install lm_eval==0.4.3 && pytest tests/recipes/test_eleuther_eval.py --with-integration
Collecting lm_eval==0.4.3
  Using cached lm_eval-0.4.3-py3-none-any.whl.metadata (38 kB)
Requirement already satisfied: accelerate>=0.26.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (0.30.0)
Requirement already satisfied: evaluate in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (0.4.2)
Requirement already satisfied: datasets>=2.16.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (2.19.0)
Requirement already satisfied: jsonlines in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (4.0.0)
Requirement already satisfied: numexpr in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (2.10.0)
Requirement already satisfied: peft>=0.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (0.10.0)
Requirement already satisfied: pybind11>=2.6.2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (2.12.0)
Requirement already satisfied: pytablewriter in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (1.2.0)
Requirement already satisfied: rouge-score>=0.0.4 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (0.1.2)
Requirement already satisfied: sacrebleu>=1.5.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (2.4.2)
Requirement already satisfied: scikit-learn>=0.24.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (1.4.2)
Requirement already satisfied: sqlitedict in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (2.1.0)
Requirement already satisfied: torch>=1.8 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (2.2.2)
Requirement already satisfied: tqdm-multiprocess in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (0.0.11)
Requirement already satisfied: transformers>=4.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (4.41.2)
Requirement already satisfied: zstandard in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (0.22.0)
Requirement already satisfied: dill in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (0.3.8)
Requirement already satisfied: word2number in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (1.1)
Requirement already satisfied: more-itertools in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from lm_eval==0.4.3) (10.2.0)
Requirement already satisfied: numpy>=1.17 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.26.0->lm_eval==0.4.3) (1.26.4)
Requirement already satisfied: packaging>=20.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.26.0->lm_eval==0.4.3) (24.0)
Requirement already satisfied: psutil in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.26.0->lm_eval==0.4.3) (5.9.8)
Requirement already satisfied: pyyaml in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.26.0->lm_eval==0.4.3) (6.0.1)
Requirement already satisfied: huggingface-hub in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.26.0->lm_eval==0.4.3) (0.23.3)
Requirement already satisfied: safetensors>=0.3.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from accelerate>=0.26.0->lm_eval==0.4.3) (0.4.3)
Requirement already satisfied: filelock in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (3.13.4)
Requirement already satisfied: pyarrow>=12.0.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (16.0.0)
Requirement already satisfied: pyarrow-hotfix in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (0.6)
Requirement already satisfied: pandas in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (2.2.2)
Requirement already satisfied: requests>=2.19.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (2.31.0)
Requirement already satisfied: tqdm>=4.62.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (4.66.2)
Requirement already satisfied: xxhash in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (3.4.1)
Requirement already satisfied: multiprocess in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (0.70.16)
Requirement already satisfied: fsspec<=2024.3.1,>=2023.1.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from fsspec[http]<=2024.3.1,>=2023.1.0->datasets>=2.16.0->lm_eval==0.4.3) (2024.3.1)
Requirement already satisfied: aiohttp in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from datasets>=2.16.0->lm_eval==0.4.3) (3.9.5)
Requirement already satisfied: absl-py in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from rouge-score>=0.0.4->lm_eval==0.4.3) (2.1.0)
Requirement already satisfied: nltk in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from rouge-score>=0.0.4->lm_eval==0.4.3) (3.8.1)
Requirement already satisfied: six>=1.14.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from rouge-score>=0.0.4->lm_eval==0.4.3) (1.16.0)
Requirement already satisfied: portalocker in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.3) (2.8.2)
Requirement already satisfied: regex in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.3) (2024.4.16)
Requirement already satisfied: tabulate>=0.8.9 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.3) (0.9.0)
Requirement already satisfied: colorama in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.3) (0.4.6)
Requirement already satisfied: lxml in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sacrebleu>=1.5.0->lm_eval==0.4.3) (4.9.4)
Requirement already satisfied: scipy>=1.6.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from scikit-learn>=0.24.1->lm_eval==0.4.3) (1.13.0)
Requirement already satisfied: joblib>=1.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from scikit-learn>=0.24.1->lm_eval==0.4.3) (1.4.2)
Requirement already satisfied: threadpoolctl>=2.0.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from scikit-learn>=0.24.1->lm_eval==0.4.3) (3.5.0)
Requirement already satisfied: typing-extensions>=4.8.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (4.11.0)
Requirement already satisfied: sympy in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (1.12)
Requirement already satisfied: networkx in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (3.3)
Requirement already satisfied: jinja2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (3.1.3)
Requirement already satisfied: nvidia-cuda-nvrtc-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (12.1.105)
Requirement already satisfied: nvidia-cuda-runtime-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (12.1.105)
Requirement already satisfied: nvidia-cuda-cupti-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (12.1.105)
Requirement already satisfied: nvidia-cudnn-cu12==8.9.2.26 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (8.9.2.26)
Requirement already satisfied: nvidia-cublas-cu12==12.1.3.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (12.1.3.1)
Requirement already satisfied: nvidia-cufft-cu12==11.0.2.54 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (11.0.2.54)
Requirement already satisfied: nvidia-curand-cu12==10.3.2.106 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (10.3.2.106)
Requirement already satisfied: nvidia-cusolver-cu12==11.4.5.107 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (11.4.5.107)
Requirement already satisfied: nvidia-cusparse-cu12==12.1.0.106 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (12.1.0.106)
Requirement already satisfied: nvidia-nccl-cu12==2.19.3 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (2.19.3)
Requirement already satisfied: nvidia-nvtx-cu12==12.1.105 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (12.1.105)
Requirement already satisfied: triton==2.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from torch>=1.8->lm_eval==0.4.3) (2.2.0)
Requirement already satisfied: nvidia-nvjitlink-cu12 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from nvidia-cusolver-cu12==11.4.5.107->torch>=1.8->lm_eval==0.4.3) (12.4.127)
Requirement already satisfied: tokenizers<0.20,>=0.19 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from transformers>=4.1->lm_eval==0.4.3) (0.19.1)
Requirement already satisfied: attrs>=19.2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from jsonlines->lm_eval==0.4.3) (23.2.0)
Requirement already satisfied: setuptools>=38.3.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.3) (68.2.2)
Requirement already satisfied: DataProperty<2,>=1.0.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.3) (1.0.1)
Requirement already satisfied: mbstrdecoder<2,>=1.0.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.3) (1.1.3)
Requirement already satisfied: pathvalidate<4,>=2.3.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.3) (3.2.0)
Requirement already satisfied: tabledata<2,>=1.3.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.3) (1.3.3)
Requirement already satisfied: tcolorpy<1,>=0.0.5 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pytablewriter->lm_eval==0.4.3) (0.1.6)
Requirement already satisfied: typepy<2,>=1.3.2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from typepy[datetime]<2,>=1.3.2->pytablewriter->lm_eval==0.4.3) (1.3.2)
Requirement already satisfied: aiosignal>=1.1.2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.3) (1.3.1)
Requirement already satisfied: frozenlist>=1.1.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.3) (1.4.1)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.3) (6.0.5)
Requirement already satisfied: yarl<2.0,>=1.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from aiohttp->datasets>=2.16.0->lm_eval==0.4.3) (1.9.4)
Requirement already satisfied: chardet<6,>=3.0.4 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from mbstrdecoder<2,>=1.0.0->pytablewriter->lm_eval==0.4.3) (5.2.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.3) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.3) (3.7)
Requirement already satisfied: urllib3<3,>=1.21.1 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.3) (2.2.1)
Requirement already satisfied: certifi>=2017.4.17 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from requests>=2.19.0->datasets>=2.16.0->lm_eval==0.4.3) (2024.2.2)
Requirement already satisfied: python-dateutil<3.0.0,>=2.8.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from typepy[datetime]<2,>=1.3.2->pytablewriter->lm_eval==0.4.3) (2.9.0.post0)
Requirement already satisfied: pytz>=2018.9 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from typepy[datetime]<2,>=1.3.2->pytablewriter->lm_eval==0.4.3) (2024.1)
Requirement already satisfied: MarkupSafe>=2.0 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from jinja2->torch>=1.8->lm_eval==0.4.3) (2.1.5)
Requirement already satisfied: click in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from nltk->rouge-score>=0.0.4->lm_eval==0.4.3) (8.1.7)
Requirement already satisfied: tzdata>=2022.7 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from pandas->datasets>=2.16.0->lm_eval==0.4.3) (2024.1)
Requirement already satisfied: mpmath>=0.19 in /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages (from sympy->torch>=1.8->lm_eval==0.4.3) (1.3.0)
Using cached lm_eval-0.4.3-py3-none-any.whl (1.7 MB)
Installing collected packages: lm_eval
  Attempting uninstall: lm_eval
    Found existing installation: lm_eval 0.4.2
    Uninstalling lm_eval-0.4.2:
      Successfully uninstalled lm_eval-0.4.2
Successfully installed lm_eval-0.4.3
Expected artifacts for test run are:
small-ckpt-tune-03082024.pt
small-ckpt-meta-03082024.pt
small-ckpt-hf-03082024.pt
small-ckpt-tune-llama3-05052024.pt
tokenizer.model
tokenizer_llama3.model
File already exists locally: /tmp/test-artifacts/small-ckpt-tune-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-meta-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-hf-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-tune-llama3-05052024.pt
File already exists locally: /tmp/test-artifacts/tokenizer.model
File already exists locally: /tmp/test-artifacts/tokenizer_llama3.model
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.11.9, pytest-8.1.1, pluggy-1.5.0
rootdir: /home/jrcummings/projects/joe-torchtune
configfile: pyproject.toml
plugins: integration-0.2.3, mock-3.14.0, cov-5.0.0, hypothesis-6.103.1
collected 2 items

tests/recipes/test_eleuther_eval.py ..                                                                                                                                                                                                                                   [100%]

=============================================================================================================================== warnings summary ===============================================================================================================================
tests/recipes/test_eleuther_eval.py::TestEleutherEval::test_torchtune_checkpoint_eval_results
  /home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================================== 2 passed, 1 warning in 13.46s =========================================================================================================================

```

</details>
