### PR TITLE
Remove warning from Phi-3 tokenizer

### DIFF
--- a/torchtune/models/phi3/_model_builders.py
+++ b/torchtune/models/phi3/_model_builders.py
@@ -53,10 +53,6 @@ def phi3_mini_tokenizer(path: str) -> Phi3MiniSentencePieceTokenizer:
         it is also augmented with special tokens like <endoftext>
         and <assistant>.
 
-    Warning:
-        Microsoft currently opts to ignore system messages citing better performance.
-        See https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/discussions/51 for more details.
-
     Returns:
         Phi3MiniSentencePieceTokenizer: Instantiation of the SPM tokenizer.
     """


### PR DESCRIPTION
#### Context

We included this warning b/c the Microsoft team had previously just ignored system prompts for Phi-3. The have [remedied this](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/discussions/51#668323bf065caa5a21a2d1e0) so the warning is no longer needed.

#### Changelog

* Remove warning

#### Test

EYES