### PR TITLE
Vision cross attention mask transform

### DIFF
--- a/docs/source/api_ref_modules.rst
+++ b/docs/source/api_ref_modules.rst
@@ -93,3 +93,4 @@ Functions used for preprocessing images.
     transforms.resize_with_pad
     transforms.tile_crop
     transforms.find_supported_resolutions
+    transforms.VisionCrossAttentionMask

--- a/tests/torchtune/modules/transforms/test_transforms.py
+++ b/tests/torchtune/modules/transforms/test_transforms.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, List, Mapping, Protocol
+
+from torchtune.data import Message
+from torchtune.modules.tokenizers import ModelTokenizer
+from torchtune.modules.transforms import Pipeline, TokenizeMessages, CrossAttentionMask

--- a/torchtune/modules/transforms/__init__.py
+++ b/torchtune/modules/transforms/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtune.modules.transforms._transforms import (
+    Compose,
+    TokenizeMessages,
+    Transform,
+)
+
+__all__ = [
+    "Transform",
+    "Compose",
+    "TokenizeMessages",
+]

--- a/torchtune/modules/transforms/__init__.py
+++ b/torchtune/modules/transforms/__init__.py
@@ -4,11 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtune.modules.transforms._transforms import (
-    Compose,
-    TokenizeMessages,
-    Transform,
-)
+from torchtune.modules.transforms._transforms import Transform, VisionCrossAttentionMask
 from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (  # noqa
     find_supported_resolutions,
     get_canvas_best_fit,
@@ -20,10 +16,9 @@ from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop  # noq
 
 __all__ = [
     "Transform",
-    "Compose",
-    "TokenizeMessages",
     "get_canvas_best_fit",
     "resize_with_pad",
     "tile_crop",
     "find_supported_resolutions",
+    "VisionCrossAttentionMask",
 ]

--- a/torchtune/modules/transforms/_transforms.py
+++ b/torchtune/modules/transforms/_transforms.py
@@ -63,7 +63,7 @@ class VisionCrossAttentionMask(Transform):
         self.patches_per_tile = patch_grid_size**2
         self.image_token_id = image_token_id
 
-    def _get_image_attention_intervals(self, tokens: List[int]) -> List[List[int, int]]:
+    def _get_image_attention_intervals(self, tokens: List[int]) -> List[List[int]]:
         """
         Returns a list of lists of the form [start, end) where start is the index
         of the current image token and end is the index of the next image token, exclusive.
@@ -72,7 +72,7 @@ class VisionCrossAttentionMask(Transform):
             tokens (List[int]): List of token IDs in the text sequence
 
         Returns:
-            List[List[int, int]]: List of lists of the form [start, end) indicating
+            List[List[int]]: List of lists of the form [start, end) indicating
                 range of positions in text sequence that should attend to the image
 
         Example:

--- a/torchtune/modules/transforms/_transforms.py
+++ b/torchtune/modules/transforms/_transforms.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Mapping, Protocol
+from typing import Any, List, Mapping, Protocol
 
 import torch
 
@@ -12,12 +12,10 @@ import torch
 class Transform(Protocol):
     """
     Loose interface for all data and model transforms. Transforms operate at the
-    sample level and perform operations on a sample dict which is contained in
-    kwargs. Any fields that will be processed are unfolded with explicit keyword-arguments,
-    then the updated dict is returned.
+    sample level and perform operations on a sample dict, returning the updated dict.
     """
 
-    def __call__(self, **kwargs) -> Mapping[str, Any]:
+    def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
         pass
 
 
@@ -116,20 +114,20 @@ class VisionCrossAttentionMask(Transform):
             last_mask_end = vision_mask[1]
         return vision_masks
 
-    def __call__(self, sample: Dict[str, Any]) -> Dict[str, Any]:
+    def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
         """
         Generates the vision cross-attention mask for the given sample based on
         the image token locations interleaved in the text sequence.
 
         Args:
-            sample (Dict[str, Any]): Sample dict containing the following keys:
+            sample (Mapping[str, Any]): Sample dict containing the following keys:
                 - tokens (List[int]): List of token IDs in the text sequence. Number of
                     image token IDs in the sequence must match the number of images.
                 - images (List[torch.Tensor]): List of image Tensors post-tiling of shape
                     (n_tiles, c, h, w) each.
 
         Returns:
-            Dict[str, Any]: updated sample with the following keys:
+            Mapping[str, Any]: updated sample with the following keys:
                 - encoder_mask (List[torch.Tensor]): list of masks with shape (text_seq_len, image_seq_len),
                     where length of list == number of images in sample
                 - tokens (List[int]): original tokens

--- a/torchtune/modules/transforms/_transforms.py
+++ b/torchtune/modules/transforms/_transforms.py
@@ -27,8 +27,9 @@ class VisionCrossAttentionMask(Transform):
     participate in cross-attention with an image token will show True in the mask
     and follow the interleaved structure laid out in Fig. 7 of the Flamingo paper
     (https://arxiv.org/pdf/2204.14198):
-        1) Text tokens immediately following the image token up until the next image token
-        2) Consecutive image tokens attend to subsequent text tokens
+    
+        (1) Text tokens immediately following the image token up until the next image token
+        (2) Consecutive image tokens attend to subsequent text tokens
 
     ::
 

--- a/torchtune/modules/transforms/_transforms.py
+++ b/torchtune/modules/transforms/_transforms.py
@@ -27,7 +27,7 @@ class VisionCrossAttentionMask(Transform):
     participate in cross-attention with an image token will show True in the mask
     and follow the interleaved structure laid out in Fig. 7 of the Flamingo paper
     (https://arxiv.org/pdf/2204.14198):
-    
+
         (1) Text tokens immediately following the image token up until the next image token
         (2) Consecutive image tokens attend to subsequent text tokens
 

--- a/torchtune/modules/transforms/_transforms.py
+++ b/torchtune/modules/transforms/_transforms.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, List, Mapping, Protocol
+
+from torchtune.data import Message
+from torchtune.modules.tokenizers import ModelTokenizer
+
+
+class Transform(Protocol):
+    """
+    Loose interface for all data and model transforms. Transforms operate at the
+    sample level and perform operations on a sample dict which is contained in
+    kwargs. Any fields that will be processed are unfolded with explicit keyword-arguments,
+    then the updated dict is returned.
+    """
+
+    def __call__(self, **kwargs) -> Mapping[str, Any]:
+        pass
+
+
+class Compose(Transform):
+    """
+    Compose multiple transforms together, inspired by torchvision's ``Compose`` API
+
+    Args:
+        transforms (List[Transform]): List of transforms to compose together in sequential order.
+    """
+
+    def __init__(self, transforms: List[Transform]) -> None:
+        self.transforms = transforms
+
+    def __call__(self, **kwargs) -> Mapping[str, Any]:
+        for transform in self.transforms:
+            kwargs = transform(**kwargs)
+        return kwargs
+
+
+class TokenizeMessages(Transform):
+    """
+    Apply the ``tokenize_messages`` method from a given
+    :class:`~torchtune.modules.tokenizers.ModelTokenizer` on the ``messages`` field of the sample.
+
+    Args:
+        tokenizer (ModelTokenizer): Tokenizer used by the model that implements
+            the ``tokenize_messages`` method.
+    """
+
+    def __init__(self, tokenizer: ModelTokenizer, max_seq_len: int) -> None:
+        self.tokenizer = tokenizer
+        self.max_seq_len = max_seq_len
+
+    def __call__(self, *, messages: List[Message], **kwargs) -> Mapping[str, Any]:
+        tokens, mask = self.tokenizer.tokenize_messages(
+            messages, max_seq_len=self.max_seq_len
+        )
+        kwargs.update({"tokens": tokens, "mask": mask})
+        return kwargs


### PR DESCRIPTION
## Context
Multimodal models that use cross-attention layers in the text LLM backbone to attend to outputs of a vision encoder on the images require a cross-attention mask to ensure the correct text tokens attend to the right images. For multiple, interleaved images in a single sample, we follow the approach in Flamingo (Fig. 7 of https://arxiv.org/pdf/2204.14198) where text tokens after an image attend to that particular image (more details in docstrings). To create this mask, this PR adds a transform class that takes a sample dictionary (i.e., during data preprocessing in one of torchtune's dataset classes), computes this cross-attention mask and adds it to the dictionary.

Handling variable number of tiles and number of images across samples will be done in the batch collator in a follow-up PR. For now, we return the masks as a list of tensors, one mask per image, which can have varied n_tiles.

## Changelog
- Add base Transform interface
- Add `VisionCrossAttentionMask`
- Add unit tests for `VisionCrossAttentionMask`

## Test plan
`pytest tests/torchtune/modules/transforms/test_transforms.py`

## Docs
<img width="882" alt="image" src="https://github.com/pytorch/torchtune/assets/33648637/8552fdd1-2287-4d54-ab36-650e1487b60c">
