### PR TITLE
[debug] compile FSDP2 recipe

### DIFF
--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -355,6 +355,9 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # Ensure no params and buffers are on meta device
         utils.validate_no_params_on_meta_device(model)
 
+        backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
+        model.compile(backend=backend)
+
         if self._is_rank_zero:
             log.info(
                 f"Instantiating model and loading checkpoint took {time.perf_counter() - init_start:.2f} secs"


### PR DESCRIPTION
Debugging issues when compiling our FSDP2 recipe with QLoRA.

Running 

```
tune run --nnodes 1 --nproc_per_node 2 lora_finetune_fsdp2 --config llama2/7B_qlora
```

errors out with [this stack trace](https://gist.github.com/ebsmothers/d912c068b49f15535b09927a53bf01b1) complaining that `'NF4Tensor' object has no attribute 'block_size'`.
