### PR TITLE
Experimental Flag for tune ls

### DIFF
--- a/docs/source/tune_cli.rst
+++ b/docs/source/tune_cli.rst
@@ -105,7 +105,7 @@ with matching names. By default we ignore safetensor files, but if you want to i
 List built-in recipes and configs
 ---------------------------------
 
-The ``tune ls`` command lists out all the built-in recipes and configs within torchtune.
+The ``tune ls`` command lists out all the built-in recipes and configs within torchtune. Include the `--experimental` flag to view experimental new recipes as well.
 
 
 .. code-block:: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ where = [""]
 include = ["torchtune*", "recipes*"]
 
 [tool.setuptools.package-data]
-recipes = ["configs/*.yaml", "configs/*/*.yaml"]
+recipes = ["configs/*.yaml", "configs/*/*.yaml", "configs/*/*/*.yaml"]
 
 
 # ---- Tooling specifications ---- #

--- a/tests/torchtune/_cli/test_ls.py
+++ b/tests/torchtune/_cli/test_ls.py
@@ -23,6 +23,20 @@ class TestTuneListCommand:
         captured = capsys.readouterr()
         output = captured.out.rstrip("\n")
 
+        for recipe in get_all_recipes(include_experimental=False):
+            assert recipe.name in output
+            for config in recipe.configs:
+                assert config.name in output
+
+    def test_ls_lists_all_recipes_and_configs_experimental(self, capsys, monkeypatch):
+        testargs = "tune ls --experimental".split()
+
+        monkeypatch.setattr(sys, "argv", testargs)
+        runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        captured = capsys.readouterr()
+        output = captured.out.rstrip("\n")
+
         for recipe in get_all_recipes():
             assert recipe.name in output
             for config in recipe.configs:

--- a/torchtune/_cli/ls.py
+++ b/torchtune/_cli/ls.py
@@ -40,6 +40,11 @@ class List(Subcommand):
             ),
             formatter_class=argparse.RawTextHelpFormatter,
         )
+        self._parser.add_argument(
+            "--experimental",
+            action="store_true",
+            help="Includes experimental recipes and configs in output",
+        )
         self._parser.set_defaults(func=self._ls_cmd)
 
     def _ls_cmd(self, args: argparse.Namespace) -> None:
@@ -49,7 +54,7 @@ class List(Subcommand):
         print(header)
 
         # Print recipe/config pairs
-        for recipe in get_all_recipes():
+        for recipe in get_all_recipes(include_experimental=args.experimental):
             # If there are no configs for a recipe, print a blank config
             recipe_str = recipe.name
             if len(recipe.configs) == 0:

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -20,6 +20,7 @@ class Recipe:
     file_path: str
     configs: List[Config]
     supports_distributed: bool
+    experimental: bool = False
 
 
 _ALL_RECIPES = [
@@ -187,6 +188,7 @@ _ALL_RECIPES = [
             ),
         ],
         supports_distributed=True,
+        experimental=True,
     ),
     Recipe(
         name="generate",
@@ -224,6 +226,9 @@ _ALL_RECIPES = [
 ]
 
 
-def get_all_recipes():
+def get_all_recipes(include_experimental: bool = True) -> List[Recipe]:
     """List of recipes available from the CLI."""
-    return _ALL_RECIPES
+    if include_experimental:
+        return _ALL_RECIPES
+    else:
+        return [r for r in _ALL_RECIPES if not r.experimental]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Currently we have a number of recipes under dev that we would like to make accessible to users but still clearly signal to users that these are not as well tested and may have special dependencies. The current behavior is to list these all in "tune ls" which isn't ideal as it doesn't disclose the experimental nature of these recipes. One option would be to exclude them entirely from "tune ls" but then it makes it very difficult to use them outside of github.

The proposal here is to add an "experimental" flag to tune ls that displays the extra recipes. All of the recipes are always available in tune run, but if you want to view them in ls you must pass the extra flag. This is accomplished by adding an extra parameter to the recipe dataclass in _recipe_registry that allows some recipes to be marked as experimental. Then get_all_recipes can accept an argument "include_experimental". This is True for "tune run" and False by default for "tune ls".

#### Changelog
- include_experimental added to get_all_recipes
- experimental added to recipe dataclass
- experimental flag added to tune ls
- Updated unit test and cli rst
- Fixed bug where dev recipes weren't included in project package

#### Test plan
Ran tests and test tune ls in terminal for expected outputs

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
