### PR TITLE
Fix Gemma 7B checkpoint save

### DIFF
--- a/torchtune/models/convert_weights.py
+++ b/torchtune/models/convert_weights.py
@@ -249,6 +249,7 @@ def tune_to_peft_adapter_weights(
     num_heads: int = 32,
     num_kv_heads: int = 32,
     dim: int = 4096,
+    head_dim: int = None,
 ):
     converted_state_dict = {}
     full_mapping = {}
@@ -266,7 +267,8 @@ def tune_to_peft_adapter_weights(
             }
         )
 
-    head_dim = dim // num_heads
+    if head_dim is None:
+        head_dim = dim // num_heads
 
     def _permute_lora_matrix(t, n_heads):
         rank = t.shape[-1]

--- a/torchtune/utils/_checkpointing/_checkpointer.py
+++ b/torchtune/utils/_checkpointing/_checkpointer.py
@@ -537,6 +537,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     num_heads=self._config["num_attention_heads"],
                     num_kv_heads=self._config["num_key_value_heads"],
                     dim=self._config["hidden_size"],
+                    head_dim=self._config.get("head_dim", None),
                 )
                 peft_output_path = Path.joinpath(
                     self._output_dir, "adapter_model"


### PR DESCRIPTION
Fixes #1122. See point (2) [here](https://github.com/pytorch/torchtune/issues/1122#issuecomment-2224695316).

Test:

```
tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config \
gemma/7B_lora max_steps_per_epoch=5 epochs=1
...
INFO:torchtune.utils.logging:Model checkpoint of size 5.00 GB saved to /tmp/gemma-7b/hf_model_0001_0.pt
INFO:torchtune.utils.logging:Model checkpoint of size 4.98 GB saved to /tmp/gemma-7b/hf_model_0002_0.pt
INFO:torchtune.utils.logging:Model checkpoint of size 4.98 GB saved to /tmp/gemma-7b/hf_model_0003_0.pt
INFO:torchtune.utils.logging:Model checkpoint of size 2.11 GB saved to /tmp/gemma-7b/hf_model_0004_0.pt
INFO:torchtune.utils.logging:Adapter checkpoint of size 0.37 GB saved to /tmp/gemma-7b/adapter_0.pt
INFO:torchtune.utils.logging:Adapter checkpoint of size 0.37 GB saved to /tmp/gemma-7b/adapter_model.bin
INFO:torchtune.utils.logging:Adapter checkpoint of size 0.00 GB saved to /tmp/gemma-7b/adapter_config.json
```


