### PR TITLE
Fix incorrect date check for ao nightlies

### DIFF
--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
+  pull_request: # TODO: remove before landing (just for testing)
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
-  pull_request: # TODO: remove before landing (just for testing)
   workflow_dispatch:
 
 concurrency:

--- a/torchtune/modules/low_precision/_utils.py
+++ b/torchtune/modules/low_precision/_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
 from typing import Optional, Tuple
 
@@ -14,6 +15,18 @@ import torchao
 
 def _is_fbcode():
     return not hasattr(torch.version, "git_version")
+
+
+def _nightly_version_ge(ao_version_str: str, date: str) -> bool:
+    """
+    Compare a torchao nightly version to a date of the form
+    %Y-%m-%d.
+
+    Returns True if the nightly version is greater than or equal to
+        the date, False otherwise
+    """
+    ao_datetime = datetime.strptime(ao_version_str.split("+")[0], "%Y.%m.%d")
+    return ao_datetime >= datetime.strptime(date, "%Y-%m-%d")
 
 
 def _get_torchao_version() -> Tuple[Optional[str], Optional[bool]]:

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -13,10 +13,13 @@ from torchao.quantization.quant_api import (
     Quantizer,
 )
 
-from torchtune.modules.low_precision._utils import _get_torchao_version
+from torchtune.modules.low_precision._utils import (
+    _get_torchao_version,
+    _nightly_version_ge,
+)
 
 ao_version, is_nightly = _get_torchao_version()
-if is_nightly and (ao_version >= "2024.7.3"):
+if is_nightly and _nightly_version_ge(ao_version, "2024-07-03"):
     from torchao.quantization.quant_api import quantize_ as quantize
 else:
     from torchao.quantization.quant_api import quantize


### PR DESCRIPTION
Our nightly recipe test CI job is failing because we aren't parsing the dates in ao nightlies correctly. We gate a feature on the 7/3 nightly, which is represented as "2024.7.3+cu121" (e.g.). But "2024.7.3+cu121" >= e.g. "2024.7.13+cu121", so we can't compare the raw strings.

This PR adds a util to convert everything to datetime objects so that we're comparing across a standardized format.

Test plan: added PR trigger to nightly recipe test, confirmed CI was green: 

<img width="1712" alt="Screenshot 2024-07-12 at 7 43 00 PM" src="https://github.com/user-attachments/assets/d703e53c-e6b1-4669-b909-0d403af057d4">
