### PR TITLE
[EZ] Fix comment formatting in code-llama configs

### DIFF
--- a/recipes/configs/code_llama2/7B_full_low_memory.yaml
+++ b/recipes/configs/code_llama2/7B_full_low_memory.yaml
@@ -4,6 +4,7 @@
 # This config assumes that you've run the following command before launching
 # this run:
 #     tune download meta-llama/CodeLlama-7b-hf --output-dir /tmp/CodeLlama-7b-hf
+#
 # The default config uses an optimizer from bitsandbytes. If you do not have it installed,
 # you can install it with
 #   pip install bitsandbytes

--- a/recipes/configs/code_llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/code_llama2/7B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#     tune download meta-llama/CodeLlama-7b-hf --output-dir /tmp/CodeLlama-7b-hf
+#   tune download meta-llama/CodeLlama-7b-hf --output-dir /tmp/CodeLlama-7b-hf
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config code_llama2/7B_lora_single_device

--- a/recipes/configs/code_llama2/7B_qlora_single_device.yaml
+++ b/recipes/configs/code_llama2/7B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#     tune download meta-llama/CodeLlama-7b-hf --output-dir /tmp/CodeLlama-7b-hf
+#   tune download meta-llama/CodeLlama-7b-hf --output-dir /tmp/CodeLlama-7b-hf
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config code_llama2/7B_qlora_single_device


### PR DESCRIPTION
Mainly nits for making formatting for comments on top of configs for code-llama consistent with the rest of the repo