### PR TITLE
DPO Loss refactor

### DIFF
--- a/docs/source/api_ref_modules.rst
+++ b/docs/source/api_ref_modules.rst
@@ -81,6 +81,8 @@ Loss
    :nosignatures:
 
    loss.DPOLoss
+   loss.RSOLoss
+   loss.IPOLoss
 
 
 Vision Transforms

--- a/recipes/configs/llama2/7B_lora_dpo.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo.yaml
@@ -65,7 +65,6 @@ loss:
   _component_: torchtune.modules.loss.DPOLoss
   beta: 0.1
   label_smoothing: 0
-  loss_type: sigmoid
 
 # Training
 epochs: 1

--- a/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
@@ -64,7 +64,6 @@ loss:
   _component_: torchtune.modules.loss.DPOLoss
   beta: 0.1
   label_smoothing: 0
-  loss_type: sigmoid
 
 # Training
 epochs: 1

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -93,6 +93,12 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
 
         - Logging. Terminal, Disk, WandB and TensorBoard are all supported.
 
+    The following losses are supported in this recipe:
+        - :class:`~torchtune.modules.loss.DPOLoss`: Direct Preference Optimization (DPO).
+        - :class:`~torchtune.modules.loss.RSOPLoss`: Rejection Sampling Optimization (RSO).
+        - :class:`~torchtune.modules.loss.IPO`: Identity Preference Optimization (IPO).
+
+
     For a full list of example configs for this recipe, run ``tune ls`` on the command line. Each config
     has example commands for how to kick-off training.
 
@@ -356,11 +362,11 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             sync_module_states=True,
             # Initialize empty modules on all non-zero ranks
             param_init_fn=(
-                lambda module: module.to_empty(
-                    device=torch.device("cuda"), recurse=False
+                lambda module: (
+                    module.to_empty(device=torch.device("cuda"), recurse=False)
+                    if not self._is_rank_zero
+                    else None
                 )
-                if not self._is_rank_zero
-                else None
             ),
         )
 

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -48,6 +48,12 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             with the base model weights. Note that intra-epoch resumption is not supported.
         - Logging to terminal, WandB, or TensorBoard.
 
+
+    The following losses are supported in this recipe:
+        - :class:`~torchtune.modules.loss.DPOLoss`: Direct Preference Optimization (DPO).
+        - :class:`~torchtune.modules.loss.RSOPLoss`: Rejection Sampling Optimization (RSO).
+        - :class:`~torchtune.modules.loss.IPO`: Identity Preference Optimization (IPO).
+
     Assumptions:
         - Checkpoints are ONLY saved at epoch boundaries. In case of failure, work done
             in ongoing epoch is lost.

--- a/tests/torchtune/modules/loss/test_dpo_loss.py
+++ b/tests/torchtune/modules/loss/test_dpo_loss.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from torchtune.modules.loss import DPOLoss, IPOLoss, RSOLoss
+
+
+@pytest.fixture(autouse=True)
+def random():
+    torch.manual_seed(16)
+
+
+class TestDPOLosses:
+    @pytest.fixture
+    def dpo_loss(self):
+        return DPOLoss(
+            beta=0.1,
+            label_smoothing=0.0,
+        )
+
+    @pytest.fixture
+    def rso_loss(self):
+        return RSOLoss(
+            gamma=0.1,
+        )
+
+    @pytest.fixture
+    def ipo_loss(self):
+        return IPOLoss(
+            tau=0.1,
+        )
+
+    @pytest.fixture
+    def loss_inputs(self):
+        """
+        kind-of-random inputs for testing the math out (below).
+        """
+        policy_chosen_logprobs = torch.tensor([-0.5, -10.0, -1.0])
+        policy_rejected_logprobs = torch.tensor([-0.1, -30.0, -21.0])
+
+        ref_chosen_logprobs = torch.tensor([-0.5, -10.1, -0.1])
+        ref_rejected_logprobs = torch.tensor([-0.1, -20.1, -0.1])
+
+        return (
+            policy_chosen_logprobs,
+            policy_rejected_logprobs,
+            ref_chosen_logprobs,
+            ref_rejected_logprobs,
+        )
+
+    def test_dpo_loss(self, dpo_loss, loss_inputs):
+        """
+        here's the maths (see `loss_inputs`):
+        ratios = torch.tensor([-0.4, 20.0, 20.0])
+        ref_ratios = torch.tensor([-0.4, 10, 0.0])
+
+            logits is ratios - ref_ratios
+
+        logits = torch.tensor([0.0, 10.0, 20.0])
+        scaled_logits = torch.tensor([0.0, 1.0, 2.0])
+
+        since label_smoothing is zero, loss is NLL with temperature scaled logits
+            logsigmoid is log(1/1+exp(-scaled_logits))
+            exp(-scaled_logits) is [1, 1/e, 1/e^2]
+            logsigmoid is -log([1 / 2, 1 / (1 + 1/e), 1 / (1 + 1/e^2)])
+
+        expected_losses = -torch.tensor(
+            [1 / 2, 1 / (1 + torch.exp(torch.tensor(-1.0))), 1 / (1 + torch.exp(torch.tensor(-2.0)))]
+        ).log()
+        expected_losses = -expected_logsigmoids
+        """
+        exp_scaled_logits = torch.exp(torch.tensor([0.0, -1.0, -2.0]))
+        expected_losses = -(1 / (1 + exp_scaled_logits)).log()
+        losses, *_ = dpo_loss(*loss_inputs)
+
+        torch.testing.assert_close(losses, expected_losses, atol=1e-4, rtol=1e-5)
+
+    def test_rso_loss(self, rso_loss, loss_inputs):
+        """
+        # maths:
+        ratios = torch.tensor([-0.4, 20.0, 20.0])
+        ref_ratios = torch.tensor([-0.4, 10, 0.0])
+
+        # logits is ratios - ref_ratios
+
+        logits = torch.tensor([0.0, 10.0, 20.0])
+        scaled_logits = torch.tensor([0.0, 1.0, 2.0])
+
+        # hinge loss doesn't use label smoothing
+        # loss = relu(1 - scaled_logits) = max(0, 1 - scaled_logits)
+        expected_losses = torch.tensor([1.0, 0.0, 0.0])
+        """
+
+        expected_losses = torch.tensor([1.0, 0.0, 0.0])
+
+        losses, *_ = rso_loss(*loss_inputs)
+
+        torch.testing.assert_close(losses, expected_losses, atol=1e-4, rtol=1e-5)
+
+    def test_ipo_loss(self, ipo_loss, loss_inputs):
+        """
+        # maths:
+        ratios = torch.tensor([-0.4, 20.0, 20.0])
+        ref_ratios = torch.tensor([-0.4, 10, 0.0])
+
+        # logits is ratios - ref_ratios
+
+        logits = torch.tensor([0.0, 10.0, 20.0])
+
+        # ipo loss is (logits - 1 / (2 * tau)) ** 2
+        = [-5, 5, 15] ** 2
+        = [25, 25, 225]
+        """
+        expected_losses = torch.tensor([25.0, 25.0, 225.0])
+        losses, *_ = ipo_loss(*loss_inputs)
+        torch.testing.assert_close(losses, expected_losses, atol=1e-4, rtol=1e-5)

--- a/torchtune/modules/loss/__init__.py
+++ b/torchtune/modules/loss/__init__.py
@@ -4,6 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .dpo import DPOLoss
+from .dpo import DPOLoss, IPOLoss, RSOLoss
 
-__all__ = ["DPOLoss"]
+__all__ = ["DPOLoss", "RSOLoss", "IPOLoss"]

--- a/torchtune/modules/loss/dpo.py
+++ b/torchtune/modules/loss/dpo.py
@@ -14,6 +14,11 @@ import torch.nn.functional as F
 class DPOLoss(nn.Module):
     """
     Direct Preference Optimization (DPO) Loss module: https://arxiv.org/abs/2305.18290.
+    Simply stated from the paper:
+
+        Intuitively, the DPO update increases the relative log probability of preferred to dispreferred responses,
+        but it incorporates a dynamic, per-example importance weight that prevents
+        the model degeneration that we find occurs with a naive probability ratio objective.
 
     Based on the implementation in HF's TRL library:
     https://github.com/huggingface/trl/blob/5d1deb1445828cfd0e947cb3a7925b1c03a283fc/trl/trainer/dpo_trainer.py#L844
@@ -21,19 +26,16 @@ class DPOLoss(nn.Module):
     Args:
         beta (float): Temperature parameter for the DPO loss, typically in the range of 0.1 to 0.5. Default is 0.1.
         label_smoothing (float): Parameter encoding uncertainty about the labels. Default is 0.
-        loss_type (str): Type of loss function to be used. Should be one of ['sigmoid', 'hinge', 'ipo', 'kto_pair'].
     """
 
     def __init__(
         self,
         beta: float = 0.1,
         label_smoothing: float = 0.0,
-        loss_type: str = "sigmoid",
     ):
-        super(DPOLoss, self).__init__()
+        super().__init__()
         self.beta = beta
         self.label_smoothing = label_smoothing
-        self.loss_type = loss_type
 
     def forward(
         self,
@@ -61,8 +63,6 @@ class DPOLoss(nn.Module):
                 - chosen_rewards: Rewards for the chosen responses.
                 - rejected_rewards: Rewards for the rejected responses.
 
-        Raises:
-            ValueError: If an unknown loss type is specified.
         """
         pi_logratios = policy_chosen_logps - policy_rejected_logps
         ref_logratios = reference_chosen_logps - reference_rejected_logps
@@ -72,43 +72,162 @@ class DPOLoss(nn.Module):
         # The beta is a temperature parameter for the DPO loss, typically something in the range of 0.1 to 0.5.
         # We ignore the reference model as beta -> 0. The label_smoothing parameter encodes our uncertainty about the labels and
         # calculates a conservative DPO loss.
-        if self.loss_type == "sigmoid":
-            losses = (
-                -F.logsigmoid(self.beta * logits) * (1 - self.label_smoothing)
-                - F.logsigmoid(-self.beta * logits) * self.label_smoothing
-            )
-        elif self.loss_type == "hinge":
-            losses = torch.relu(1 - self.beta * logits)
-        elif self.loss_type == "ipo":
-            losses = (logits - 1 / (2 * self.beta)) ** 2
-        elif self.loss_type == "kto_pair":
-            chosen_kl = (
-                (policy_chosen_logps - reference_chosen_logps).mean().clamp(min=0)
-            )
-            rejected_kl = (
-                (policy_rejected_logps - reference_rejected_logps).mean().clamp(min=0)
-            )
-
-            chosen_logratios = policy_chosen_logps - reference_chosen_logps
-            rejected_logratios = policy_rejected_logps - reference_rejected_logps
-
-            losses = torch.cat(
-                (
-                    1 - F.sigmoid(self.beta * (chosen_logratios - rejected_kl)),
-                    1 - F.sigmoid(self.beta * (chosen_kl - rejected_logratios)),
-                ),
-                0,
-            )
-        else:
-            raise ValueError(
-                f"Unknown loss type: {self.loss_type}. Should be one of ['sigmoid', 'hinge', 'ipo', 'kto_pair']"
-            )
+        losses = (
+            -F.logsigmoid(self.beta * logits) * (1 - self.label_smoothing)
+            - F.logsigmoid(-self.beta * logits) * self.label_smoothing
+        )
 
         chosen_rewards = (
             self.beta * (policy_chosen_logps - reference_chosen_logps).detach()
         )
         rejected_rewards = (
             self.beta * (policy_rejected_logps - reference_rejected_logps).detach()
+        )
+
+        return losses, chosen_rewards, rejected_rewards
+
+
+class RSOLoss(nn.Module):
+    """
+    Statistical Rejection Sampling Optimization (RSO) or "hinge" loss module: https://arxiv.org/abs/2309.06657.
+    Intuition from the paper:
+
+        DPO is a logistic regression on human preference data, and SLiC (https://arxiv.org/abs/2305.10425) is almost
+        equivalent to a support vector machine (SVM) with hinge loss. [RSO] improve[s] SLiC as the SVM counter part of DPO.
+
+    Based on the implementation in HF's TRL library:
+    https://github.com/huggingface/trl/blob/4dce042a3863db1d375358e8c8092b874b02934b/trl/trainer/dpo_trainer.py#L1141
+
+    Args:
+        gamma (float): Equivalent temperature parameter (from DPO) for the RSO loss.
+    """
+
+    def __init__(
+        self,
+        gamma: float = 0.1,
+    ):
+        super().__init__()
+        self.gamma = gamma
+
+    def forward(
+        self,
+        policy_chosen_logps: torch.Tensor,
+        policy_rejected_logps: torch.Tensor,
+        reference_chosen_logps: torch.Tensor,
+        reference_rejected_logps: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Compute the RSO loss for a batch of policy and reference model log probabilities.
+
+        Args:
+            policy_chosen_logps (torch.Tensor): Log probabilities of the policy model
+                for the chosen responses. Shape: (batch_size)
+            policy_rejected_logps (torch.Tensor): Log probabilities of the policy model
+                for the rejected responses. Shape: (batch_size)
+            reference_chosen_logps (torch.Tensor): Log probabilities of the reference model
+                for the chosen responses. Shape: (batch_size)
+            reference_rejected_logps (torch.Tensor): Log probabilities of the reference model
+                for the rejected responses. Shape: (batch_size)
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: A tuple of three tensors:
+                - losses: The RSO loss for each example in the batch.
+                - chosen_rewards: Rewards for the chosen responses.
+                - rejected_rewards: Rewards for the rejected responses.
+
+        """
+        pi_logratios = policy_chosen_logps - policy_rejected_logps
+        ref_logratios = reference_chosen_logps - reference_rejected_logps
+
+        logits = pi_logratios - ref_logratios
+
+        losses = torch.relu(1 - self.gamma * logits)
+
+        chosen_rewards = (
+            self.gamma * (policy_chosen_logps - reference_chosen_logps).detach()
+        )
+        rejected_rewards = (
+            self.gamma * (policy_rejected_logps - reference_rejected_logps).detach()
+        )
+
+        return losses, chosen_rewards, rejected_rewards
+
+
+class IPOLoss(nn.Module):
+    """
+    Identity Preference Optimisation (IPO) Loss module: https://arxiv.org/abs/2310.12036.
+    Intuition from the paper:
+
+        (Given a policy pi and reference policy, pi_ref)
+
+        IPO learns from preferences dataset simply by regressing the gap between log-likelihood ratios
+
+        log(pi(chosen)/pi(rejected)) and log(pi_ref(chosen)/pi_ref(rejected))
+
+        to 1/(2*tau), where tau is the temperature parameter. [T]he weaker the regularisation becomes, the
+        higher would be the log-likelihood ratio of chosen to rejected logprobs. In other words IPO, unlike DPO,
+        always regularizes its solution towards pi_ref by controlling the gap between the log-likelihood ratios
+
+        log(pi(chosen)/pi(rejected)) and log(pi_ref(chosen)/pi_ref(rejected))
+
+        thus avoiding the over-fitting to the preference dataset.
+
+    Based on the implementation in HF's TRL library:
+    https://github.com/huggingface/trl/blob/4dce042a3863db1d375358e8c8092b874b02934b/trl/trainer/dpo_trainer.py#L1143
+
+    Args:
+        tau (float): Equivalent temperature scaling parameter (from DPO) for the IPO loss. From the TRL documentation:
+
+            the [tau] parameter is the reciprocal of the gap between the log-likelihood ratios of the
+            chosen vs the rejected completion pair and thus the smaller the tau the larger this gap is.
+    """
+
+    def __init__(
+        self,
+        tau: float = 0.1,
+    ):
+        super().__init__()
+        self.tau = tau
+
+    def forward(
+        self,
+        policy_chosen_logps: torch.Tensor,
+        policy_rejected_logps: torch.Tensor,
+        reference_chosen_logps: torch.Tensor,
+        reference_rejected_logps: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Compute the DPO loss for a batch of policy and reference model log probabilities.
+
+        Args:
+            policy_chosen_logps (torch.Tensor): Log probabilities of the policy model
+                for the chosen responses. Shape: (batch_size)
+            policy_rejected_logps (torch.Tensor): Log probabilities of the policy model
+                for the rejected responses. Shape: (batch_size)
+            reference_chosen_logps (torch.Tensor): Log probabilities of the reference model
+                for the chosen responses. Shape: (batch_size)
+            reference_rejected_logps (torch.Tensor): Log probabilities of the reference model
+                for the rejected responses. Shape: (batch_size)
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: A tuple of three tensors:
+                - losses: The DPO loss for each example in the batch.
+                - chosen_rewards: Rewards for the chosen responses.
+                - rejected_rewards: Rewards for the rejected responses.
+
+        """
+        pi_logratios = policy_chosen_logps - policy_rejected_logps
+        ref_logratios = reference_chosen_logps - reference_rejected_logps
+
+        logits = pi_logratios - ref_logratios
+
+        losses = (logits - 1 / (2 * self.tau)) ** 2
+
+        chosen_rewards = (
+            self.tau * (policy_chosen_logps - reference_chosen_logps).detach()
+        )
+        rejected_rewards = (
+            self.tau * (policy_rejected_logps - reference_rejected_logps).detach()
         )
 
         return losses, chosen_rewards, rejected_rewards

--- a/torchtune/modules/loss/dpo.py
+++ b/torchtune/modules/loss/dpo.py
@@ -23,6 +23,13 @@ class DPOLoss(nn.Module):
     Based on the implementation in HF's TRL library:
     https://github.com/huggingface/trl/blob/5d1deb1445828cfd0e947cb3a7925b1c03a283fc/trl/trainer/dpo_trainer.py#L844
 
+    DPO retains similarities to PPO (https://arxiv.org/abs/2009.01325), where it optimizes a policy
+    (language) model to align with human preferences, and regularizes the loss function using a baseline
+    reference (the frozen, initial language model) to prevent over-fitting to the preference dataset.
+    It differs from PPO by optimizing the policy model directly using labelled preference data, rather
+    than using an additional reward model to provide feedback.
+    This significantly simplifies training and reduces compute overhead.
+
     Args:
         beta (float): Temperature parameter for the DPO loss, typically in the range of 0.1 to 0.5. Default is 0.1.
         label_smoothing (float): Parameter encoding uncertainty about the labels. Default is 0.
@@ -174,6 +181,7 @@ class IPOLoss(nn.Module):
 
     Based on the implementation in HF's TRL library:
     https://github.com/huggingface/trl/blob/4dce042a3863db1d375358e8c8092b874b02934b/trl/trainer/dpo_trainer.py#L1143
+
 
     Args:
         tau (float): Equivalent temperature scaling parameter (from DPO) for the IPO loss. From the TRL documentation:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [x] refactor

I was initially looking at this refactor to add SimPO into the DPO recipe, but got slightly carried away. I think we might need a separate SimPO recipe down the line anyway, since DPO-style losses use a reference model, whereas SimPO doesn't.

This PR refactors the DPO loss module into separate classes for each of the loss types it supported. Each separate loss is now documented with a reference to its corresponding paper, a little intuition about how it works, and comes with a corresponding unit test.


#### Test plan

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
