### PR TITLE
Expose `split` in dataset builders

### DIFF
--- a/torchtune/datasets/_alpaca.py
+++ b/torchtune/datasets/_alpaca.py
@@ -18,6 +18,7 @@ def alpaca_dataset(
     train_on_input: bool = True,
     max_seq_len: int = 512,
     packed: bool = False,
+    split: str = "train",
 ) -> InstructDataset:
     """
     Support for family of Alpaca-style datasets from Hugging Face Datasets using
@@ -40,7 +41,8 @@ def alpaca_dataset(
             Default is 512, but we recommend setting this to the highest you can fit in memory and
             is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
-
+        split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
+            of a given split, e.g. ``split="train[:10%]"``. Default is "train".
     Returns:
         InstructDataset: dataset configured with source data and template
 
@@ -59,7 +61,7 @@ def alpaca_dataset(
         train_on_input=train_on_input,
         max_seq_len=max_seq_len,
         packed=packed,
-        split="train",
+        split=split,
     )
 
 

--- a/torchtune/datasets/_chat.py
+++ b/torchtune/datasets/_chat.py
@@ -30,9 +30,6 @@ class ChatDataset(Dataset):
     The general flow from loading a sample to tokenized prompt is:
     load sample -> apply transform -> foreach turn{format into template -> tokenize}
 
-    If the column/key names differ from the expected names in the :class:`~torchtune.data.ChatFormat`,
-    then the ``column_map`` argument can be used to provide this mapping.
-
     Use ``convert_to_messages`` to prepare your dataset into the Llama2 chat format
     and roles::
 
@@ -56,9 +53,7 @@ class ChatDataset(Dataset):
         chat_format (Optional[ChatFormat]): template used to format the chat. This is used to add structured text around the actual
             messages, such as the [INST] tags in Llama2 and in Mistral. The extra text will still get tokenized as normal text, not
             as special tokens. In models like Llama3 where the tokenizer adds tags as special tokens, ``chat_format`` is not needed,
-            unless you want to structure messages in a particular way for inference. If the placeholder variable names in the
-            template do not match the column/key names in the dataset, use ``column_map`` to map them. For a list of all possible
-            chat formats, check out :ref:`chat_formats`. Default: None.
+            unless you want to structure messages in a particular way for inference.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.

--- a/torchtune/datasets/_cnn_dailymail.py
+++ b/torchtune/datasets/_cnn_dailymail.py
@@ -15,6 +15,7 @@ def cnn_dailymail_articles_dataset(
     tokenizer: ModelTokenizer,
     source: str = "ccdv/cnn_dailymail",
     max_seq_len: Optional[int] = None,
+    split: str = "train",
     **load_dataset_kwargs: Dict[str, Any],
 ) -> TextCompletionDataset:
     """
@@ -29,6 +30,8 @@ def cnn_dailymail_articles_dataset(
         max_seq_len (Optional[int]): Maximum number of tokens in the returned input and label token id lists.
             Default is None, disabling truncation. We recommend setting this to the highest you can fit in memory
             and is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
+        split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
+            of a given split, e.g. ``split="train[:10%]"``. Default is "train".
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Returns:
@@ -40,7 +43,7 @@ def cnn_dailymail_articles_dataset(
         source=source,
         column="article",
         max_seq_len=max_seq_len,
-        split="train",
+        split=split,
         # This is used to specify the version of the dataset, a required argument
         # by the cnn_dailymail dataset builder:
         # https://huggingface.co/datasets/ccdv/cnn_dailymail/blob/main/cnn_dailymail.py#L80

--- a/torchtune/datasets/_grammar.py
+++ b/torchtune/datasets/_grammar.py
@@ -14,6 +14,7 @@ def grammar_dataset(
     source: str = "liweili/c4_200m",
     train_on_input: bool = False,
     packed: bool = False,
+    split: str = "train",
 ) -> InstructDataset:
     """
     Support for grammar correction datasets and their variants from Hugging Face Datasets.
@@ -35,6 +36,8 @@ def grammar_dataset(
         source (str): path string of dataset, anything supported by Hugging Face's ``load_dataset``.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
+        split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
+            of a given split, e.g. ``split="train[:10%]"``. Default is "train".
 
     Returns:
         InstructDataset: dataset configured with source data and template
@@ -54,5 +57,5 @@ def grammar_dataset(
         column_map={"sentence": "input"},
         train_on_input=train_on_input,
         packed=packed,
-        split="train",
+        split=split,
     )

--- a/torchtune/datasets/_samsum.py
+++ b/torchtune/datasets/_samsum.py
@@ -14,6 +14,7 @@ def samsum_dataset(
     source: str = "samsum",
     train_on_input: bool = False,
     packed: bool = False,
+    split: str = "train",
 ) -> InstructDataset:
     """
     Support for summarization datasets and their variants from Hugging Face Datasets.
@@ -35,6 +36,8 @@ def samsum_dataset(
         source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
+        split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
+            of a given split, e.g. ``split="train[:10%]"``. Default is "train".
 
     Returns:
         InstructDataset: dataset configured with source data and template
@@ -54,5 +57,5 @@ def samsum_dataset(
         column_map={"output": "summary"},
         train_on_input=train_on_input,
         packed=packed,
-        split="train",
+        split=split,
     )

--- a/torchtune/datasets/_slimorca.py
+++ b/torchtune/datasets/_slimorca.py
@@ -19,6 +19,7 @@ def slimorca_dataset(
     max_seq_len: int = 1024,
     train_on_input: bool = False,
     packed: bool = False,
+    split: str = "train",
 ) -> ChatDataset:
     """
     Support for `SlimOrca-style <https://huggingface.co/datasets/Open-Orca/SlimOrca-Dedup>`_
@@ -42,6 +43,8 @@ def slimorca_dataset(
             Default is 1024.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
+        split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
+            of a given split, e.g. ``split="train[:10%]"``. Default is "train".
 
     Raises:
         ValueError: If `max_seq_len` is less than 4.
@@ -72,5 +75,5 @@ def slimorca_dataset(
         max_seq_len=max_seq_len,
         train_on_input=train_on_input,
         packed=packed,
-        split="train",
+        split=split,
     )

--- a/torchtune/datasets/_stack_exchanged_paired.py
+++ b/torchtune/datasets/_stack_exchanged_paired.py
@@ -14,6 +14,7 @@ def stack_exchanged_paired_dataset(
     *,
     source: str = "lvwerra/stack-exchange-paired",
     max_seq_len: int = 1024,
+    split: str = "train",
 ) -> PreferenceDataset:
     """
     Family of preference datasets similar to `StackExchangePaired data
@@ -24,6 +25,8 @@ def stack_exchanged_paired_dataset(
         source (str): path string of dataset, anything supported by Hugging Face's `load_dataset`.
         max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
             Default is 1024.
+        split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
+            of a given split, e.g. ``split="train[:10%]"``. Default is "train".
 
     Returns:
         PreferenceDataset: The preference dataset built from source paired data.
@@ -38,6 +41,6 @@ def stack_exchanged_paired_dataset(
             "rejected": "response_k",
         },
         max_seq_len=max_seq_len,
-        split="train",
+        split=split,
         data_dir="data/rl",
     )

--- a/torchtune/datasets/_wikitext.py
+++ b/torchtune/datasets/_wikitext.py
@@ -16,6 +16,7 @@ def wikitext_dataset(
     source: str = "wikitext",
     subset: str = "wikitext-103-raw-v1",
     max_seq_len: Optional[int] = None,
+    split: str = "train",
     **load_dataset_kwargs: Dict[str, Any],
 ) -> TextCompletionDataset:
     """
@@ -31,6 +32,8 @@ def wikitext_dataset(
         max_seq_len (Optional[int]): Maximum number of tokens in the returned input and label token id lists.
             Default is None, disabling truncation. We recommend setting this to the highest you can fit in memory
             and is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
+        split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
+            of a given split, e.g. ``split="train[:10%]"``. Default is "train".
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Returns:
@@ -43,6 +46,6 @@ def wikitext_dataset(
         column="text",
         max_seq_len=max_seq_len,
         name=subset,
-        split="train",
+        split=split,
         **load_dataset_kwargs,
     )


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Discussed in https://github.com/pytorch/torchtune/issues/1107#issuecomment-2239651967. This exposes the `split` arg for `datasets.load_dataset` in our default dataset builders - particularly useful (as documented) for specifying fractions of datasets to train with, which all levels of users might enjoy.

#### Test plan

👁️     .    👁️

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
