### PR TITLE
Fix check for valid config for 70B training with fused optimizer

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -105,8 +105,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             )
 
         if (
-            cfg.get("fsdp_cpu_offload", False)
-            and cfg.get("fused", False)
+            cfg.get("fsdp_cpu_offload", True)
+            and cfg.get("optimizer.fused", True)
             and not utils.torch_version_ge("2.4.0")
         ):
             raise RuntimeError(

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -105,8 +105,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             )
 
         if (
-            cfg.get("fsdp_cpu_offload", True)
-            and cfg.get("optimizer.fused", True)
+            cfg.get("fsdp_cpu_offload", False)
+            and cfg.optimizer.get("fused", False)
             and not utils.torch_version_ge("2.4.0")
         ):
             raise RuntimeError(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
* Check for "fused" on the optimizer in the config itself

#### Test plan

**Check that it doesn't hit the check when PyTorch is high enough and options are selected**
1. Install pytorch nightlies
2. `tune run --nproc_per_node 8 full_finetune_distributed --config llama3/70B_full`
3. Confirm it runs ✅

**Check that it doesn't hit the check when options are not selected**
1. Set fused to False
2. `tune run --nproc_per_node 8 full_finetune_distributed --config llama3/70B_full`
3. Confirm it runs  ✅

**Check that it does hit the check when PyTorch is not high enough and options are selected**
1. Install pytorch 2.3 (latest stable)
3. `tune run --nproc_per_node 8 full_finetune_distributed --config llama3/70B_full`
4. Confirm it hits the error ✅