### PR TITLE
Checkpointer Save "adapter_only" Option

### DIFF
--- a/tests/torchtune/utils/test_checkpointer.py
+++ b/tests/torchtune/utils/test_checkpointer.py
@@ -306,7 +306,7 @@ class TestHFLlama2FullModelCheckpointer:
     ):
         """ """
         state_dict = single_file_checkpointer.load_checkpoint()
-        # state_dict = {MODEL_KEY: orig_state_dict}
+
         with pytest.raises(
             ValueError, match="Adapter checkpoint not found in state_dict"
         ):
@@ -324,6 +324,7 @@ class TestHFLlama2FullModelCheckpointer:
             output_state_dict_1 = safe_torch_load(output_file_1)
 
         output_state_dict_2 = safe_torch_load(output_file_2)
+        # Check that the empty adapter we saved is the one loaded succesfully
         assert len(output_state_dict_2.keys()) == 0
 
     def test_save_checkpoint_in_peft_format(

--- a/torchtune/utils/_checkpointing/_checkpointer.py
+++ b/torchtune/utils/_checkpointing/_checkpointer.py
@@ -215,6 +215,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         state_dict: Dict[str, Any],
         epoch: int,
         intermediate_checkpoint: bool = False,
+        adapter_only: bool = False,
     ) -> None:
         """
         Save torchtune checkpoint to file. If ``intermediate_checkpoint`` is True, an additional
@@ -240,19 +241,21 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 we're not overwriting intermediate checkpoint files
             intermediate_checkpoint (bool): If True, save an additional checkpoint file with the
                 recipe state
+            adapter_only (bool): If True, only save the adapter weights. Default is False
         """
         self._output_dir.mkdir(exist_ok=True)
 
         # Output file is always a .pt file with the epoch number in the name
-        checkpoint_file = Path.joinpath(
-            self._output_dir, f"torchtune_model_{epoch}"
-        ).with_suffix(".pt")
-        torch.save(state_dict[utils.MODEL_KEY], checkpoint_file)
-        logger.info(
-            "Model checkpoint of size "
-            f"{os.path.getsize(checkpoint_file) / 1000**3:.2f} GB "
-            f"saved to {checkpoint_file}"
-        )
+        if not adapter_only:
+            checkpoint_file = Path.joinpath(
+                self._output_dir, f"torchtune_model_{epoch}"
+            ).with_suffix(".pt")
+            torch.save(state_dict[utils.MODEL_KEY], checkpoint_file)
+            logger.info(
+                "Model checkpoint of size "
+                f"{os.path.getsize(checkpoint_file) / 1000**3:.2f} GB "
+                f"saved to {checkpoint_file}"
+            )
 
         if utils.ADAPTER_KEY in state_dict:
             output_path = Path.joinpath(
@@ -263,6 +266,10 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 "Adapter checkpoint of size "
                 f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
                 f"saved to {output_path}"
+            )
+        elif adapter_only:
+            raise ValueError(
+                "Adapter checkpoint not found in state_dict. Please ensure that the state_dict contains adapter weights."
             )
 
         # If the recipe state needs to be output, first remove the model state dict
@@ -449,6 +456,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         state_dict: Dict[str, Any],
         epoch: int,
         intermediate_checkpoint: bool = False,
+        adapter_only: bool = False,
     ) -> None:
         """
         Save HF checkpoint to file. If ``intermediate_checkpoint`` is True, an additional
@@ -463,54 +471,58 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             epoch (int): Epoch number. Used to create the checkpoint file name
             intermediate_checkpoint (bool): If True, an additional checkpoint files for recipe state
                 and (if applicable) adapter weights are created. Default is False
+            adapter_only (bool): If True, only save the adapter weights. Default is False
         """
         self._output_dir.mkdir(exist_ok=True)
 
         # convert the state_dict back to hf format; do this inplace
-        if self._model_type == ModelType.PHI3_MINI:
-            state_dict[utils.MODEL_KEY] = phi3_tune_to_hf(state_dict[utils.MODEL_KEY])
-        elif self._model_type == ModelType.MISTRAL_REWARD:
-            state_dict[utils.MODEL_KEY] = mistral_reward_tune_to_hf(
-                state_dict[utils.MODEL_KEY],
-                num_heads=self._config["num_attention_heads"],
-                num_kv_heads=self._config["num_key_value_heads"],
-                dim=self._config["hidden_size"],
-            )
-        else:
-            state_dict[utils.MODEL_KEY] = convert_weights.tune_to_hf(
-                state_dict[utils.MODEL_KEY],
-                num_heads=self._config["num_attention_heads"],
-                num_kv_heads=self._config["num_key_value_heads"],
-                dim=self._config["hidden_size"],
-                head_dim=self._config.get("head_dim", None),
-            )
-
-        # split the state_dict into separate dicts, one for each output checkpoint file
-        split_state_dicts: Dict[str, Dict[str, torch.Tensor]] = {}
-        for key, weight in state_dict[utils.MODEL_KEY].items():
-            cpt_idx = self._weight_map[key]
-            if cpt_idx not in split_state_dicts:
-                split_state_dicts[cpt_idx] = {}
-            split_state_dicts[cpt_idx].update({key: weight})
-
-        # write the partitioned state dicts to the right checkpoint file
-        for cpt_idx, model_state_dict in split_state_dicts.items():
-            if not self._safe_serialization:
-                output_path = Path.joinpath(
-                    self._output_dir, f"hf_model_{cpt_idx}_{epoch}"
-                ).with_suffix(".pt")
-                torch.save(model_state_dict, output_path)
+        if not adapter_only:
+            if self._model_type == ModelType.PHI3_MINI:
+                state_dict[utils.MODEL_KEY] = phi3_tune_to_hf(
+                    state_dict[utils.MODEL_KEY]
+                )
+            elif self._model_type == ModelType.MISTRAL_REWARD:
+                state_dict[utils.MODEL_KEY] = mistral_reward_tune_to_hf(
+                    state_dict[utils.MODEL_KEY],
+                    num_heads=self._config["num_attention_heads"],
+                    num_kv_heads=self._config["num_key_value_heads"],
+                    dim=self._config["hidden_size"],
+                )
             else:
-                output_path = Path.joinpath(
-                    self._output_dir,
-                    f"model-0{cpt_idx}-of-0{list(split_state_dicts.keys())[-1]}_{epoch}",
-                ).with_suffix(".safetensors")
-                save_file(model_state_dict, output_path, metadata={"format": "pt"})
-            logger.info(
-                "Model checkpoint of size "
-                f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
-                f"saved to {output_path}"
-            )
+                state_dict[utils.MODEL_KEY] = convert_weights.tune_to_hf(
+                    state_dict[utils.MODEL_KEY],
+                    num_heads=self._config["num_attention_heads"],
+                    num_kv_heads=self._config["num_key_value_heads"],
+                    dim=self._config["hidden_size"],
+                    head_dim=self._config.get("head_dim", None),
+                )
+
+            # split the state_dict into separate dicts, one for each output checkpoint file
+            split_state_dicts: Dict[str, Dict[str, torch.Tensor]] = {}
+            for key, weight in state_dict[utils.MODEL_KEY].items():
+                cpt_idx = self._weight_map[key]
+                if cpt_idx not in split_state_dicts:
+                    split_state_dicts[cpt_idx] = {}
+                split_state_dicts[cpt_idx].update({key: weight})
+
+            # write the partitioned state dicts to the right checkpoint file
+            for cpt_idx, model_state_dict in split_state_dicts.items():
+                if not self._safe_serialization:
+                    output_path = Path.joinpath(
+                        self._output_dir, f"hf_model_{cpt_idx}_{epoch}"
+                    ).with_suffix(".pt")
+                    torch.save(model_state_dict, output_path)
+                else:
+                    output_path = Path.joinpath(
+                        self._output_dir,
+                        f"model-0{cpt_idx}-of-0{list(split_state_dicts.keys())[-1]}_{epoch}",
+                    ).with_suffix(".safetensors")
+                    save_file(model_state_dict, output_path, metadata={"format": "pt"})
+                logger.info(
+                    "Model checkpoint of size "
+                    f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
+                    f"saved to {output_path}"
+                )
 
         if utils.ADAPTER_KEY in state_dict:
             # Save torchtune format adapter weights even if we save PEFT format
@@ -548,6 +560,10 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
                     f"saved to {peft_output_path}"
                 )
+        elif adapter_only:
+            raise ValueError(
+                "Adapter checkpoint not found in state_dict. Please ensure that the state_dict contains adapter weights."
+            )
 
         if utils.ADAPTER_CONFIG in state_dict:
             if self._model_type == ModelType.PHI3_MINI:
@@ -670,6 +686,7 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
         state_dict: Dict[str, Any],
         epoch: int,
         intermediate_checkpoint: bool = False,
+        adapter_only: bool = False,
     ) -> None:
         """
         Save Meta checkpoint to file. If ``intermediate_checkpoint`` is True, an additional
@@ -681,21 +698,24 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
             epoch (int): Epoch number. Used to create the checkpoint file name
             intermediate_checkpoint (bool): If True, an additional checkpoint files for recipe state
                 and (if applicable) adapter weights are created. Default is False
+            adapter_only (bool): If True, only save the adapter weights. Default is False
         """
         self._output_dir.mkdir(exist_ok=True)
-        model_state_dict = state_dict[utils.MODEL_KEY]
-        state_dict[utils.MODEL_KEY] = convert_weights.tune_to_meta(model_state_dict)
 
-        # Output file is always a .pt file with the epoch number in the name
-        checkpoint_file = Path.joinpath(
-            self._output_dir, f"meta_model_{epoch}"
-        ).with_suffix(".pt")
-        torch.save(state_dict[utils.MODEL_KEY], checkpoint_file)
-        logger.info(
-            "Model checkpoint of size "
-            f"{os.path.getsize(checkpoint_file) / 1000**3:.2f} GB "
-            f"saved to {checkpoint_file}"
-        )
+        if not adapter_only:
+            model_state_dict = state_dict[utils.MODEL_KEY]
+            state_dict[utils.MODEL_KEY] = convert_weights.tune_to_meta(model_state_dict)
+
+            # Output file is always a .pt file with the epoch number in the name
+            checkpoint_file = Path.joinpath(
+                self._output_dir, f"meta_model_{epoch}"
+            ).with_suffix(".pt")
+            torch.save(state_dict[utils.MODEL_KEY], checkpoint_file)
+            logger.info(
+                "Model checkpoint of size "
+                f"{os.path.getsize(checkpoint_file) / 1000**3:.2f} GB "
+                f"saved to {checkpoint_file}"
+            )
 
         if utils.ADAPTER_KEY in state_dict:
             output_path = Path.joinpath(
@@ -706,6 +726,10 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
                 "Adapter checkpoint of size "
                 f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
                 f"saved to {output_path}"
+            )
+        elif adapter_only:
+            raise ValueError(
+                "Adapter checkpoint not found in state_dict. Please ensure that the state_dict contains adapter weights."
             )
 
         # If the recipe state needs to be output, first remove the model state dict


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
This adds a new option to save_checkpoint to only save the adapter if it's available. This adds the option to all three checkpointers. This is needed to better support large checkpoint models like 405B where it doesn't make sense to save the entire checkpoint after each epoch for a lora recipe.

This PR was intended as a minimal change on the checkpoint PR without breaking recipes, hence adding this option. An alternative approach would be to have each checkpointer implement save_checkpoint, save_adapter, and save_recipe. This would simplify conditional logic for saving but I leave this to the checkpoint refactor work.

This implementation raises an error if adapter_only=True and there is no adapter. adapter_only has no affect on intermediate_checkpoint.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
