### PR TITLE
[RFC] Chat preference datasets

### DIFF
--- a/docs/source/api_ref_datasets.rst
+++ b/docs/source/api_ref_datasets.rst
@@ -39,6 +39,7 @@ These are especially useful for specifying from a YAML config.
 
     instruct_dataset
     chat_dataset
+    chat_preference_dataset
     text_completion_dataset
 
 Generic dataset classes
@@ -55,4 +56,5 @@ Class representations for the above dataset builders.
     TextCompletionDataset
     ConcatDataset
     PackedDataset
-    PreferenceDataset
+    InstructPreferenceDataset
+    ChatPreferenceDataset

--- a/tests/torchtune/datasets/test_preference_dataset.py
+++ b/tests/torchtune/datasets/test_preference_dataset.py
@@ -1,0 +1,141 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+import pytest
+from tests.test_utils import DummyChatFormat, DummyTokenizer
+from torchtune.data import Message
+from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
+from torchtune.datasets import ChatPreferenceDataset
+
+
+class TestChatPreferenceDataset:
+    @pytest.fixture
+    def chat_format(self):
+        return DummyChatFormat
+
+    @pytest.fixture
+    def dialogue(self):
+        return [
+            Message.from_dict(
+                {
+                    "role": "user",
+                    "content": "Rockin', rockin', and rollin'",
+                    "masked": True,
+                }
+            ),
+            Message.from_dict(
+                {
+                    "role": "assistant",
+                    "content": "Down to the beach, I am strolling",
+                    "masked": False,
+                }
+            ),
+            Message.from_dict(
+                {
+                    "role": "user",
+                    "content": "But the seagulls poke at my head, not fun!",
+                    "masked": True,
+                }
+            ),
+            Message.from_dict(
+                {
+                    "role": "assistant",
+                    "content": "I said, `Seagulls, mm! Stop it now!`",
+                    "masked": False,
+                }
+            ),
+        ]
+
+    @pytest.fixture
+    def sample(self, dialogue):
+        return [
+            {
+                "chosen": dialogue,
+                "rejected": dialogue,
+            }
+        ]
+
+    @mock.patch("torchtune.datasets._preference.load_dataset")
+    def test_get_item(self, mock_load_dataset, chat_format, sample):
+        mock_load_dataset.return_value = sample
+        expected_tokenized_prompts = [
+            [
+                0,
+                5,
+                8,
+                8,
+                3,
+                7,
+                10,
+                4,
+                2,
+                3,
+                6,
+                1,
+                2,
+                9,
+                -1,
+                0,
+                5,
+                3,
+                3,
+                8,
+                4,
+                2,
+                2,
+                5,
+                3,
+                4,
+                10,
+                1,
+                5,
+                10,
+                3,
+                4,
+                2,
+                5,
+                -1,
+            ]
+        ]
+        prompt_lengths = (7, 12)
+        expected_labels = [
+            [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[0]
+            + [
+                4,
+                2,
+                3,
+                6,
+                1,
+                2,
+                9,
+                -1,
+            ]
+            + [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[1]
+            + [1, 5, 10, 3, 4, 2, 5, -1]
+        ]
+        ds = ChatPreferenceDataset(
+            tokenizer=DummyTokenizer(),
+            source="stop/it/now",
+            convert_to_messages=lambda x, y: x["conversations"],
+            chat_format=chat_format,
+            max_seq_len=100,
+            train_on_input=False,
+        )
+        mock_load_dataset.assert_called_once()
+
+        chosen_prompts, chosen_labels = (
+            ds[0]["chosen_input_ids"],
+            ds[0]["chosen_labels"],
+        )
+        rejected_prompts, rejected_labels = (
+            ds[0]["rejected_input_ids"],
+            ds[0]["rejected_labels"],
+        )
+
+        assert chosen_prompts == rejected_prompts == expected_tokenized_prompts[0]
+        assert chosen_labels == rejected_labels == expected_labels[0]

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -11,7 +11,11 @@ from torchtune.datasets._concat import ConcatDataset
 from torchtune.datasets._grammar import grammar_dataset
 from torchtune.datasets._instruct import instruct_dataset, InstructDataset
 from torchtune.datasets._packed import PackedDataset
-from torchtune.datasets._preference import PreferenceDataset
+from torchtune.datasets._preference import (
+    chat_preference_dataset,
+    ChatPreferenceDataset,
+    InstructPreferenceDataset,
+)
 from torchtune.datasets._samsum import samsum_dataset
 from torchtune.datasets._slimorca import slimorca_dataset
 from torchtune.datasets._stack_exchanged_paired import stack_exchanged_paired_dataset
@@ -38,5 +42,7 @@ __all__ = [
     "PackedDataset",
     "ConcatDataset",
     "wikitext_dataset",
-    "PreferenceDataset",
+    "InstructPreferenceDataset",
+    "ChatPreferenceDataset",
+    "chat_preference_dataset",
 ]

--- a/torchtune/datasets/_preference.py
+++ b/torchtune/datasets/_preference.py
@@ -9,15 +9,24 @@ from typing import Any, Callable, Dict, List, Mapping, Optional
 import numpy as np
 from datasets import load_dataset
 from torch.utils.data import Dataset
+from torchtune.config._utils import _get_component_from_path
 
-from torchtune.data import CROSS_ENTROPY_IGNORE_IDX, InstructTemplate, Message
+from torchtune.data import (
+    ChatFormat,
+    CROSS_ENTROPY_IGNORE_IDX,
+    get_openai_messages,
+    get_sharegpt_messages,
+    InstructTemplate,
+    Message,
+    validate_messages,
+)
 
 from torchtune.modules.tokenizers import ModelTokenizer
 
 
-class PreferenceDataset(Dataset):
+class InstructPreferenceDataset(Dataset):
     """
-    Class that supports any custom dataset with instruction-based prompts and a
+    Class that supports any custom preference dataset with instruction-based prompts and a
     configurable template.
 
     The general flow from loading a sample to tokenized prompt is:
@@ -35,7 +44,8 @@ class PreferenceDataset(Dataset):
         transform (Optional[Callable]): transform to apply to the sample before formatting to the template.
             Default is None.
         column_map (Optional[Dict[str, str]]): a mapping from the expected placeholder names in the template
-            to the column/key names in the sample. If None, assume these are identical.
+            to the column/key names in the sample. The expected column names are "prompt", "chosen", and "rejected".
+            The default mapping uses identical keys i.e. ``{"prompt": "prompt", "chosen": "chosen", "rejected": "rejected"}``.
         max_seq_len (Optional[int]): Maximum number of tokens in the returned input and label token id lists.
             Default is None, disabling truncation. We recommend setting this to the highest you can fit in memory
             and is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
@@ -56,14 +66,25 @@ class PreferenceDataset(Dataset):
         self._data = load_dataset(source, **load_dataset_kwargs)
         self.template = template
         self._transform = transform
-        self._column_map = column_map
-        self.max_seq_len = max_seq_len
-        self._data = self._data.filter(
-            lambda x: len(x[column_map["prompt"]]) + len(x[column_map["chosen"]])
-            <= max_seq_len
-            and len(x[column_map["prompt"]]) + len(x[column_map["rejected"]])
-            <= max_seq_len
+        self._column_map = (
+            column_map
+            if column_map is not None
+            else {
+                "prompt": "prompt",
+                "chosen": "chosen",
+                "rejected": "rejected",
+            }
         )
+        self.max_seq_len = max_seq_len
+
+        # TODO move this to the DPO Recipe / to a DPO specific transform
+        if max_seq_len is not None:
+            self._data = self._data.filter(
+                lambda x: len(x[column_map["prompt"]]) + len(x[column_map["chosen"]])
+                <= max_seq_len
+                and len(x[column_map["prompt"]]) + len(x[column_map["rejected"]])
+                <= max_seq_len
+            )
 
     def __len__(self):
         return len(self._data)
@@ -76,18 +97,19 @@ class PreferenceDataset(Dataset):
         transformed_sample = self._transform(sample) if self._transform else sample
         prompt = self.template.format(transformed_sample, self._column_map)
 
-        column_map = self._column_map or {}
-        key_chosen = column_map.get("chosen", "chosen")
-        key_rejected = column_map.get("rejected", "rejected")
-
         chosen_message = [
             Message(role="user", content=prompt, masked=True),
-            Message(role="assistant", content=transformed_sample[key_chosen]),
+            Message(
+                role="assistant", content=transformed_sample[self._column_map["chosen"]]
+            ),
         ]
 
         rejected_message = [
             Message(role="user", content=prompt, masked=True),
-            Message(role="assistant", content=transformed_sample[key_rejected]),
+            Message(
+                role="assistant",
+                content=transformed_sample[self._column_map["rejected"]],
+            ),
         ]
 
         # TODO: Trunction differs from original DPO repo
@@ -117,3 +139,192 @@ class PreferenceDataset(Dataset):
         )
 
         return batch
+
+
+class ChatPreferenceDataset(Dataset):
+    """
+    Class that supports any custom preference dataset with chat-based prompts and a
+    configurable template. See :class:`~torchtune.data.ChatDataset` for more details.
+
+    The general flow from loading a sample to tokenized prompt is:
+    load sample -> apply transform -> format into template -> tokenize
+
+    Args:
+        tokenizer (ModelTokenizer): Tokenizer used by the model that implements the ``tokenize_messages`` method.
+        source (str): path string of dataset, anything supported by Hugging Face's ``load_dataset``
+            (https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path)
+        convert_to_messages (Callable[[Mapping[str, Any]], List[Message]]): function that keys into the desired field in the sample
+            and converts to a list of :class:`~torchtune.data.Message` that follows the Llama format with the expected keys
+        chat_format (Optional[ChatFormat]): template used to format the chat. This is used to add structured text around the actual
+            messages, such as the [INST] tags in Llama2 and in Mistral. The extra text will still get tokenized as normal text, not
+            as special tokens. In models like Llama3 where the tokenizer adds tags as special tokens, ``chat_format`` is not needed,
+            unless you want to structure messages in a particular way for inference. If the placeholder variable names in the
+            template do not match the column/key names in the dataset, use ``column_map`` to map them. For a list of all possible
+            chat formats, check out :ref:`chat_formats`. Default: None.
+        column_map (Optional[Dict[str, str]]): a mapping from the expected placeholder names in the template
+            to the column/key names in the sample. The expected column names are "chosen", and "rejected".
+            The default mapping uses identical keys i.e. ``{"chosen": "chosen", "rejected": "rejected"}``.
+        max_seq_len (Optional[int]): Maximum number of tokens in the returned input and label token id lists.
+            Default is None, disabling truncation. We recommend setting this to the highest you can fit in memory
+            and is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
+    """
+
+    def __init__(
+        self,
+        tokenizer: ModelTokenizer,
+        source: str,
+        convert_to_messages: Callable[[Mapping[str, Any]], List[Message]],
+        chat_format: Optional[ChatFormat] = None,
+        column_map: Optional[Dict[str, str]] = None,
+        max_seq_len: Optional[int] = None,
+        train_on_input: bool = False,
+        **load_dataset_kwargs: Dict[str, Any],
+    ) -> None:
+
+        if not isinstance(chat_format(), ChatFormat):
+            raise ValueError(
+                f"chat_format must be a ChatFormat class, not {type(chat_format())}"
+            )
+        self._tokenizer = tokenizer
+        self._data = load_dataset(source, **load_dataset_kwargs)
+        self._convert_to_messages = convert_to_messages
+        self.chat_format = chat_format
+
+        self._column_map = (
+            column_map
+            if column_map is not None
+            else {
+                "chosen": "chosen",
+                "rejected": "rejected",
+            }
+        )
+
+        self.train_on_input = train_on_input
+        self.max_seq_len = max_seq_len
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, index: int) -> Dict[str, List[int]]:
+        sample = self._data[index]
+        return self._prepare_sample(sample)
+
+    def _prepare_sample(self, sample: Mapping[str, Any]) -> Dict[str, List[int]]:
+
+        # this should support both sharegpt and openai formats
+        chosen_messages = self._convert_to_messages(
+            {"conversations": sample[self._column_map["chosen"]]}, self.train_on_input
+        )
+        rejected_messages = self._convert_to_messages(
+            {"conversations": sample[self._column_map["rejected"]]}, self.train_on_input
+        )
+
+        if self.chat_format is not None:
+            chosen_messages = self.chat_format.format(chosen_messages)
+            rejected_messages = self.chat_format.format(rejected_messages)
+
+        validate_messages(chosen_messages)
+        validate_messages(rejected_messages)
+
+        chosen_input_ids, c_masks = self._tokenizer.tokenize_messages(
+            chosen_messages, self.max_seq_len
+        )
+        chosen_labels = list(
+            np.where(c_masks, CROSS_ENTROPY_IGNORE_IDX, chosen_input_ids)
+        )
+
+        rejected_input_ids, r_masks = self._tokenizer.tokenize_messages(
+            rejected_messages, self.max_seq_len
+        )
+        rejected_labels = list(
+            np.where(r_masks, CROSS_ENTROPY_IGNORE_IDX, rejected_input_ids)
+        )
+
+        assert len(chosen_input_ids) == len(chosen_labels)
+        assert len(rejected_input_ids) == len(rejected_labels)
+
+        batch = dict(
+            chosen_input_ids=chosen_input_ids,
+            chosen_labels=chosen_labels,
+            rejected_input_ids=rejected_input_ids,
+            rejected_labels=rejected_labels,
+        )
+
+        return batch
+
+
+def chat_preference_dataset(
+    *,
+    tokenizer: ModelTokenizer,
+    source: str,
+    conversation_style: str,
+    chat_format: Optional[str] = None,
+    max_seq_len: int,
+    train_on_input: bool = False,
+    **load_dataset_kwargs: Dict[str, Any],
+) -> ChatPreferenceDataset:
+    """
+    Build a configurable preference dataset with conversations. This method should be
+    used to configure a custom chat-format preference dataset from the yaml config instead of
+    using :class:`~torchtune.datasets.ChatPreferenceDataset` directly, as it is made to be config friendly.
+    An example of a dataset which this config would support is
+        https://huggingface.co/datasets/argilla/ultrafeedback-binarized-preferences-cleaned
+    Args:
+        tokenizer (ModelTokenizer): Tokenizer used by the model that implements the ``tokenize_messages`` method.
+        source (str): path string of dataset, anything supported by Hugging Face's ``load_dataset``
+            (https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path)
+        conversation_style (str): string specifying expected style of conversations in the dataset
+            for automatic conversion to the :class:`~torchtune.data.Message` structure. Supported styles are: "sharegpt", "openai"
+        chat_format (Optional[str]): full import path of :class:`~torchtune.data.ChatFormat` class used to format the messages.
+            See the description in :class:`~torchtune.datasets.ChatDataset` for more details. For a list of all
+            possible chat formats, check out :ref:`chat_formats`. Default: None.
+        max_seq_len (int): Maximum number of tokens in the returned input and label token id lists.
+        train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
+
+    Examples:
+        >>> from torchtune.datasets import chat_preference_dataset
+        >>> dataset = chat_preference_dataset(
+        ...   tokenizer=tokenizer,
+        ...   source="mlabonne/orpo-dpo-mix-40k",
+        ...   conversation_style="openai",
+        ...   chat_format="torchtune.data.ChatMLFormat",
+        ...   max_seq_len=2096,
+        ...   train_on_input=False
+        ... )
+
+    This can also be accomplished via the yaml config::
+
+        dataset:
+            _component_: torchtune.datasets.chat_preference_dataset
+            source: mlabonne/orpo-dpo-mix-40k
+            conversation_style: openai
+            chat_format: torchtune.data.ChatMLFormat
+            max_seq_len: 2096
+            train_on_input: False
+
+    Returns:
+        ChatPreferenceDataset: the configured :class:`~torchtune.datasets.ChatPreferenceDataset`.
+
+    Raises:
+        ValueError: if the conversation format is not supported
+    """
+    if conversation_style == "sharegpt":
+        convert_to_messages = get_sharegpt_messages
+    elif conversation_style == "openai":
+        convert_to_messages = get_openai_messages
+    else:
+        raise ValueError(f"Unsupported conversation style: {conversation_style}")
+
+    return ChatPreferenceDataset(
+        tokenizer=tokenizer,
+        source=source,
+        convert_to_messages=convert_to_messages,
+        chat_format=_get_component_from_path(chat_format)
+        if chat_format is not None
+        else None,
+        max_seq_len=max_seq_len,
+        train_on_input=train_on_input,
+        **load_dataset_kwargs,
+    )

--- a/torchtune/datasets/_preference.py
+++ b/torchtune/datasets/_preference.py
@@ -268,8 +268,9 @@ def chat_preference_dataset(
     Build a configurable preference dataset with conversations. This method should be
     used to configure a custom chat-format preference dataset from the yaml config instead of
     using :class:`~torchtune.datasets.ChatPreferenceDataset` directly, as it is made to be config friendly.
-    An example of a dataset which this config would support is
-        https://huggingface.co/datasets/argilla/ultrafeedback-binarized-preferences-cleaned
+    An example of a dataset which this config would support is `the Ultrafeedback dataset
+    <https://huggingface.co/datasets/argilla/ultrafeedback-binarized-preferences-cleaned>`_.
+
     Args:
         tokenizer (ModelTokenizer): Tokenizer used by the model that implements the ``tokenize_messages`` method.
         source (str): path string of dataset, anything supported by Hugging Face's ``load_dataset``

--- a/torchtune/datasets/_stack_exchanged_paired.py
+++ b/torchtune/datasets/_stack_exchanged_paired.py
@@ -17,7 +17,7 @@ def stack_exchanged_paired_dataset(
     split: str = "train",
 ) -> InstructPreferenceDataset:
     """
-    Family of instruct preference datasets similar to ``StackExchangePaired data
+    Family of instruct preference datasets similar to `StackExchangePaired data
     <https://huggingface.co/datasets/lvwerra/stack-exchange-paired>`_.
 
     Args:

--- a/torchtune/datasets/_stack_exchanged_paired.py
+++ b/torchtune/datasets/_stack_exchanged_paired.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtune.data import StackExchangedPairedTemplate
-from torchtune.datasets._preference import PreferenceDataset
+from torchtune.datasets._preference import InstructPreferenceDataset
 from torchtune.modules.tokenizers import ModelTokenizer
 
 
@@ -15,9 +15,9 @@ def stack_exchanged_paired_dataset(
     source: str = "lvwerra/stack-exchange-paired",
     max_seq_len: int = 1024,
     split: str = "train",
-) -> PreferenceDataset:
+) -> InstructPreferenceDataset:
     """
-    Family of preference datasets similar to `StackExchangePaired data
+    Family of instruct preference datasets similar to ``StackExchangePaired data
     <https://huggingface.co/datasets/lvwerra/stack-exchange-paired>`_.
 
     Args:
@@ -29,9 +29,9 @@ def stack_exchanged_paired_dataset(
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
 
     Returns:
-        PreferenceDataset: The preference dataset built from source paired data.
+        InstructPreferenceDataset: The preference dataset built from source paired data.
     """
-    return PreferenceDataset(
+    return InstructPreferenceDataset(
         tokenizer=tokenizer,
         source=source,
         template=StackExchangedPairedTemplate(),


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)



#### Not all preference datasets were created equal

Some of the most popular preference datasets on HF [are chat datasets](https://huggingface.co/datasets?other=preference&sort=likes). Let's show them some love. This PR continues to flesh out our support for alignment fine-tuning by adding support for chat-style preference datasets. This also provides a concrete example for when we consider integrating preference datasets with #1186.

```python
from torchtune.datasets import chat_preference_dataset
from torchtune.data import ChatMLFormat, get_openai_messages
from torchtune.models import llama2

tokenizer = llama2.llama2_tokenizer("./target/dummy/tokenizer.model")

ds = chat_preference_dataset(
    tokenizer=tokenizer,
    source = "mlabonne/orpo-dpo-mix-40k",
    conversation_style="openai",
    chat_format="torchtune.data.ChatMLFormat",
    max_seq_len=512,
    train_on_input=False,
    split="train[:10%]"
)
print(ds[0].keys())

"""
dict_keys(['chosen_input_ids', 'chosen_labels', 'rejected_input_ids', 'rejected_labels'])
"""

print(f"chosen_input_ids:\n \t {tokenizer.decode(ds[0]["chosen_input_ids"])}")
print("-----------")
print(f"rejected_input_ids:\n \t {tokenizer.decode(ds[0]["rejected_input_ids"])}")

"""
chosen_input_ids:
 	 <|im_start|>user
 The setting is an otherworldly, yet eerily familiar, metropolis known as "Zephyria." It's a city suspended in the ether, floating amidst nebulous clouds of cosmic dust. The architecture here is surreal and alien, with buildings that twist and spiral like strands of DNA, reaching towards the cosmos. Streets are paved with luminescent cobblestones, casting soft hues of blues and purples, reflecting off iridescent structures. Strange vegetation, vibrant and bioluminescent, thrives everywhere, creating a stark contrast against the deep indigo sky.

Now, immerse me in this ethereal journey through Zephyria. <|im_end|>
<|im_start|>assistant
As you step onto the teleportation platform, there's a momentary sense of disorientation before your surroundings change abruptly. You find yourself standing on the outskirts of Zephyria, gazing at the sprawling metropolis that glows softly under the starlit canvas above. A gentle breeze, carrying hints of exotic fragrances from unknown flora, greets you. 

You begin to walk along the radiant pathway, each cobblestone pulsating beneath your feet, resonating with a rhythm that seems almost alive. The cityscape ahead shimmers with countless shades of sapphire, amethyst, and turquoise, their reflections dancing upon the glassy surfaces of the spiraling towers around you. The air vibrates subtly with an underlying hum, a symphony of unseen energy sources powering this celestial city.

Approaching one of the spiraling edifices, you reach out to touch its surface. It feels unexpectedly warm, humming slightly under your fingertips. Its translucent walls ripple with colors, revealing glimpses of life within - shadowy figures moving about, engaging in activities that seem both mundane and extraordinary.

A creature, vaguely humanoid but adorned with shimmering scales and wings akin to a dragonfly’s, approaches you. It communicates not with words, but with melod
-----------
rejected_input_ids:
 	 <|im_start|>user
 The setting is an otherworldly, yet eerily familiar, metropolis known as "Zephyria." It's a city suspended in the ether, floating amidst nebulous clouds of cosmic dust. The architecture here is surreal and alien, with buildings that twist and spiral like strands of DNA, reaching towards the cosmos. Streets are paved with luminescent cobblestones, casting soft hues of blues and purples, reflecting off iridescent structures. Strange vegetation, vibrant and bioluminescent, thrives everywhere, creating a stark contrast against the deep indigo sky.

Now, immerse me in this ethereal journey through Zephyria. <|im_end|>
<|im_start|>assistant
As you step onto the teleportation platform, there's a momentary sense of disorientation before your surroundings change abruptly. You find yourself standing on the outskirts of Zephyria, gazing at the sprawling metropolis that glows softly under the starlit canvas above. A gentle breeze, carrying hints of exotic fragrances from unknown flora, greets you. 

You begin to walk along the radiant pathway, each cobblestone pulsating beneath your feet, resonating with a rhythm that seems almost alive. The cityscape ahead shimmers with countless shades of sapphire, amethyst, and turquoise, their reflections dancing upon the glassy surfaces of the spiraling towers around you. The air vibrates subtly with an underlying hum, a symphony of unseen energy sources powering this celestial city.

Approaching one of the spiraling edifices, you reach out to touch its surface. It feels unexpectedly warm, humming slightly under your fingertips. Its translucent walls ripple with colors, revealing glimpses of life within - shadowy figures moving about, engaging in activities that seem both mundane and extraordinary.

A creature, vaguely humanoid but adorned with shimmering scales and wings akin to a dragonfly’s, approaches you. It communicates not with words, but with melod
"""

```




#### Test plan

Loading in a chat dataset preference works as expected. I've added a test for the class.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of 
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
