### PR TITLE
Remove most of the PTQ receipe

### DIFF
--- a/docs/source/tutorials/e2e_flow.rst
+++ b/docs/source/tutorials/e2e_flow.rst
@@ -319,126 +319,19 @@ Bay Area!
 Speeding up Generation using Quantization
 -----------------------------------------
 
-We saw that the generation recipe took around 11.6 seconds to generate 300 tokens.
-One technique commonly used to speed up inference is quantization. torchtune provides
-an integration with the `TorchAO <https://github.com/pytorch-labs/ao>`_
-quantization APIs. Let's first quantize the model using 4-bit weights-only quantization
-and see if this improves generation speed.
+We rely on `TorchAO <https://github.com/pytorch-labs/ao>`_ for `post training quantization <https://github.com/pytorch/ao/tree/main/torchao/quantization#quantization>`_, please take the fine tuned model from torchtune and quantize them directly in ``TorchAO``, you can also run `eval/benchmark <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_. in torchao as well. For example::
 
+  # we also support `int8_weight_only()` and `int8_dynamic_activation_int8_weight()`, see
+  # https://github.com/pytorch/ao/tree/main/torchao/quantization#other-available-quantization-techniques
+  # for a full list of techniques that we support
+  from torchao.quantization.quant_api import quantize_, int4_weight_only
+  quantize_(m, int4_weight_only())
 
-For this, we'll use the
-`quantization recipe <https://github.com/pytorch/torchtune/blob/main/recipes/quantize.py>`_.
+After quantization, we rely on `torch.compile <https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#quantization-flow-example>`_ to get speedup.
 
+Please see `this table <https://github.com/pytorch/ao#inference>`_. for performance and accuracy results for ``llama2`` and ``llama3``.
 
-Let's first copy over the config to our local working directory so we can make changes.
-
-.. code-block:: bash
-
-    tune cp quantization ./custom_quantization_config.yaml
-
-Let's modify ``custom_quantization_config.yaml`` to include the following changes.
-
-.. code-block:: yaml
-
-    checkpointer:
-        _component_: torchtune.utils.FullModelHFCheckpointer
-
-        # directory with the checkpoint files
-        # this should match the output_dir specified during
-        # finetuning
-        checkpoint_dir: <checkpoint_dir>
-
-        # checkpoint files for the fine-tuned model. This should
-        # match what's shown in the logs above
-        checkpoint_files: [
-            hf_model_0001_0.pt,
-            hf_model_0002_0.pt,
-        ]
-
-        output_dir: <checkpoint_dir>
-        model_type: LLAMA2
-
-
-Once the config is updated, let's kick off quantization! We'll use the default
-quantization method from the config.
-
-
-.. code-block:: bash
-
-    tune run quantize --config ./custom_quantization_config.yaml
-
-Once quantization is complete, you'll see the following in the logs.
-
-.. code-block:: bash
-
-    [quantize.py:68] Time for quantization: 19.76 sec
-    [quantize.py:69] Memory used: 13.95 GB
-    [quantize.py:82] Model checkpoint of size 3.67 GB saved to <checkpoint_dir>/hf_model_0001_0-4w.pt
-
-
-.. note::
-    Unlike the fine-tuned checkpoints, this outputs a single checkpoint file. This is
-    because our quantization APIs currently don't support any conversion across formats.
-    As a result you won't be able to use these quantized models outside of torchtune.
-    But you should be able to use these with the generation and evaluation recipes within
-    torchtune. These results will help inform which quantization methods you should use
-    with your favorite inference engine.
-
-Now that we have the quantized model, let's re-run generation.
-
-Modify ``custom_generation_config.yaml`` to include the following changes.
-
-.. code-block:: yaml
-
-    checkpointer:
-        # we need to use the custom torchtune checkpointer
-        # instead of the HF checkpointer for loading
-        # quantized models
-        _component_: torchtune.utils.FullModelTorchTuneCheckpointer
-
-        # directory with the checkpoint files
-        # this should match the output_dir specified during
-        # finetuning
-        checkpoint_dir: <checkpoint_dir>
-
-        # checkpoint files point to the quantized model
-        checkpoint_files: [
-            hf_model_0001_0-4w.pt,
-        ]
-
-        output_dir: <checkpoint_dir>
-        model_type: LLAMA2
-
-    # we also need to update the quantizer to what was used during
-    # quantization
-    quantizer:
-        _component_: torchtune.utils.quantization.Int4WeightOnlyQuantizer
-        groupsize: 256
-
-
-Once the config is updated, let's kick off generation! We'll use the
-same sampling parameters as before. We'll also use the same prompt we did with the
-unquantized model.
-
-.. code-block:: bash
-
-    tune run generate --config ./custom_generation_config.yaml \
-    prompt="What are some interesting sites to visit in the Bay Area?"
-
-
-Once generation is complete, you'll see the following in the logs.
-
-
-.. code-block:: bash
-
-    [generate.py:92] A park in San Francisco that sits at the top of a big hill.
-                     There are lots of trees and a beautiful view of San Francisco...
-
-    [generate.py:96] Time for inference: 4.13 sec total, 72.62 tokens/sec
-    [generate.py:99] Memory used: 17.85 GB
-
-With quantization (and torch compile under the hood), we've sped up generation
-by almost 3x!
+Note: you can run generation in `torchao repo <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_ for ``llama2`` and ``llama3`` directly for now.
 
 |
 

--- a/docs/source/tutorials/e2e_flow.rst
+++ b/docs/source/tutorials/e2e_flow.rst
@@ -319,19 +319,22 @@ Bay Area!
 Speeding up Generation using Quantization
 -----------------------------------------
 
-We rely on `TorchAO <https://github.com/pytorch-labs/ao>`_ for `post training quantization <https://github.com/pytorch/ao/tree/main/torchao/quantization#quantization>`_, please take the fine tuned model from torchtune and quantize them directly in ``TorchAO``, you can also run `eval/benchmark <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_. in torchao as well. For example::
+We rely on `torchao <https://github.com/pytorch-labs/ao>`_ for `post-training quantization <https://github.com/pytorch/ao/tree/main/torchao/quantization#quantization>`_.
+To quantize the fine-tuned model after installing torchao we can run the following command::
 
   # we also support `int8_weight_only()` and `int8_dynamic_activation_int8_weight()`, see
   # https://github.com/pytorch/ao/tree/main/torchao/quantization#other-available-quantization-techniques
   # for a full list of techniques that we support
-  from torchao.quantization.quant_api import quantize_, int4_weight_only
-  quantize_(m, int4_weight_only())
+  from torchao.quantization.quant_api import quantize\_, int4_weight_only
+  quantize\_(model, int4_weight_only())
 
-After quantization, we rely on `torch.compile <https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#quantization-flow-example>`_ to get speedup.
+After quantization, we rely on torch.compile for speedups. For more details, please see `this example usage <https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#quantization-flow-example>`_.
 
-Please see `this table <https://github.com/pytorch/ao#inference>`_. for performance and accuracy results for ``llama2`` and ``llama3``.
+torchao also provides `this table <https://github.com/pytorch/ao#inference>`_ listing performance and accuracy results for ``llama2`` and ``llama3``.
 
-Note: you can run generation in `torchao repo <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_ for ``llama2`` and ``llama3`` directly for now.
+For Llama models, you can run generation directly in torchao on the quantized model using their ``generate.py`` script as
+discussed in `this readme <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_. This way you can compare your own results
+to those in the previously-linked table.
 
 |
 

--- a/docs/source/tutorials/llama3.rst
+++ b/docs/source/tutorials/llama3.rst
@@ -237,20 +237,22 @@ Running generation with our LoRA-finetuned model, we see the following output:
 Faster generation via quantization
 ----------------------------------
 
-We can see that the model took just under 11 seconds, generating almost 19 tokens per second.
-We rely on `TorchAO <https://github.com/pytorch-labs/ao>`_ for `post training quantization <https://github.com/pytorch/ao/tree/main/torchao/quantization#quantization>`_, please take the fine tuned model from torchtune and quantize them directly in ``TorchAO``, you can also run `eval/benchmark <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_. in torchao as well. For example::
+We rely on `torchao <https://github.com/pytorch-labs/ao>`_ for `post-training quantization <https://github.com/pytorch/ao/tree/main/torchao/quantization#quantization>`_.
+To quantize the fine-tuned model after installing torchao we can run the following command::
 
   # we also support `int8_weight_only()` and `int8_dynamic_activation_int8_weight()`, see
   # https://github.com/pytorch/ao/tree/main/torchao/quantization#other-available-quantization-techniques
   # for a full list of techniques that we support
-  from torchao.quantization.quant_api import quantize_, int4_weight_only
-  quantize_(m, int4_weight_only())
+  from torchao.quantization.quant_api import quantize\_, int4_weight_only
+  quantize\_(model, int4_weight_only())
 
-After quantization, we rely on `torch.compile <https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#quantization-flow-example>`_ to get speedup.
+After quantization, we rely on torch.compile for speedups. For more details, please see `this example usage <https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#quantization-flow-example>`_.
 
-Please see `this table <https://github.com/pytorch/ao#inference>`_. for performance and accuracy results for ``llama2`` and ``llama3``.
+torchao also provides `this table <https://github.com/pytorch/ao#inference>`_ listing performance and accuracy results for ``llama2`` and ``llama3``.
 
-Note: you can run generation in `torchao repo <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_ for ``llama2`` and ``llama3`` directly for now.
+For Llama models, you can run generation directly in torchao on the quantized model using their ``generate.py`` script as
+discussed in `this readme <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_. This way you can compare your own results
+to those in the previously-linked table.
 
 
 This is just the beginning of what you can do with Meta Llama3 using torchtune and the broader ecosystem.

--- a/docs/source/tutorials/llama3.rst
+++ b/docs/source/tutorials/llama3.rst
@@ -238,104 +238,20 @@ Faster generation via quantization
 ----------------------------------
 
 We can see that the model took just under 11 seconds, generating almost 19 tokens per second.
-We can speed this up a bit by quantizing our model. Here we'll use 4-bit weights-only quantization
-as provided by `torchao <https://github.com/pytorch-labs/ao>`_.
+We rely on `TorchAO <https://github.com/pytorch-labs/ao>`_ for `post training quantization <https://github.com/pytorch/ao/tree/main/torchao/quantization#quantization>`_, please take the fine tuned model from torchtune and quantize them directly in ``TorchAO``, you can also run `eval/benchmark <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_. in torchao as well. For example::
 
-If you've been following along this far, you know the drill by now.
-Let's copy the quantization config and point it at our fine-tuned model.
+  # we also support `int8_weight_only()` and `int8_dynamic_activation_int8_weight()`, see
+  # https://github.com/pytorch/ao/tree/main/torchao/quantization#other-available-quantization-techniques
+  # for a full list of techniques that we support
+  from torchao.quantization.quant_api import quantize_, int4_weight_only
+  quantize_(m, int4_weight_only())
 
-.. code-block:: bash
+After quantization, we rely on `torch.compile <https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#quantization-flow-example>`_ to get speedup.
 
-    tune cp quantization ./custom_quantization_config.yaml
+Please see `this table <https://github.com/pytorch/ao#inference>`_. for performance and accuracy results for ``llama2`` and ``llama3``.
 
-And update ``custom_quantization_config.yaml`` with the following:
+Note: you can run generation in `torchao repo <https://github.com/pytorch/ao/tree/main/torchao/_models/llama>`_ for ``llama2`` and ``llama3`` directly for now.
 
-.. code-block:: yaml
-
-    # Model arguments
-    model:
-      _component_: torchtune.models.llama3.llama3_8b
-
-    checkpointer:
-      _component_: torchtune.utils.FullModelMetaCheckpointer
-
-      # directory with the checkpoint files
-      # this should match the output_dir specified during
-      # fine-tuning
-      checkpoint_dir: <checkpoint_dir>
-
-      # checkpoint files for the fine-tuned model. These will be logged
-      # at the end of your fine-tune
-      checkpoint_files: [
-        meta_model_0.pt
-      ]
-
-      output_dir: <checkpoint_dir>
-      model_type: LLAMA3
-
-To quantize the model, we can now run:
-
-.. code-block:: bash
-
-    tune run quantize --config ./custom_quantization_config.yaml
-
-    [quantize.py:90] Time for quantization: 2.93 sec
-    [quantize.py:91] Memory used: 23.13 GB
-    [quantize.py:104] Model checkpoint of size 4.92 GB saved to /tmp/Llama-3-8B-Instruct-hf/consolidated-4w.pt
-
-We can see that the model is now under 5 GB, or just over four bits for each of the 8B parameters.
-
-.. note::
-    Unlike the fine-tuned checkpoints, the quantization recipe outputs a single checkpoint file. This is
-    because our quantization APIs currently don't support any conversion across formats.
-    As a result you won't be able to use these quantized models outside of torchtune.
-    But you should be able to use these with the generation and evaluation recipes within
-    torchtune. These results will help inform which quantization methods you should use
-    with your favorite inference engine.
-
-Let's take our quantized model and run the same generation again.
-First, we'll make one more change to our ``custom_generation_config.yaml``.
-
-.. code-block:: yaml
-
-    checkpointer:
-      # we need to use the custom torchtune checkpointer
-      # instead of the HF checkpointer for loading
-      # quantized models
-      _component_: torchtune.utils.FullModelTorchTuneCheckpointer
-
-      # directory with the checkpoint files
-      # this should match the output_dir specified during
-      # fine-tuning
-      checkpoint_dir: <checkpoint_dir>
-
-      # checkpoint files point to the quantized model
-      checkpoint_files: [
-        consolidated-4w.pt,
-      ]
-
-      output_dir: <checkpoint_dir>
-      model_type: LLAMA3
-
-    # we also need to update the quantizer to what was used during
-    # quantization
-    quantizer:
-      _component_: torchtune.utils.quantization.Int4WeightOnlyQuantizer
-      groupsize: 256
-
-Let's re-run generation!
-
-.. code-block:: bash
-
-    tune run generate --config ./custom_generation_config.yaml \
-    prompt="Hello, my name is"
-
-    [generate.py:122] Hello, my name is Jake.
-    I am a multi-disciplined artist with a passion for creating, drawing and painting.
-    ...
-    Time for inference: 1.62 sec total, 57.95 tokens/sec
-
-By quantizing the model and running ``torch.compile`` we get over a 3x speedup!
 
 This is just the beginning of what you can do with Meta Llama3 using torchtune and the broader ecosystem.
 We look forward to seeing what you build!

--- a/recipes/configs/quantization.yaml
+++ b/recipes/configs/quantization.yaml
@@ -24,5 +24,5 @@ dtype: bf16
 seed: 1234
 
 quantizer:
-  _component_: torchtune.utils.quantization.Int4WeightOnlyQuantizer
+  _component_: torchtune.utils.quantization.Int8DynActInt4WeightQuantizer
   groupsize: 256

--- a/recipes/quantization.md
+++ b/recipes/quantization.md
@@ -1,14 +1,11 @@
 # Quantization and Sparsity
 
-torchtune integrates with [torchao](https://github.com/pytorch/ao/) for architecture optimization techniques including quantization and sparsity. Currently only some quantization techniques are integrated, see the docstrings in the [quantization recipe](quantize.py) and the [QAT recipe](qat_distributed.py) for more details.
+torchtune integrates with [torchao](https://github.com/pytorch/ao/) for QAT and QLoRA. Currently only some quantization techniques are integrated, see the docstrings in the [quantization recipe](quantize.py) and the [QAT recipe](qat_distributed.py) for more details.
 
-#### Quantize
-To quantize a model (default is int4 weight only quantization):
-```
-tune run quantize --config quantization
-```
+For post training quantization, we recommend using `torchao` directly: https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md to quantize their model
+and do eval/benchmark in torchao as well: https://github.com/pytorch/ao/tree/main/torchao/_models/llama.
 
-#### Quantization-Aware Training (QAT)
+## Quantization-Aware Training (QAT)
 
 (PyTorch 2.4+)
 
@@ -35,8 +32,7 @@ is supported. This refers to int8 dynamic per token activation quantization
 combined with int4 grouped per axis weight quantization. For more details,
 please refer to the [torchao implementation](https://github.com/pytorch/ao/blob/950a89388e88e10f26bbbbe2ec0b1710ba3d33d1/torchao/quantization/prototype/qat.py#L22).
 
-
-#### Eval
+## Eval
 To evaluate a quantized model, make the following changes to the default [evaluation config](configs/eleuther_evaluation.yaml)
 
 
@@ -52,16 +48,18 @@ checkpointer:
 
 # Quantization specific args
 quantizer:
-  _component_: torchtune.utils.quantization.Int4WeightOnlyQuantizer
+  _component_: torchtune.utils.quantization.Int8DynActInt4WeightQuantizer
   groupsize: 256
 ```
+
+Noet: we can use `Int8DynActInt4WeightQuantizer` to load a QAT quantized model since it's the same type of quantization.
 
 and run evaluation:
 ```bash
 tune run eleuther_eval --config eleuther_evaluation
 ```
 
-#### Generate
+## Generate
 To run inference using a quantized model, make the following changes to the default [generation config](configs/generation.yaml)
 
 
@@ -77,7 +75,7 @@ checkpointer:
 
 # Quantization Arguments
 quantizer:
-  _component_: torchtune.utils.quantization.Int4WeightOnlyQuantizer
+  _component_: torchtune.utils.quantization.Int8DynActInt4WeightQuantizer
   groupsize: 256
 ```
 

--- a/recipes/quantize.py
+++ b/recipes/quantize.py
@@ -25,28 +25,6 @@ class QuantizationRecipe:
     Uses quantizer classes from torchao to quantize a model.
 
     Supported quantization modes are:
-    8w:
-        torchtune.utils.quantization.Int8WeightOnlyQuantizer
-        int8 weight only per axis group quantization
-
-    4w:
-        torchtune.utils.quantization.Int4WeightOnlyQuantizer
-        int4 weight only per axis group quantization
-        Args:
-            `groupsize` (int): a parameter of int4 weight only quantization,
-            it refers to the size of quantization groups which get independent quantization parameters
-            e.g. 32, 64, 128, 256, smaller numbers means more fine grained and higher accuracy
-
-    4w-gptq:
-        torchtune.utils.quantization.Int4WeightOnlyGPTQQuantizer
-        int4 weight only per axis group quantization with GPTQ
-        Args:
-            `groupsize`: see description in `4w`
-            `blocksize`: GPTQ is applied to a 'block' of columns at a time,
-                larger blocks trade off memory for perf, recommended to be a constant
-                multiple of groupsize.
-            `percdamp`: GPTQ stablization hyperparameter, recommended to be .01
-
     8da4w (PyTorch 2.3+):
         torchtune.utils.quantization.Int8DynActInt4WeightQuantizer
         int8 per token dynamic activation with int4 weight only per axis group quantization

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -4,26 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, Optional
-
-import torch
-from torchao.quantization.quant_api import (
-    Int4WeightOnlyGPTQQuantizer,
-    Int4WeightOnlyQuantizer,
-    Quantizer,
-)
-
-from torchtune.modules.low_precision._utils import (
-    _get_torchao_version,
-    _is_fbcode,
-    _nightly_version_ge,
-)
-
-ao_version, is_nightly = _get_torchao_version()
-if _is_fbcode() or (is_nightly and _nightly_version_ge(ao_version, "2024-07-03")):
-    from torchao.quantization.quant_api import quantize_ as quantize
-else:
-    from torchao.quantization.quant_api import quantize
+from typing import Callable, Optional
 
 # importing TORCH_VERSION_AFTER_2_3 because `Int8DynActInt4WeightQuantizer`
 # is only available after 2.3 so we have to guard the pytorch versions to decide
@@ -31,25 +12,11 @@ else:
 from torchao.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4
 
 __all__ = [
-    "Int4WeightOnlyQuantizer",
-    "Int4WeightOnlyGPTQQuantizer",
-    "Int8WeightOnlyQuantizer",
     "get_quantizer_mode",
 ]
 
 
-class Int8WeightOnlyQuantizer(Quantizer):
-    def quantize(
-        self, model: torch.nn.Module, *args: Any, **kwargs: Any
-    ) -> torch.nn.Module:
-        return quantize(model, "int8_weight_only")
-
-
-_quantizer_to_mode = {
-    Int4WeightOnlyQuantizer: "4w",
-    Int8WeightOnlyQuantizer: "8w",
-    Int4WeightOnlyGPTQQuantizer: "4w-gptq",
-}
+_quantizer_to_mode = {}
 _quantizer_mode_to_disable_fake_quant = {}
 _quantizer_mode_to_enable_fake_quant = {}
 
@@ -82,9 +49,6 @@ def get_quantizer_mode(quantizer: Optional[Callable]) -> Optional[str]:
 
     Currently supported:
 
-    - :class:`~torchao.quantization.quant_api.Int4WeightOnlyQuantizer`: "4w"
-    - :class:`~torchao.quantization.quant_api.Int8WeightOnlyQuantizer`: "8w"
-    - :class:`~torchao.quantization.quant_api.Int4WeightOnlyGPTQQuantizer`: "4w-gptq"
     - :class:`~torchao.quantization.quant_api.Int8DynActInt4WeightQuantizer`: "8da4w" (requires ``torch>=2.3.0``)
     - :class:`~torchao.quantization.prototype.qat.Int8DynActInt4WeightQATQuantizer`: "8da4w-qat" (requires ``torch>=2.4.0``)
 
@@ -111,6 +75,3 @@ def _get_enable_fake_quant(quantizer_mode: str) -> Callable:
     If the quantizer is not recognized as a known QAT quantizer, return None.
     """
     return _quantizer_mode_to_enable_fake_quant.get(quantizer_mode, None)
-
-
-# test-codev


### PR DESCRIPTION
Summary:
We want to decouple PTQ and torchtune, to avoid headaches of torchao API changes breaking torchtune. Also curernt PTQ APIs in torchtune is not the most up to date ones, by removing them we could deprecate these API in torchao as well.

8da4w ptq is kept because it's used in QAT, but it can be removed after QAT is refactored as well.

User should use torchao directly after torchtune finetuning: https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md to quantize their model
and do eval/benchmark in torchao as well: https://github.com/pytorch/ao/tree/main/torchao/_models/llama

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags:

#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

Deprecate old APIs

#### Changelog
What are the changes made in this PR?

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
