### PR TITLE
Added adapter_only option to LoRA

### DIFF
--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -404,6 +404,11 @@ looks something like this:
     # set to True if restarting training
     resume_from_checkpoint: True
 
+    # adapter_only option
+    # Set to True to save only the adapter weights for intermediate epochs.
+    # For the final epoch, the entire model weights will be saved regardless of this option.
+    adapter_only: False
+
 |
 
 Putting this all together

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -404,10 +404,8 @@ looks something like this:
     # set to True if restarting training
     resume_from_checkpoint: True
 
-    # adapter_only option
-    # Set to True to save only the adapter weights for intermediate epochs.
-    # For the final epoch, the entire model weights will be saved regardless of this option.
-    adapter_only: False
+    # Set to True to save only the adapter weights
+    save_adapter_weights_only: False
 
 |
 

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -361,7 +361,7 @@ Checkpointing for LoRA
 In torchtune, we output both the adapter weights and the full model "merged" weights
 for LoRA. The "merged" checkpoint can be used just like you would use the source
 checkpoint with any post-training tools. For more details, take a look at our
-:ref:`LoRA Finetuning Tutorial <lora_finetune_label>`.
+:ref:`LoRA Finetuning Tutorial <lora_finetune_label>`.Additionally, by setting the option "save_adapter_weights_only" to True when saving a checkpoint, you can choose to save only the adapter weights.
 
 The primary difference between the two use cases is when you want to resume training
 from a checkpoint. In this case, the checkpointer needs access to both the initial frozen

--- a/recipes/configs/code_llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/code_llama2/7B_lora_single_device.yaml
@@ -49,7 +49,7 @@ checkpointer:
   output_dir: /tmp/CodeLlama-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Fine-tuning arguments
 batch_size: 2

--- a/recipes/configs/code_llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/code_llama2/7B_lora_single_device.yaml
@@ -49,6 +49,7 @@ checkpointer:
   output_dir: /tmp/CodeLlama-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Fine-tuning arguments
 batch_size: 2

--- a/recipes/configs/code_llama2/7B_qlora_single_device.yaml
+++ b/recipes/configs/code_llama2/7B_qlora_single_device.yaml
@@ -49,7 +49,7 @@ checkpointer:
   output_dir: /tmp/CodeLlama-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Fine-tuning arguments and training
 batch_size: 2

--- a/recipes/configs/code_llama2/7B_qlora_single_device.yaml
+++ b/recipes/configs/code_llama2/7B_qlora_single_device.yaml
@@ -49,6 +49,7 @@ checkpointer:
   output_dir: /tmp/CodeLlama-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Fine-tuning arguments and training
 batch_size: 2

--- a/recipes/configs/dev/llama2/13B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/13B_lora_fsdp2.yaml
@@ -45,6 +45,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-13b-hf/
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Tokenizer
 tokenizer:

--- a/recipes/configs/dev/llama2/13B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/13B_lora_fsdp2.yaml
@@ -45,7 +45,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-13b-hf/
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Tokenizer
 tokenizer:

--- a/recipes/configs/dev/llama2/70B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_lora_fsdp2.yaml
@@ -50,7 +50,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-70b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/dev/llama2/70B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_lora_fsdp2.yaml
@@ -50,6 +50,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-70b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
@@ -50,7 +50,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-70b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
@@ -50,6 +50,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-70b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/dev/llama2/7B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/7B_lora_fsdp2.yaml
@@ -47,6 +47,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/dev/llama2/7B_lora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/7B_lora_fsdp2.yaml
@@ -47,7 +47,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
@@ -46,6 +46,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/7B_qlora_fsdp2.yaml
@@ -46,7 +46,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/gemma/2B_lora.yaml
+++ b/recipes/configs/gemma/2B_lora.yaml
@@ -46,6 +46,7 @@ checkpointer:
   output_dir: /tmp/gemma-2b
   model_type: GEMMA
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/2B_lora.yaml
+++ b/recipes/configs/gemma/2B_lora.yaml
@@ -46,7 +46,7 @@ checkpointer:
   output_dir: /tmp/gemma-2b
   model_type: GEMMA
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/2B_lora_single_device.yaml
+++ b/recipes/configs/gemma/2B_lora_single_device.yaml
@@ -45,6 +45,7 @@ checkpointer:
   output_dir: /tmp/gemma-2b
   model_type: GEMMA
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/2B_lora_single_device.yaml
+++ b/recipes/configs/gemma/2B_lora_single_device.yaml
@@ -45,7 +45,7 @@ checkpointer:
   output_dir: /tmp/gemma-2b
   model_type: GEMMA
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/2B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/2B_qlora_single_device.yaml
@@ -45,6 +45,7 @@ checkpointer:
   output_dir: /tmp/gemma-2b
   model_type: GEMMA
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/2B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/2B_qlora_single_device.yaml
@@ -45,7 +45,7 @@ checkpointer:
   output_dir: /tmp/gemma-2b
   model_type: GEMMA
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/7B_lora.yaml
+++ b/recipes/configs/gemma/7B_lora.yaml
@@ -48,7 +48,7 @@ checkpointer:
   output_dir: /tmp/gemma-7b/
   model_type: GEMMA
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/7B_lora.yaml
+++ b/recipes/configs/gemma/7B_lora.yaml
@@ -48,6 +48,7 @@ checkpointer:
   output_dir: /tmp/gemma-7b/
   model_type: GEMMA
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/7B_lora_single_device.yaml
+++ b/recipes/configs/gemma/7B_lora_single_device.yaml
@@ -47,6 +47,7 @@ checkpointer:
   output_dir: /tmp/gemma-7b/
   model_type: GEMMA
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/7B_lora_single_device.yaml
+++ b/recipes/configs/gemma/7B_lora_single_device.yaml
@@ -47,7 +47,7 @@ checkpointer:
   output_dir: /tmp/gemma-7b/
   model_type: GEMMA
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/7B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/7B_qlora_single_device.yaml
@@ -47,6 +47,7 @@ checkpointer:
   output_dir: /tmp/gemma-7b/
   model_type: GEMMA
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/gemma/7B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/7B_qlora_single_device.yaml
@@ -47,7 +47,7 @@ checkpointer:
   output_dir: /tmp/gemma-7b/
   model_type: GEMMA
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/llama2/13B_lora.yaml
+++ b/recipes/configs/llama2/13B_lora.yaml
@@ -41,6 +41,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-13b-hf/
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Tokenizer
 tokenizer:

--- a/recipes/configs/llama2/13B_lora.yaml
+++ b/recipes/configs/llama2/13B_lora.yaml
@@ -41,7 +41,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-13b-hf/
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Tokenizer
 tokenizer:

--- a/recipes/configs/llama2/13B_qlora_single_device.yaml
+++ b/recipes/configs/llama2/13B_qlora_single_device.yaml
@@ -41,7 +41,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-13b-hf/
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/13B_qlora_single_device.yaml
+++ b/recipes/configs/llama2/13B_qlora_single_device.yaml
@@ -41,6 +41,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-13b-hf/
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -46,7 +46,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-70b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -46,6 +46,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-70b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora.yaml
+++ b/recipes/configs/llama2/7B_lora.yaml
@@ -43,7 +43,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora.yaml
+++ b/recipes/configs/llama2/7B_lora.yaml
@@ -43,6 +43,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora_dpo.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo.yaml
@@ -43,7 +43,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora_dpo.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo.yaml
@@ -43,6 +43,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
@@ -18,7 +18,7 @@
 # Model Arguments
 model:
   _component_: torchtune.models.llama2.lora_llama2_7b
-  lora_attn_modules: ['q_proj', 'v_proj']
+  lora_attn_modules: ["q_proj", "v_proj"]
   apply_lora_to_mlp: False
   apply_lora_to_output: False
   lora_rank: 8
@@ -42,6 +42,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
@@ -42,7 +42,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_dpo_single_device.yaml
@@ -18,7 +18,7 @@
 # Model Arguments
 model:
   _component_: torchtune.models.llama2.lora_llama2_7b
-  lora_attn_modules: ["q_proj", "v_proj"]
+  lora_attn_modules: ['q_proj', 'v_proj']
   apply_lora_to_mlp: False
   apply_lora_to_output: False
   lora_rank: 8

--- a/recipes/configs/llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_single_device.yaml
@@ -41,7 +41,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_single_device.yaml
@@ -41,6 +41,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_qlora_single_device.yaml
+++ b/recipes/configs/llama2/7B_qlora_single_device.yaml
@@ -40,7 +40,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama2/7B_qlora_single_device.yaml
+++ b/recipes/configs/llama2/7B_qlora_single_device.yaml
@@ -40,6 +40,7 @@ checkpointer:
   output_dir: /tmp/Llama-2-7b-hf
   model_type: LLAMA2
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/70B_lora.yaml
+++ b/recipes/configs/llama3/70B_lora.yaml
@@ -61,6 +61,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-70B-Instruct
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/70B_lora.yaml
+++ b/recipes/configs/llama3/70B_lora.yaml
@@ -61,7 +61,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-70B-Instruct
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/8B_lora.yaml
+++ b/recipes/configs/llama3/8B_lora.yaml
@@ -41,6 +41,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/8B_lora.yaml
+++ b/recipes/configs/llama3/8B_lora.yaml
@@ -41,7 +41,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/8B_lora_single_device.yaml
+++ b/recipes/configs/llama3/8B_lora_single_device.yaml
@@ -40,7 +40,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/8B_lora_single_device.yaml
+++ b/recipes/configs/llama3/8B_lora_single_device.yaml
@@ -40,6 +40,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -39,7 +39,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -39,6 +39,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/70B_lora.yaml
+++ b/recipes/configs/llama3_1/70B_lora.yaml
@@ -60,7 +60,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-70B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/70B_lora.yaml
+++ b/recipes/configs/llama3_1/70B_lora.yaml
@@ -60,6 +60,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-70B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/8B_lora.yaml
+++ b/recipes/configs/llama3_1/8B_lora.yaml
@@ -44,7 +44,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/8B_lora.yaml
+++ b/recipes/configs/llama3_1/8B_lora.yaml
@@ -44,6 +44,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/8B_lora_single_device.yaml
+++ b/recipes/configs/llama3_1/8B_lora_single_device.yaml
@@ -43,7 +43,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/8B_lora_single_device.yaml
+++ b/recipes/configs/llama3_1/8B_lora_single_device.yaml
@@ -43,6 +43,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3_1/8B_qlora_single_device.yaml
@@ -42,7 +42,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3_1/8B_qlora_single_device.yaml
@@ -42,6 +42,7 @@ checkpointer:
   output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
   model_type: LLAMA3
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -53,7 +53,7 @@ checkpointer:
   output_dir: /tmp/Mistral-7B-v0.1
   model_type: MISTRAL
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/mistral/7B_lora.yaml
+++ b/recipes/configs/mistral/7B_lora.yaml
@@ -53,6 +53,7 @@ checkpointer:
   output_dir: /tmp/Mistral-7B-v0.1
   model_type: MISTRAL
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/mistral/7B_lora_single_device.yaml
+++ b/recipes/configs/mistral/7B_lora_single_device.yaml
@@ -50,6 +50,7 @@ checkpointer:
   output_dir: /tmp/Mistral-7B-v0.1
   model_type: MISTRAL
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/mistral/7B_lora_single_device.yaml
+++ b/recipes/configs/mistral/7B_lora_single_device.yaml
@@ -50,7 +50,7 @@ checkpointer:
   output_dir: /tmp/Mistral-7B-v0.1
   model_type: MISTRAL
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/mistral/7B_qlora_single_device.yaml
+++ b/recipes/configs/mistral/7B_qlora_single_device.yaml
@@ -51,7 +51,7 @@ checkpointer:
   output_dir: /tmp/Mistral-7B-v0.1
   model_type: MISTRAL
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/mistral/7B_qlora_single_device.yaml
+++ b/recipes/configs/mistral/7B_qlora_single_device.yaml
@@ -51,6 +51,7 @@ checkpointer:
   output_dir: /tmp/Mistral-7B-v0.1
   model_type: MISTRAL
 resume_from_checkpoint: False
+adapter_only: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/phi3/mini_lora.yaml
+++ b/recipes/configs/phi3/mini_lora.yaml
@@ -42,6 +42,7 @@ checkpointer:
   output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/phi3/mini_lora.yaml
+++ b/recipes/configs/phi3/mini_lora.yaml
@@ -42,7 +42,7 @@ checkpointer:
   output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/phi3/mini_lora_single_device.yaml
+++ b/recipes/configs/phi3/mini_lora_single_device.yaml
@@ -40,6 +40,7 @@ checkpointer:
   output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/phi3/mini_lora_single_device.yaml
+++ b/recipes/configs/phi3/mini_lora_single_device.yaml
@@ -40,7 +40,7 @@ checkpointer:
   output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/phi3/mini_qlora_single_device.yaml
+++ b/recipes/configs/phi3/mini_qlora_single_device.yaml
@@ -39,7 +39,7 @@ checkpointer:
   output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
-adapter_only: False
+save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/phi3/mini_qlora_single_device.yaml
+++ b/recipes/configs/phi3/mini_qlora_single_device.yaml
@@ -39,6 +39,7 @@ checkpointer:
   output_dir: /tmp/Phi-3-mini-4k-instruct
   model_type: PHI3_MINI
 resume_from_checkpoint: False
+adapter_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -539,7 +539,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     "Saving final model checkpoint."
                     "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                     "You need to merge the adapter weights into your base model for further use. "
-                    "See {where do we point them for now??}"
+                    "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
                 )
 
     def concatenated_forward(

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -143,6 +143,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self.global_step = 0
 
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
+        self._adapter_only = cfg.get("adapter_only", False)
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
@@ -526,11 +527,20 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     }
                 )
 
-            self._checkpointer.save_checkpoint(
-                checkpoint_dict,
-                epoch=epoch,
-                intermediate_checkpoint=intermediate_checkpoint,
-            )
+            # If the option was True, save only the adapter except for the last epoch
+            if self._adapter_only and epoch + 1 < self.total_epochs:
+                self._checkpointer.save_checkpoint(
+                    checkpoint_dict,
+                    epoch=epoch,
+                    intermediate_checkpoint=(epoch + 1 < self.total_epochs),
+                    adapter_only=True,
+                )
+            else:
+                self._checkpointer.save_checkpoint(
+                    checkpoint_dict,
+                    epoch=epoch,
+                    intermediate_checkpoint=(epoch + 1 < self.total_epochs),
+                )
 
     def concatenated_forward(
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -539,7 +539,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     "Saving final model checkpoint."
                     "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                     "You need to merge the adapter weights into your base model for further use. "
-                    "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
+                    f"See {type(self._checkpointer).__name__}"
                 )
 
     def concatenated_forward(

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -141,11 +141,8 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
-
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
-        log.info(f"save_adapter_weights_only: {self._save_adapter_weights_only}")
-
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
@@ -535,12 +532,18 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 adapter_only=self._save_adapter_weights_only,
             )
             if not is_intermediate_epoch:
-                log.info(
-                    "Saving final model checkpoint."
-                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                    "You need to merge the adapter weights into your base model for further use. "
-                    f"See {type(self._checkpointer).__name__}"
-                )
+                log.ingo("Saving final epoch checkpoint.")
+                if self._save_adapter_weights_only:
+                    log.info(
+                        "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
+                        "You need to merge the adapter weights into your base model for further use. "
+                        f"See {type(self._checkpointer).__name__}"
+                    )
+                else:
+                    log.info(
+                        "The full model checkpoint, including all weights and configurations, has been saved successfully."
+                        "You can now use this checkpoint for further training or inference."
+                    )
 
     def concatenated_forward(
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -537,7 +537,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             if not is_intermediate_epoch:
                 log.info(
                     "Saving final model checkpoint."
-                    "Please note that you have set save_adapter_only=True, so only adapter weights will be saved."
+                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                     "You need to merge the adapter weights into your base model for further use. "
                     "See {where do we point them for now??}"
                 )

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -531,19 +531,6 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 intermediate_checkpoint=is_intermediate_epoch,
                 adapter_only=self._save_adapter_weights_only,
             )
-            if not is_intermediate_epoch:
-                log.ingo("Saving final epoch checkpoint.")
-                if self._save_adapter_weights_only:
-                    log.info(
-                        "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                        "You need to merge the adapter weights into your base model for further use. "
-                        f"See {type(self._checkpointer).__name__}"
-                    )
-                else:
-                    log.info(
-                        "The full model checkpoint, including all weights and configurations, has been saved successfully."
-                        "You can now use this checkpoint for further training or inference."
-                    )
 
     def concatenated_forward(
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -472,9 +472,13 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         - Adapter weights with key ADAPTER_KEY
         - Relevant recipe state if training is not complete
 
-        Checkpointer will save the merged weights, adapter weights and recipe state in
-        different checkpoint files. To correctly resume from training, the adapter weights
-        and recipe state must be provided along with the base model weights.
+        If the `self._adapter_only` option is True, the checkpointer will:
+        - Save only the adapter weights for all epochs except the final epoch
+        - Save the complete state (merged weights, adapter weights, and recipe state) for the final epoch only
+
+        If the `self._adapter_only` option is False, the checkpointer will save the complete state for all epochs.
+
+        To correctly resume from training, the adapter weights and recipe state must be provided along with the base model weights.
         """
         # final dict passed onto the checkpointer
         checkpoint_dict = {}
@@ -528,18 +532,19 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 )
 
             # If the option was True, save only the adapter except for the last epoch
-            if self._adapter_only and epoch + 1 < self.total_epochs:
+            is_intermediate_epoch = epoch + 1 < self.total_epochs
+            if self._adapter_only and is_intermediate_epoch:
                 self._checkpointer.save_checkpoint(
                     checkpoint_dict,
                     epoch=epoch,
-                    intermediate_checkpoint=(epoch + 1 < self.total_epochs),
+                    intermediate_checkpoint=is_intermediate_epoch,
                     adapter_only=True,
                 )
             else:
                 self._checkpointer.save_checkpoint(
                     checkpoint_dict,
                     epoch=epoch,
-                    intermediate_checkpoint=(epoch + 1 < self.total_epochs),
+                    intermediate_checkpoint=is_intermediate_epoch,
                 )
 
     def concatenated_forward(

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -105,7 +105,9 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self.global_step = 0
 
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
-        self._adapter_only = cfg.get("adapter_only", False)
+        self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
+        log.info(f"save_adapter_weights_only: {self._save_adapter_weights_only}")
+
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
@@ -362,18 +364,15 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         - Merged weights with key MODEL_KEY
         - Adapter weights with key ADAPTER_KEY
         - Relevant recipe state if training is not complete
-
-        If the `self._adapter_only` option is True, the checkpointer will:
-        - Save only the adapter weights for all epochs except the final epoch
-        - Save the complete state (merged weights, adapter weights, and recipe state) for the final epoch only
-
-        If the `self._adapter_only` option is False, the checkpointer will save the complete state for all epochs.
+        - If the `self._save_adapter_weights_only` option is True, the checkpointer will save only the adapter weights
 
         To correctly resume from training, the adapter weights and recipe state must be provided along with the base model weights.
         """
         ckpt_dict = {}
+
+        is_intermediate_epoch = epoch + 1 < self.total_epochs
         # if training is in-progress, checkpoint the optimizer state as well
-        if epoch + 1 < self.total_epochs:
+        if is_intermediate_epoch:
             ckpt_dict.update(
                 {
                     utils.OPT_KEY: self._optimizer.state_dict(),
@@ -402,20 +401,18 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         }
         ckpt_dict.update({utils.ADAPTER_KEY: adapter_state_dict})
 
-        # If the option was True, save only the adapter except for the last epoch
-        is_intermediate_epoch = epoch + 1 < self.total_epochs
-        if self._adapter_only and is_intermediate_epoch:
-            self._checkpointer.save_checkpoint(
-                ckpt_dict,
-                epoch=epoch,
-                intermediate_checkpoint=is_intermediate_epoch,
-                adapter_only=True,
-            )
-        else:
-            self._checkpointer.save_checkpoint(
-                ckpt_dict,
-                epoch=epoch,
-                intermediate_checkpoint=is_intermediate_epoch,
+        self._checkpointer.save_checkpoint(
+            ckpt_dict,
+            epoch=epoch,
+            intermediate_checkpoint=is_intermediate_epoch,
+            adapter_only=self._save_adapter_weights_only,
+        )
+        if not is_intermediate_epoch:
+            log.info(
+                "Saving final model checkpoint."
+                "Please note that you have set save_adapter_only=True, so only adapter weights will be saved."
+                "You need to merge the adapter weights into your base model for further use. "
+                "See {where do we point them for now??}"
             )
 
     def concatenated_forward(

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -404,19 +404,6 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             intermediate_checkpoint=is_intermediate_epoch,
             adapter_only=self._save_adapter_weights_only,
         )
-        if not is_intermediate_epoch:
-            log.ingo("Saving final epoch checkpoint.")
-            if self._save_adapter_weights_only:
-                log.info(
-                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                    "You need to merge the adapter weights into your base model for further use. "
-                    f"See {type(self._checkpointer).__name__}"
-                )
-            else:
-                log.info(
-                    "The full model checkpoint, including all weights and configurations, has been saved successfully."
-                    "You can now use this checkpoint for further training or inference."
-                )
 
     def concatenated_forward(
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -412,7 +412,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                 "Saving final model checkpoint."
                 "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                 "You need to merge the adapter weights into your base model for further use. "
-                "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
+                f"See {type(self._checkpointer).__name__}"
             )
 
     def concatenated_forward(

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -412,7 +412,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                 "Saving final model checkpoint."
                 "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                 "You need to merge the adapter weights into your base model for further use. "
-                "See {where do we point them for now??}"
+                "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
             )
 
     def concatenated_forward(

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -103,11 +103,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
-
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
-        log.info(f"save_adapter_weights_only: {self._save_adapter_weights_only}")
-
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
@@ -408,12 +405,18 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             adapter_only=self._save_adapter_weights_only,
         )
         if not is_intermediate_epoch:
-            log.info(
-                "Saving final model checkpoint."
-                "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                "You need to merge the adapter weights into your base model for further use. "
-                f"See {type(self._checkpointer).__name__}"
-            )
+            log.ingo("Saving final epoch checkpoint.")
+            if self._save_adapter_weights_only:
+                log.info(
+                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
+                    "You need to merge the adapter weights into your base model for further use. "
+                    f"See {type(self._checkpointer).__name__}"
+                )
+            else:
+                log.info(
+                    "The full model checkpoint, including all weights and configurations, has been saved successfully."
+                    "You can now use this checkpoint for further training or inference."
+                )
 
     def concatenated_forward(
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -367,9 +367,9 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         """
         ckpt_dict = {}
 
-        is_intermediate_epoch = epoch + 1 < self.total_epochs
+        intermediate_checkpoint = epoch + 1 < self.total_epochs
         # if training is in-progress, checkpoint the optimizer state as well
-        if is_intermediate_epoch:
+        if intermediate_checkpoint:
             ckpt_dict.update(
                 {
                     utils.OPT_KEY: self._optimizer.state_dict(),
@@ -401,7 +401,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self._checkpointer.save_checkpoint(
             ckpt_dict,
             epoch=epoch,
-            intermediate_checkpoint=is_intermediate_epoch,
+            intermediate_checkpoint=intermediate_checkpoint,
             adapter_only=self._save_adapter_weights_only,
         )
 

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -410,7 +410,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         if not is_intermediate_epoch:
             log.info(
                 "Saving final model checkpoint."
-                "Please note that you have set save_adapter_only=True, so only adapter weights will be saved."
+                "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                 "You need to merge the adapter weights into your base model for further use. "
                 "See {where do we point them for now??}"
             )

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -618,7 +618,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     "Saving final model checkpoint."
                     "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                     "You need to merge the adapter weights into your base model for further use. "
-                    "See {where do we point them for now??}"
+                    "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
                 )
 
     def train(self) -> None:

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -544,7 +544,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # final dict passed onto the checkpointer
         checkpoint_dict = {}
 
-        is_intermediate_epoch = epoch + 1 < self.total_epochs
+        intermediate_checkpoint = epoch + 1 < self.total_epochs
         # To prevent GPU memory from spiking during checkpoint save,
         # we consolidate the full model and optim state dicts on CPU for rank 0
         with FSDP.state_dict_type(
@@ -554,7 +554,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             FullOptimStateDictConfig(offload_to_cpu=True, rank0_only=True),
         ):
             cpu_state_dict = self._model.state_dict()
-            if is_intermediate_epoch:
+            if intermediate_checkpoint:
                 opt_state_dict = FSDP.optim_state_dict(self._model, self._optimizer)
             else:
                 opt_state_dict = None
@@ -581,7 +581,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
             # if training is in-progress, checkpoint the optimizer state and recipe state
             # as well.
-            if is_intermediate_epoch:
+            if intermediate_checkpoint:
                 checkpoint_dict.update(
                     {
                         utils.OPT_KEY: opt_state_dict,
@@ -607,7 +607,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             self._checkpointer.save_checkpoint(
                 checkpoint_dict,
                 epoch=epoch,
-                intermediate_checkpoint=is_intermediate_epoch,
+                intermediate_checkpoint=intermediate_checkpoint,
                 adapter_only=self._save_adapter_weights_only,
             )
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -539,9 +539,13 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         - Adapter weights with key ADAPTER_KEY
         - Relevant recipe state if training is not complete
 
-        Checkpointer will save the merged weights, adapter weights and recipe state in
-        different checkpoint files. To correctly resume from training, the adapter weights
-        and recipe state must be provided along with the base model weights.
+        If the `self._adapter_only` option is True, the checkpointer will:
+        - Save only the adapter weights for all epochs except the final epoch
+        - Save the complete state (merged weights, adapter weights, and recipe state) for the final epoch only
+
+        If the `self._adapter_only` option is False, the checkpointer will save the complete state for all epochs.
+
+        To correctly resume from training, the adapter weights and recipe state must be provided along with the base model weights.
         """
         # final dict passed onto the checkpointer
         checkpoint_dict = {}
@@ -607,18 +611,19 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             checkpoint_dict.update({utils.ADAPTER_CONFIG: adapter_config})
 
             # If the option was True, save only the adapter except for the last epoch
-            if self._adapter_only and epoch + 1 < self.total_epochs:
+            is_intermediate_epoch = epoch + 1 < self.total_epochs
+            if self._adapter_only and is_intermediate_epoch:
                 self._checkpointer.save_checkpoint(
                     checkpoint_dict,
                     epoch=epoch,
-                    intermediate_checkpoint=(epoch + 1 < self.total_epochs),
+                    intermediate_checkpoint=is_intermediate_epoch,
                     adapter_only=True,
                 )
             else:
                 self._checkpointer.save_checkpoint(
                     checkpoint_dict,
                     epoch=epoch,
-                    intermediate_checkpoint=(epoch + 1 < self.total_epochs),
+                    intermediate_checkpoint=is_intermediate_epoch,
                 )
 
     def train(self) -> None:

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -135,11 +135,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
-
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
-        log.info(f"save_adapter_weights_only: {self._save_adapter_weights_only}")
-
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
@@ -614,12 +611,18 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 adapter_only=self._save_adapter_weights_only,
             )
             if not is_intermediate_epoch:
-                log.info(
-                    "Saving final model checkpoint."
-                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                    "You need to merge the adapter weights into your base model for further use. "
-                    f"See {type(self._checkpointer).__name__}"
-                )
+                log.ingo("Saving final epoch checkpoint.")
+                if self._save_adapter_weights_only:
+                    log.info(
+                        "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
+                        "You need to merge the adapter weights into your base model for further use. "
+                        f"See {type(self._checkpointer).__name__}"
+                    )
+                else:
+                    log.info(
+                        "The full model checkpoint, including all weights and configurations, has been saved successfully."
+                        "You can now use this checkpoint for further training or inference."
+                    )
 
     def train(self) -> None:
         """

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -618,7 +618,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     "Saving final model checkpoint."
                     "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                     "You need to merge the adapter weights into your base model for further use. "
-                    "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
+                    f"See {type(self._checkpointer).__name__}"
                 )
 
     def train(self) -> None:

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -616,7 +616,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             if not is_intermediate_epoch:
                 log.info(
                     "Saving final model checkpoint."
-                    "Please note that you have set save_adapter_only=True, so only adapter weights will be saved."
+                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                     "You need to merge the adapter weights into your base model for further use. "
                     "See {where do we point them for now??}"
                 )

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -610,19 +610,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 intermediate_checkpoint=is_intermediate_epoch,
                 adapter_only=self._save_adapter_weights_only,
             )
-            if not is_intermediate_epoch:
-                log.ingo("Saving final epoch checkpoint.")
-                if self._save_adapter_weights_only:
-                    log.info(
-                        "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                        "You need to merge the adapter weights into your base model for further use. "
-                        f"See {type(self._checkpointer).__name__}"
-                    )
-                else:
-                    log.info(
-                        "The full model checkpoint, including all weights and configurations, has been saved successfully."
-                        "You can now use this checkpoint for further training or inference."
-                    )
 
     def train(self) -> None:
         """

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -530,7 +530,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 "Saving final model checkpoint."
                 "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                 "You need to merge the adapter weights into your base model for further use. "
-                "See {where do we point them for now??}"
+                "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
             )
 
     def train(self) -> None:

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -528,7 +528,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         if not is_intermediate_epoch:
             log.info(
                 "Saving final model checkpoint."
-                "Please note that you have set save_adapter_only=True, so only adapter weights will be saved."
+                "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                 "You need to merge the adapter weights into your base model for further use. "
                 "See {where do we point them for now??}"
             )

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -474,9 +474,9 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         """
         ckpt_dict = {}
 
-        is_intermediate_epoch = epoch + 1 < self.total_epochs
+        intermediate_checkpoint = epoch + 1 < self.total_epochs
         # if training is in-progress, checkpoint the optimizer state as well
-        if is_intermediate_epoch:
+        if intermediate_checkpoint:
             ckpt_dict.update(
                 {
                     utils.OPT_KEY: self._optimizer.state_dict(),
@@ -519,7 +519,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._checkpointer.save_checkpoint(
             ckpt_dict,
             epoch=epoch,
-            intermediate_checkpoint=is_intermediate_epoch,
+            intermediate_checkpoint=intermediate_checkpoint,
             adapter_only=self._save_adapter_weights_only,
         )
 

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -530,7 +530,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 "Saving final model checkpoint."
                 "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
                 "You need to merge the adapter weights into your base model for further use. "
-                "See 'https://github.com/pytorch/torchtune/blob/main/docs/source/deep_dives/checkpointer.rst'"
+                f"See {type(self._checkpointer).__name__}"
             )
 
     def train(self) -> None:

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -130,7 +130,9 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self.global_step = 0
 
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
-        self._adapter_only = cfg.get("adapter_only", False)
+        self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
+        log.info(f"save_adapter_weights_only: {self._save_adapter_weights_only}")
+
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
@@ -469,18 +471,15 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         - Merged weights with key MODEL_KEY
         - Adapter weights with key ADAPTER_KEY
         - Relevant recipe state if training is not complete
-
-        If the `self._adapter_only` option is True, the checkpointer will:
-        - Save only the adapter weights for all epochs except the final epoch
-        - Save the complete state (merged weights, adapter weights, and recipe state) for the final epoch only
-
-        If the `self._adapter_only` option is False, the checkpointer will save the complete state for all epochs.
+        - If the `self._save_adapter_weights_only` option is True, the checkpointer will save only the adapter weights
 
         To correctly resume from training, the adapter weights and recipe state must be provided along with the base model weights.
         """
         ckpt_dict = {}
+
+        is_intermediate_epoch = epoch + 1 < self.total_epochs
         # if training is in-progress, checkpoint the optimizer state as well
-        if epoch + 1 < self.total_epochs:
+        if is_intermediate_epoch:
             ckpt_dict.update(
                 {
                     utils.OPT_KEY: self._optimizer.state_dict(),
@@ -520,20 +519,18 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         }
         ckpt_dict.update({utils.ADAPTER_CONFIG: adapter_config})
 
-        # If the option was True, save only the adapter except for the last epoch
-        is_intermediate_epoch = epoch + 1 < self.total_epochs
-        if self._adapter_only and is_intermediate_epoch:
-            self._checkpointer.save_checkpoint(
-                ckpt_dict,
-                epoch=epoch,
-                intermediate_checkpoint=is_intermediate_epoch,
-                adapter_only=True,
-            )
-        else:
-            self._checkpointer.save_checkpoint(
-                ckpt_dict,
-                epoch=epoch,
-                intermediate_checkpoint=is_intermediate_epoch,
+        self._checkpointer.save_checkpoint(
+            ckpt_dict,
+            epoch=epoch,
+            intermediate_checkpoint=is_intermediate_epoch,
+            adapter_only=self._save_adapter_weights_only,
+        )
+        if not is_intermediate_epoch:
+            log.info(
+                "Saving final model checkpoint."
+                "Please note that you have set save_adapter_only=True, so only adapter weights will be saved."
+                "You need to merge the adapter weights into your base model for further use. "
+                "See {where do we point them for now??}"
             )
 
     def train(self) -> None:

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -128,11 +128,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
-
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
-        log.info(f"save_adapter_weights_only: {self._save_adapter_weights_only}")
-
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
@@ -526,12 +523,18 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             adapter_only=self._save_adapter_weights_only,
         )
         if not is_intermediate_epoch:
-            log.info(
-                "Saving final model checkpoint."
-                "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                "You need to merge the adapter weights into your base model for further use. "
-                f"See {type(self._checkpointer).__name__}"
-            )
+            log.ingo("Saving final epoch checkpoint.")
+            if self._save_adapter_weights_only:
+                log.info(
+                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
+                    "You need to merge the adapter weights into your base model for further use. "
+                    f"See {type(self._checkpointer).__name__}"
+                )
+            else:
+                log.info(
+                    "The full model checkpoint, including all weights and configurations, has been saved successfully."
+                    "You can now use this checkpoint for further training or inference."
+                )
 
     def train(self) -> None:
         """

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -522,19 +522,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             intermediate_checkpoint=is_intermediate_epoch,
             adapter_only=self._save_adapter_weights_only,
         )
-        if not is_intermediate_epoch:
-            log.ingo("Saving final epoch checkpoint.")
-            if self._save_adapter_weights_only:
-                log.info(
-                    "Please note that you have set save_adapter_weights_only=True, so only adapter weights will be saved."
-                    "You need to merge the adapter weights into your base model for further use. "
-                    f"See {type(self._checkpointer).__name__}"
-                )
-            else:
-                log.info(
-                    "The full model checkpoint, including all weights and configurations, has been saved successfully."
-                    "You can now use this checkpoint for further training or inference."
-                )
 
     def train(self) -> None:
         """

--- a/torchtune/utils/_checkpointing/_checkpointer.py
+++ b/torchtune/utils/_checkpointing/_checkpointer.py
@@ -282,7 +282,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 f"saved to {output_path}"
             )
         else:
-            logger.ingo("Saving final epoch checkpoint.")
+            logger.info("Saving final epoch checkpoint.")
             if adapter_only:
                 logger.info(
                     "Please note that you have set adapter_only=True, so only adapter weights will be saved."
@@ -609,7 +609,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 f"saved to {output_path}"
             )
         else:
-            logger.ingo("Saving final epoch checkpoint.")
+            logger.info("Saving final epoch checkpoint.")
             if adapter_only:
                 logger.info(
                     "Please note that you have set adapter_only=True, so only adapter weights will be saved."
@@ -769,7 +769,7 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
                 f"saved to {output_path}"
             )
         else:
-            logger.ingo("Saving final epoch checkpoint.")
+            logger.info("Saving final epoch checkpoint.")
             if adapter_only:
                 logger.info(
                     "Please note that you have set adapter_only=True, so only adapter weights will be saved."

--- a/torchtune/utils/_checkpointing/_checkpointer.py
+++ b/torchtune/utils/_checkpointing/_checkpointer.py
@@ -281,6 +281,19 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
                 f"saved to {output_path}"
             )
+        else:
+            logger.ingo("Saving final epoch checkpoint.")
+            if adapter_only:
+                logger.info(
+                    "Please note that you have set adapter_only=True, so only adapter weights will be saved."
+                    "You need to merge the adapter weights into your base model for further use. "
+                    f"See {self.__class__.__name__}.save_checkpoint for more details."
+                )
+            else:
+                logger.info(
+                    "The full model checkpoint, including all weights and configurations, has been saved successfully."
+                    "You can now use this checkpoint for further training or inference."
+                )
 
 
 class FullModelHFCheckpointer(_CheckpointerInterface):
@@ -595,6 +608,19 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
                 f"saved to {output_path}"
             )
+        else:
+            logger.ingo("Saving final epoch checkpoint.")
+            if adapter_only:
+                logger.info(
+                    "Please note that you have set adapter_only=True, so only adapter weights will be saved."
+                    "You need to merge the adapter weights into your base model for further use. "
+                    f"See {self.__class__.__name__}.save_checkpoint for more details."
+                )
+            else:
+                logger.info(
+                    "The full model checkpoint, including all weights and configurations, has been saved successfully."
+                    "You can now use this checkpoint for further training or inference."
+                )
 
 
 class FullModelMetaCheckpointer(_CheckpointerInterface):
@@ -742,3 +768,16 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
                 f"{os.path.getsize(output_path) / 1000**3:.2f} GB "
                 f"saved to {output_path}"
             )
+        else:
+            logger.ingo("Saving final epoch checkpoint.")
+            if adapter_only:
+                logger.info(
+                    "Please note that you have set adapter_only=True, so only adapter weights will be saved."
+                    "You need to merge the adapter weights into your base model for further use. "
+                    f"See {self.__class__.__name__}.save_checkpoint for more details."
+                )
+            else:
+                logger.info(
+                    "The full model checkpoint, including all weights and configurations, has been saved successfully."
+                    "You can now use this checkpoint for further training or inference."
+                )


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
close #1212

#### Changelog
In #1210, the "adapter_only" (boolean) option was added to the save_checkpoint method of each Checkpointer class. When this option is set to True, only the adapter weights are saved instead of the entire model weights.
This PR applies that change to LoRA fine-tuning.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [x] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
