### PR TITLE
Unify configs for Phi3

### DIFF
--- a/recipes/configs/phi3/mini_full.yaml
+++ b/recipes/configs/phi3/mini_full.yaml
@@ -17,22 +17,16 @@
 # Single device full finetuning requires more memory optimizations. It's
 # best to use mini_low_memory.yaml for those cases
 
+# Model arguments
+model:
+  _component_: torchtune.models.phi3.phi3_mini
+
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.phi3.phi3_mini_tokenizer
   path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
 
-# Dataset
-dataset:
-  _component_: torchtune.datasets.alpaca_cleaned_dataset
-  max_seq_len: 4096
-seed: null
-shuffle: True
-
-# Model Arguments
-model:
-  _component_: torchtune.models.phi3.phi3_mini
-
+# Checkpointer
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
@@ -45,16 +39,22 @@ checkpointer:
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 
+# Dataset
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+seed: null
+shuffle: True
+
 # Fine-tuning arguments
-batch_size: 2
 epochs: 1
+max_steps_per_epoch: null
+batch_size: 2
+gradient_accumulation_steps: 16
 optimizer:
   _component_: torch.optim.AdamW
   lr: 5e-6
 loss:
   _component_: torch.nn.CrossEntropyLoss
-max_steps_per_epoch: null
-gradient_accumulation_steps: 16
 
 # Training env
 device: cuda
@@ -62,13 +62,11 @@ device: cuda
 # Memory management
 enable_activation_checkpointing: True
 memory_efficient_fsdp_wrap: False
-
-# Reduced precision
 dtype: bf16
 
 # Logging
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: ${output_dir}
-output_dir: /tmp/Phi-3-mini-4k-instruct
+  log_dir: /tmp/Phi-3-mini-4k-instruct/logs
 log_every_n_steps: 1
+log_peak_memory_stats: False

--- a/recipes/configs/phi3/mini_full_low_memory.yaml
+++ b/recipes/configs/phi3/mini_full_low_memory.yaml
@@ -19,22 +19,16 @@
 #
 # This config works only for training on single device.
 
+# Model arguments
+model:
+  _component_: torchtune.models.phi3.phi3_mini
+
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.phi3.phi3_mini_tokenizer
   path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
 
-# Dataset
-dataset:
-  _component_: torchtune.datasets.alpaca_cleaned_dataset
-  max_seq_len: 4096
-seed: null
-shuffle: True
-
-# Model Arguments
-model:
-  _component_: torchtune.models.phi3.phi3_mini
-
+# Checkpointer
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
@@ -47,33 +41,35 @@ checkpointer:
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 
+# Dataset
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+seed: null
+shuffle: True
+
 # Fine-tuning arguments
-batch_size: 2
 epochs: 1
+max_steps_per_epoch: null
+batch_size: 2
+gradient_accumulation_steps: 1
 optimizer:
   _component_: bitsandbytes.optim.PagedAdamW
   lr: 5e-6
+optimizer_in_bwd: True
 loss:
   _component_: torch.nn.CrossEntropyLoss
-max_steps_per_epoch: null
-gradient_accumulation_steps: 1
-optimizer_in_bwd: True
+compile: False
 
 # Training env
 device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-
-# Reduced precision
 dtype: bf16
-
-# Model compilation
-compile: False
 
 # Logging
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: ${output_dir}
-output_dir: /tmp/Phi-3-mini-4k-instruct
+  log_dir: /tmp/Phi-3-mini-4k-instruct/logs
 log_every_n_steps: 1
+log_peak_memory_stats: False

--- a/recipes/configs/phi3/mini_lora.yaml
+++ b/recipes/configs/phi3/mini_lora.yaml
@@ -17,8 +17,7 @@
 # For single device LoRA finetuning please use mini_lora_single_device.yaml
 # or mini_qlora_single_device.yaml
 
-
-# Model Arguments
+# Model arguments
 model:
   _component_: torchtune.models.phi3.lora_phi3_mini
   lora_attn_modules: ['q_proj', 'v_proj']
@@ -27,10 +26,12 @@ model:
   lora_rank: 8
   lora_alpha: 16
 
+# Tokenizer
 tokenizer:
   _component_: torchtune.models.phi3.phi3_mini_tokenizer
   path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
 
+# Checkpointer
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
@@ -43,14 +44,17 @@ checkpointer:
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 
-# Dataset and Sampler
+# Dataset
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
 seed: null
 shuffle: True
-batch_size: 2
 
-# Optimizer and Scheduler
+# Fine-tuning arguments
+epochs: 1
+max_steps_per_epoch: null
+batch_size: 2
+gradient_accumulation_steps: 32
 optimizer:
   _component_: torch.optim.AdamW
   weight_decay: 0.01
@@ -58,24 +62,19 @@ optimizer:
 lr_scheduler:
   _component_: torchtune.modules.get_cosine_schedule_with_warmup
   num_warmup_steps: 100
-
 loss:
   _component_: torch.nn.CrossEntropyLoss
 
-# Training
-epochs: 1
-max_steps_per_epoch: null
-gradient_accumulation_steps: 32
+# Training env
+device: cuda
+
+# Memory management
+enable_activation_checkpointing: False
+dtype: bf16
 
 # Logging
-output_dir: /tmp/lora_finetune_output
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: ${output_dir}
+  log_dir: /tmp/Phi-3-mini-4k-instruct
 log_every_n_steps: 1
 log_peak_memory_stats: False
-
-# Environment
-device: cuda
-dtype: bf16
-enable_activation_checkpointing: False

--- a/recipes/configs/phi3/mini_lora.yaml
+++ b/recipes/configs/phi3/mini_lora.yaml
@@ -75,6 +75,6 @@ dtype: bf16
 # Logging
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: /tmp/Phi-3-mini-4k-instruct
+  log_dir: /tmp/Phi-3-mini-4k-instruct/logs
 log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/phi3/mini_lora_single_device.yaml
+++ b/recipes/configs/phi3/mini_lora_single_device.yaml
@@ -15,8 +15,7 @@
 #
 # This config works only for training on single device.
 
-
-# Model Arguments
+# Model arguments
 model:
   _component_: torchtune.models.phi3.lora_phi3_mini
   lora_attn_modules: ['q_proj', 'v_proj']
@@ -25,10 +24,12 @@ model:
   lora_rank: 8
   lora_alpha: 16
 
+# Tokenizer
 tokenizer:
   _component_: torchtune.models.phi3.phi3_mini_tokenizer
   path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
 
+# Checkpointer
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
@@ -41,14 +42,17 @@ checkpointer:
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 
-# Dataset and Sampler
+# Dataset
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
 seed: null
 shuffle: True
-batch_size: 2
 
-# Optimizer and Scheduler
+# Fine-tuning arguments
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 64
+batch_size: 2
 optimizer:
   _component_: torch.optim.AdamW
   weight_decay: 0.01
@@ -56,37 +60,32 @@ optimizer:
 lr_scheduler:
   _component_: torchtune.modules.get_cosine_schedule_with_warmup
   num_warmup_steps: 100
-
 loss:
   _component_: torch.nn.CrossEntropyLoss
-
-# Training
-epochs: 1
-max_steps_per_epoch: null
-gradient_accumulation_steps: 64
 compile: False
 
-# Logging
-output_dir: /tmp/lora_finetune_output
-metric_logger:
-  _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: ${output_dir}
-log_every_n_steps: 1
-log_peak_memory_stats: False
-
-# Environment
+# Training env
 device: cuda
+
+# Memory management
 dtype: bf16
 enable_activation_checkpointing: True
 
-# Show case the usage of pytorch profiler
+# Logging
+metric_logger:
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: /tmp/Phi-3-mini-4k-instruct/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+
+# Showcase the usage of PyTorch profiler
 # Set enabled to False as it's only needed for debugging training
 profiler:
   _component_: torchtune.utils.setup_torch_profiler
   enabled: False
 
   #Output directory of trace artifacts
-  output_dir: ${output_dir}/profiling_outputs
+  output_dir: /tmp/Phi-3-mini-4k-instruct/profiling_outputs
 
   #`torch.profiler.ProfilerActivity` types to trace
   cpu: True

--- a/recipes/configs/phi3/mini_qlora_single_device.yaml
+++ b/recipes/configs/phi3/mini_qlora_single_device.yaml
@@ -15,7 +15,7 @@
 #
 # This config works only for training on single device.
 
-# Model Arguments
+# Model arguments
 model:
   _component_: torchtune.models.phi3.qlora_phi3_mini
   lora_attn_modules: ['q_proj', 'v_proj', 'k_proj', 'output_proj']
@@ -24,10 +24,12 @@ model:
   lora_rank: 8
   lora_alpha: 16
 
+# Tokenizer
 tokenizer:
   _component_: torchtune.models.phi3.phi3_mini_tokenizer
   path: /tmp/Phi-3-mini-4k-instruct/tokenizer.model
 
+# Checkpointer
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Phi-3-mini-4k-instruct
@@ -40,14 +42,17 @@ checkpointer:
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 
-# Dataset and Sampler
+# Dataset
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
 seed: null
 shuffle: True
-batch_size: 2
 
-# Optimizer and Scheduler
+# Fine-tuning arguments
+epochs: 1
+max_steps_per_epoch: null
+batch_size: 2
+gradient_accumulation_steps: 16
 optimizer:
   _component_: torch.optim.AdamW
   weight_decay: 0.01
@@ -55,36 +60,31 @@ optimizer:
 lr_scheduler:
   _component_: torchtune.modules.get_cosine_schedule_with_warmup
   num_warmup_steps: 100
-
 loss:
   _component_: torch.nn.CrossEntropyLoss
-
-# Training
-epochs: 1
-max_steps_per_epoch: null
-gradient_accumulation_steps: 16
 compile: False
 
+# Training env
+device: cuda
+
+# Memory management
+enable_activation_checkpointing: True
+dtype: bf16
+
 # Logging
-output_dir: /tmp/qlora_finetune_output/
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: ${output_dir}
+  log_dir: /tmp/Phi-3-mini-4k-instruct
 log_every_n_steps: 1
 log_peak_memory_stats: False
 
-# Environment
-device: cuda
-dtype: bf16
-enable_activation_checkpointing: True
-
-# Show case the usage of pytorch profiler
+# Showcase the usage of PyTorch profiler
 # Set enabled to False as it's only needed for debugging training
 profiler:
   _component_: torchtune.utils.setup_torch_profiler
   enabled: False
 
-  #Output directory of trace artifacts
+  # Output directory of trace artifacts
   output_dir: ${output_dir}/profiling_outputs
 
   #`torch.profiler.ProfilerActivity` types to trace

--- a/recipes/configs/phi3/mini_qlora_single_device.yaml
+++ b/recipes/configs/phi3/mini_qlora_single_device.yaml
@@ -74,7 +74,7 @@ dtype: bf16
 # Logging
 metric_logger:
   _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: /tmp/Phi-3-mini-4k-instruct
+  log_dir: /tmp/Phi-3-mini-4k-instruct/logs
 log_every_n_steps: 1
 log_peak_memory_stats: False
 

--- a/recipes/configs/phi3/mini_qlora_single_device.yaml
+++ b/recipes/configs/phi3/mini_qlora_single_device.yaml
@@ -85,7 +85,7 @@ profiler:
   enabled: False
 
   # Output directory of trace artifacts
-  output_dir: ${output_dir}/profiling_outputs
+  output_dir: /tmp/Phi-3-mini-4k-instruct/profiling_outputs
 
   #`torch.profiler.ProfilerActivity` types to trace
   cpu: True


### PR DESCRIPTION
#### Context

I couldn't take it anymore. Every one of our configs looks different, has different names for things, has different params, and use different datasets as examples. Some of this makes sense and is related to the specific use-case. The majority though is just our fast moving codebase and increases the mental strain on the user to find something in a config. 

At last I can rest.

#### Changelog
* Impose an order to the elements in the config: model, tokenizer, checkpointer, dataset, fine-tuning arguments, training env, memory management, logging, profiler (optional)
* Move epoch related things and sim batch size related things close to each other
* Add `log_peak_memory_stats` to every config
* Remove max_seq_len from the configs that had it - no need in this example
* Set output-dir to the common tmp name we've been using.

#### Test plan

1. EYES and that this makes sense
2. I will be running each of these configs for 10 steps and confirming everything looks right 

#### Next steps

Once we agree on everything here, I will either do the rest of the configs myself or ask the community for help.
