### PR TITLE
[DOCS] Cross-reference API/deep dives/tutorials

### DIFF
--- a/docs/source/api_ref_models.rst
+++ b/docs/source/api_ref_models.rst
@@ -240,19 +240,3 @@ Vision components to support multimodality using `CLIP encoder <https://arxiv.or
 
 
 .. _convert_weights_label:
-
-convert_weights
----------------
-
-Weight conversion utilities between different checkpoint formats. In addition to mapping weights between
-checkpoint formats, we use :func:`tune_to_hf <convert_weights.tune_to_hf>` and :func:`hf_to_tune <convert_weights.hf_to_tune>`
-to ensure model parameters read from HF ``config.json`` files are identical to torchtune's model implementations.
-
-.. autosummary::
-    :toctree: generated/
-    :nosignatures:
-
-    convert_weights.tune_to_hf
-    convert_weights.hf_to_tune
-    convert_weights.tune_to_meta
-    convert_weights.meta_to_tune

--- a/docs/source/api_ref_models.rst
+++ b/docs/source/api_ref_models.rst
@@ -237,3 +237,22 @@ Vision components to support multimodality using `CLIP encoder <https://arxiv.or
     clip.TokenPositionalEmbedding
     clip.TiledTokenPositionalEmbedding
     clip.TilePositionalEmbedding
+
+
+.. _convert_weights_label:
+
+convert_weights
+---------------
+
+Weight conversion utilities between different checkpoint formats. In addition to mapping weights between
+checkpoint formats, we use :func:`tune_to_hf <convert_weights.tune_to_hf>` and :func:`hf_to_tune <convert_weights.hf_to_tune>`
+to ensure model parameters read from HF ``config.json`` files are identical to torchtune's model implementations.
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    convert_weights.tune_to_hf
+    convert_weights.hf_to_tune
+    convert_weights.tune_to_meta
+    convert_weights.meta_to_tune

--- a/docs/source/api_ref_models.rst
+++ b/docs/source/api_ref_models.rst
@@ -237,6 +237,3 @@ Vision components to support multimodality using `CLIP encoder <https://arxiv.or
     clip.TokenPositionalEmbedding
     clip.TiledTokenPositionalEmbedding
     clip.TilePositionalEmbedding
-
-
-.. _convert_weights_label:

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -130,6 +130,7 @@ each of which supports a different checkpoint format.
 
 
 :class:`HFCheckpointer <torchtune.utils.FullModelHFCheckpointer>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This checkpointer reads and writes checkpoints in a format which is compatible with the transformers
 framework from Hugging Face. As mentioned above, this is the most popular format within the Hugging Face
@@ -201,6 +202,7 @@ The following snippet explains how the HFCheckpointer is setup in torchtune conf
 |
 
 :class:`MetaCheckpointer <torchtune.utils.FullModelMetaCheckpointer>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This checkpointer reads and writes checkpoints in a format which is compatible with the original meta-llama
 github repository.
@@ -260,6 +262,7 @@ The following snippet explains how the MetaCheckpointer is setup in torchtune co
 |
 
 :class:`TorchTuneCheckpointer <torchtune.utils.FullModelTorchTuneCheckpointer>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This checkpointer reads and writes checkpoints in a format that is compatible with torchtune's
 model definition. This does not perform any state_dict conversions and is currently used either

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -115,9 +115,15 @@ fine-tuned checkpoints from torchtune with any post-training tool (quantization,
 which supports the source format, without any code changes OR conversion scripts. This is one of the
 ways in which torchtune interoperates with the surrounding ecosystem.
 
-To be "state-dict invariant", the ``load_checkpoint`` and
-``save_checkpoint`` methods make use of the weight convertors available
-:ref:`here<convert_weights_label>`.
+.. note::
+
+  To be state-dict "invariant" in this way, the ``load_checkpoint`` and ``save_checkpoint`` methods of each checkpointer
+  make use of weight convertors which correctly map weights between checkpoint formats. For example, when loading weights
+  from HuggingFace, we apply a permutation to certain weights on load and save to ensure checkpoints behave exactly the same.
+  To further illustrate this, the llama family of models uses a
+  `generic weight converter function <https://github.com/pytorch/torchtune/blob/898670f0eb58f956b5228e5a55ccac4ea0efaff8/torchtune/models/convert_weights.py#L113>`_
+  whilst some other models like Phi have their own `conversion functions <https://github.com/pytorch/torchtune/blob/main/torchtune/models/phi3/_convert_weights.py>`_
+  which can be found within their model folders.
 
 |
 
@@ -196,8 +202,6 @@ The following snippet explains how the HFCheckpointer is setup in torchtune conf
     read directly from the ``config.json`` file. This helps ensure we either load the weights
     correctly or error out in case of discrepancy between the HF checkpoint file and torchtune's
     model implementations. This json file is downloaded from the hub along with the model checkpoints.
-    More details on how these are used during conversion can be found
-    :ref:`here <convert_weights_label>`.
 
 |
 

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -119,7 +119,7 @@ ways in which torchtune interoperates with the surrounding ecosystem.
 
   To be state-dict "invariant" in this way, the ``load_checkpoint`` and ``save_checkpoint`` methods of each checkpointer
   make use of weight converters which correctly map weights between checkpoint formats. For example, when loading weights
-  from HuggingFace, we apply a permutation to certain weights on load and save to ensure checkpoints behave exactly the same.
+  from Hugging Face, we apply a permutation to certain weights on load and save to ensure checkpoints behave exactly the same.
   To further illustrate this, the llama family of models uses a
   `generic weight converter function <https://github.com/pytorch/torchtune/blob/898670f0eb58f956b5228e5a55ccac4ea0efaff8/torchtune/models/convert_weights.py#L113>`_
   whilst some other models like Phi have their own `conversion functions <https://github.com/pytorch/torchtune/blob/main/torchtune/models/phi3/_convert_weights.py>`_

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -122,7 +122,7 @@ ways in which torchtune interoperates with the surrounding ecosystem.
   from Hugging Face, we apply a permutation to certain weights on load and save to ensure checkpoints behave exactly the same.
   To further illustrate this, the Llama family of models uses a
   `generic weight converter function <https://github.com/pytorch/torchtune/blob/898670f0eb58f956b5228e5a55ccac4ea0efaff8/torchtune/models/convert_weights.py#L113>`_
-  whilst some other models like Phi have their own `conversion functions <https://github.com/pytorch/torchtune/blob/main/torchtune/models/phi3/_convert_weights.py>`_
+  whilst some other models like Phi3 have their own `conversion functions <https://github.com/pytorch/torchtune/blob/main/torchtune/models/phi3/_convert_weights.py>`_
   which can be found within their model folders.
 
 |

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -120,7 +120,7 @@ ways in which torchtune interoperates with the surrounding ecosystem.
   To be state-dict "invariant" in this way, the ``load_checkpoint`` and ``save_checkpoint`` methods of each checkpointer
   make use of weight converters which correctly map weights between checkpoint formats. For example, when loading weights
   from Hugging Face, we apply a permutation to certain weights on load and save to ensure checkpoints behave exactly the same.
-  To further illustrate this, the llama family of models uses a
+  To further illustrate this, the Llama family of models uses a
   `generic weight converter function <https://github.com/pytorch/torchtune/blob/898670f0eb58f956b5228e5a55ccac4ea0efaff8/torchtune/models/convert_weights.py#L113>`_
   whilst some other models like Phi have their own `conversion functions <https://github.com/pytorch/torchtune/blob/main/torchtune/models/phi3/_convert_weights.py>`_
   which can be found within their model folders.

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -118,7 +118,7 @@ ways in which torchtune interoperates with the surrounding ecosystem.
 .. note::
 
   To be state-dict "invariant" in this way, the ``load_checkpoint`` and ``save_checkpoint`` methods of each checkpointer
-  make use of weight convertors which correctly map weights between checkpoint formats. For example, when loading weights
+  make use of weight converters which correctly map weights between checkpoint formats. For example, when loading weights
   from HuggingFace, we apply a permutation to certain weights on load and save to ensure checkpoints behave exactly the same.
   To further illustrate this, the llama family of models uses a
   `generic weight converter function <https://github.com/pytorch/torchtune/blob/898670f0eb58f956b5228e5a55ccac4ea0efaff8/torchtune/models/convert_weights.py#L113>`_

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -117,7 +117,7 @@ ways in which torchtune interoperates with the surrounding ecosystem.
 
 To be "state-dict invariant", the ``load_checkpoint`` and
 ``save_checkpoint`` methods make use of the weight convertors available
-`here <https://github.com/pytorch/torchtune/blob/main/torchtune/models/convert_weights.py>`_.
+:ref:`here<convert_weights_label>`.
 
 |
 
@@ -125,11 +125,11 @@ Handling different Checkpoint Formats
 -------------------------------------
 
 torchtune supports three different
-`checkpointers <https://github.com/pytorch/torchtune/blob/main/torchtune/utils/_checkpointing/_checkpointer.py>`_,
+:ref:`checkpointers<checkpointing_label>`,
 each of which supports a different checkpoint format.
 
 
-**HFCheckpointer**
+:class:`HFCheckpointer <torchtune.utils.FullModelHFCheckpointer>`
 
 This checkpointer reads and writes checkpoints in a format which is compatible with the transformers
 framework from Hugging Face. As mentioned above, this is the most popular format within the Hugging Face
@@ -196,11 +196,11 @@ The following snippet explains how the HFCheckpointer is setup in torchtune conf
     correctly or error out in case of discrepancy between the HF checkpoint file and torchtune's
     model implementations. This json file is downloaded from the hub along with the model checkpoints.
     More details on how these are used during conversion can be found
-    `here <https://github.com/pytorch/torchtune/blob/main/torchtune/models/convert_weights.py>`_.
+    :ref:`here <convert_weights_label>`.
 
 |
 
-**MetaCheckpointer**
+:class:`MetaCheckpointer <torchtune.utils.FullModelMetaCheckpointer>`
 
 This checkpointer reads and writes checkpoints in a format which is compatible with the original meta-llama
 github repository.
@@ -259,7 +259,7 @@ The following snippet explains how the MetaCheckpointer is setup in torchtune co
 
 |
 
-**TorchTuneCheckpointer**
+:class:`TorchTuneCheckpointer <torchtune.utils.FullModelTorchTuneCheckpointer>`
 
 This checkpointer reads and writes checkpoints in a format that is compatible with torchtune's
 model definition. This does not perform any state_dict conversions and is currently used either
@@ -460,8 +460,7 @@ For this section we'll use the Llama2 13B model in HF format.
 
 
 You can do this with any model supported by torchtune. You can find a full list
-of models and model builders
-`here <https://github.com/pytorch/torchtune/tree/main/torchtune/models>`__.
+of models and model builders :ref:`here <models>`.
 
 We hope this deep-dive provided a deeper insight into the checkpointer and
 associated utilities in torchtune. Happy tuning!

--- a/docs/source/deep_dives/configs.rst
+++ b/docs/source/deep_dives/configs.rst
@@ -47,8 +47,8 @@ for a particular run.
     enable_fsdp: True
     ...
 
-Configuring components using :code:`instantiate`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Configuring components using :func:`instantiate<torchtune.config.instantiate>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Many fields will require specifying torchtune objects with associated keyword
 arguments as parameters. Models, datasets, optimizers, and loss functions are
 common examples of this. You can easily do this using the :code:`_component_`
@@ -152,10 +152,10 @@ will automatically resolve it for you.
 
 Validating your config
 ^^^^^^^^^^^^^^^^^^^^^^
-We provide a convenient CLI utility, :code:`tune validate`, to quickly verify that
+We provide a convenient CLI utility, :ref:`tune validate<validate_cli_label>`, to quickly verify that
 your config is well-formed and all components can be instantiated properly. You
 can also pass in overrides if you want to test out the exact commands you will run
-your experiments with. If any parameters are not well-formed, :code:`tune validate`
+your experiments with. If any parameters are not well-formed, :ref:`tune validate<validate_cli_label>`
 will list out all the locations where an error was found.
 
 .. code-block:: bash
@@ -216,6 +216,8 @@ the config itself. To enable quick experimentation, you can specify override val
 to parameters in your config via the :code:`tune` command. These should be specified
 as key-value pairs :code:`k1=v1 k2=v2 ...`
 
+.. TODO (SalmanMohammadi) link this to the upcoming recipe docpage for the lora recipe
+
 For example, to run the :code:`lora_finetune_single_device` recipe with custom model and tokenizer directories, you can provide overrides:
 
 .. code-block:: bash
@@ -248,9 +250,10 @@ Removing config fields
 You may need to remove certain parameters from the config when changing components
 through overrides that require different keyword arguments. You can do so by using
 the `~` flag and specify the dotpath of the config field you would like to remove.
-For example, if you want to override a built-in config and use the ``bitsandbytes.optim.PagedAdamW8bit``
+For example, if you want to override a built-in config and use the
+`bitsandbytes.optim.PagedAdamW8bit <https://huggingface.co/docs/bitsandbytes/main/en/reference/optim/adamw#bitsandbytes.optim.PagedAdamW8bit>`_
 optimizer, you may need to delete parameters like ``foreach`` which are
-specific to PyTorch optimizers. Note that this example requires that you have ``bitsandbytes``
+specific to PyTorch optimizers. Note that this example requires that you have `bitsandbytes <https://github.com/bitsandbytes-foundation/bitsandbytes>`_
 installed.
 
 .. code-block:: yaml

--- a/docs/source/deep_dives/recipe_deepdive.rst
+++ b/docs/source/deep_dives/recipe_deepdive.rst
@@ -68,6 +68,8 @@ For a complete working example, refer to the
 in torchtune and the associated
 `config <https://github.com/pytorch/torchtune/blob/main/recipes/configs/7B_full.yaml>`_.
 
+.. TODO (SalmanMohammadi) ref to full finetune recipe doc
+
 |
 
 What Recipes are not?
@@ -209,7 +211,7 @@ You can learn all about configs in our :ref:`config deep-dive<config_tutorial_la
 Config and CLI parsing using :code:`parse`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 We provide a convenient decorator :func:`~torchtune.config.parse` that wraps
-your recipe to enable running from the command-line with :code:`tune` with config
+your recipe to enable running from the command-line with :ref:`tune <cli_label>` with config
 and CLI override parsing.
 
 .. code-block:: python
@@ -225,7 +227,7 @@ and CLI override parsing.
 Running your recipe
 ^^^^^^^^^^^^^^^^^^^
 You should be able to run your recipe by providing the direct paths to your custom
-recipe and custom config using the :code:`tune` command with any CLI overrides:
+recipe and custom config using the :ref:`tune <cli_label>` command with any CLI overrides:
 
 .. code-block:: bash
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -41,7 +41,7 @@ And should see the following output:
 Install via ``git clone``
 -------------------------
 
-If you want the latest and greatest features from torchtune or if you want to become a contributor,
+If you want the latest and greatest features from torchtune or if you want to `become a contributor <https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md>`_,
 you can also install the package locally with the following command.
 
 .. code-block:: bash

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -39,15 +39,17 @@ As you go through the tutorials and code, there are two concepts which will help
 
 **Configs.** YAML files which help you configure training settings (dataset, model, chekckpoint) and
 hyperparameters (batch size, learning rate) without modifying code.
-See the :ref:`All About Configs deep-dive <config_tutorial_label>` for more information.
+See the ":ref:`All About Configs<config_tutorial_label>`" deep-dive for more information.
 
 **Recipes.** Recipes can be thought of
 as targeted end-to-end pipelines for training and optionally evaluating LLMs.
 Each recipe implements a training method (eg: full fine-tuning) with a set of meaningful
 features (eg: FSDP + Activation Checkpointing + Gradient Accumulation + Reduced Precision training)
-applied to a given model family (eg: Llama2). See the :ref:`What Are Recipes? deep-dive<recipe_deepdive>` for more information.
+applied to a given model family (eg: Llama2). See the ":ref:`What Are Recipes?<recipe_deepdive>`" deep-dive for more information.
 
 |
+
+.. _design_principles_label:
 
 Design Principles
 -----------------
@@ -56,7 +58,8 @@ torchtune embodies `PyTorch’s design philosophy <https://pytorch.org/docs/stab
 
 **Native PyTorch**
 
-torchtune is a native-PyTorch library. While we provide integrations with the surrounding ecosystem (eg: Hugging Face Datasets, EleutherAI Eval Harness), all of the core functionality is written in PyTorch.
+torchtune is a native-PyTorch library. While we provide integrations with the surrounding ecosystem (eg: `Hugging Face Datasets <https://huggingface.co/docs/datasets/en/index>`_,
+`EleutherAI's Eval Harness <https://github.com/EleutherAI/lm-evaluation-harness>`_), all of the core functionality is written in PyTorch.
 
 
 **Simplicity and Extensibility**

--- a/docs/source/tune_cli.rst
+++ b/docs/source/tune_cli.rst
@@ -34,6 +34,8 @@ The ``--help`` option is convenient for getting more details about any command. 
 available options and their details. For example, ``tune download --help`` provides more information on how
 to download files using the CLI.
 
+.. _tune_download_label:
+
 Download a model
 ----------------
 
@@ -102,6 +104,8 @@ with matching names. By default we ignore safetensor files, but if you want to i
     built-in recipes or configs. For a list of supported model families and architectures, see :ref:`models<models>`.
 
 
+.. _tune_ls_label:
+
 List built-in recipes and configs
 ---------------------------------
 
@@ -123,11 +127,13 @@ The ``tune ls`` command lists out all the built-in recipes and configs within to
                                              llama3/70B_full
     ...
 
+.. _tune_cp_cli_label:
+
 Copy a built-in recipe or config
 --------------------------------
 
 The ``tune cp <recipe|config> <path>`` command copies built-in recipes and configs to a provided location. This allows you to make a local copy of a library
-recipe or config to edit directly for yourself.
+recipe or config to edit directly for yourself. See :ref:`here <tune_cp_label>` for an example of how to use this command.
 
 .. list-table::
    :widths: 30 60
@@ -200,6 +206,8 @@ Further information on config overrides can be found :ref:`here  <cli_override>`
 .. code-block:: bash
 
   tune run <RECIPE> --config <CONFIG> epochs=1
+
+.. _validate_cli_label:
 
 Validate a config
 -----------------

--- a/docs/source/tutorials/chat.rst
+++ b/docs/source/tutorials/chat.rst
@@ -317,13 +317,13 @@ object.
         )
 
 .. note::
-    You can pass in any keyword argument for :code:`load_dataset` into all our
+    You can pass in any keyword argument for `load_dataset <https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/loading_methods#datasets.load_dataset>`_ into all our
     Dataset classes and they will honor them. This is useful for common parameters
     such as specifying the data split with :code:`split` or configuration with
     :code:`name`
 
 Now we're ready to start fine-tuning! We'll use the built-in LoRA single device recipe.
-Use the :code:`tune cp` command to get a copy of the :code:`8B_lora_single_device.yaml`
+Use the :ref:`tune cp <tune_cp_cli_label>` command to get a copy of the :code:`8B_lora_single_device.yaml`
 config and update it to use your new dataset. Create a new folder for your project
 and make sure the dataset builder and message converter are saved in that directory,
 then specify it in the config.

--- a/docs/source/tutorials/datasets.rst
+++ b/docs/source/tutorials/datasets.rst
@@ -56,7 +56,7 @@ Hugging Face datasets
 ---------------------
 
 We provide first class support for datasets on the Hugging Face hub. Under the hood,
-all of our built-in datasets and dataset builders are using Hugging Face's ``load_dataset()``
+all of our built-in datasets and dataset builders are using Hugging Face's `load_dataset() <https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/loading_methods#datasets.load_dataset>`_
 to load in your data, whether local or on the hub.
 
 You can pass in a Hugging Face dataset path to the ``source`` parameter in any of our builders
@@ -97,7 +97,7 @@ on Hugging Face's `documentation. <https://huggingface.co/docs/datasets/en/loadi
 Setting max sequence length
 ---------------------------
 
-The default collator :func:`~torchtune.utils.collate.padded_collate` used in all
+The default collator, :func:`~torchtune.utils.padded_collate`, used in all
 our training recipes will pad samples to the max sequence length within the batch,
 not globally. If you wish to set an upper limit on the max sequence length globally,
 you can specify it in the dataset builder with ``max_seq_len``. Any sample in the dataset
@@ -250,7 +250,7 @@ Here is an example of a sample that is formatted with :class:`~torchtune.data.Al
     # ### Response:
     #
 
-We provide `other instruct templates <data>`
+We provide :ref:`other instruct templates <data>`
 for common tasks such summarization and grammar correction. If you need to create your own
 instruct template for a custom task, you can inherit from :class:`~torchtune.data.InstructTemplate`
 and create your own class.

--- a/docs/source/tutorials/e2e_flow.rst
+++ b/docs/source/tutorials/e2e_flow.rst
@@ -151,6 +151,8 @@ Run Evaluation using EleutherAI's Eval Harness
 
 We've fine-tuned a model. But how well does this model really do? Let's run some Evaluations!
 
+.. TODO (SalmanMohammadi) ref eval recipe docs
+
 torchtune integrates with
 `EleutherAI's evaluation harness <https://github.com/EleutherAI/lm-evaluation-harness>`_.
 An example of this is available through the
@@ -169,7 +171,7 @@ will be easier than overriding all of these elements through the CLI.
 
     tune cp eleuther_evaluation ./custom_eval_config.yaml \
 
-For this tutorial we'll use the ``truthfulqa_mc2`` task from the harness.
+For this tutorial we'll use the `truthfulqa_mc2 <https://github.com/sylinrl/TruthfulQA>`_ task from the harness.
 This task measures a model's propensity to be truthful when answering questions and
 measures the model's zero-shot accuracy on a question followed by one or more true
 responses and one or more false responses. Let's first run a baseline without fine-tuning.
@@ -526,7 +528,7 @@ Uploading your model to the Hugging Face Hub
 --------------------------------------------
 
 Your new model is working great and you want to share it with the world. The easiest way to do this
-is utilizing the ``huggingface-cli`` command, which works seamlessly with torchtune. Simply point the CLI
+is utilizing the `huggingface-cli <https://huggingface.co/docs/huggingface_hub/en/guides/cli>`_ command, which works seamlessly with torchtune. Simply point the CLI
 to your finetuned model directory like so:
 
 .. code-block:: bash

--- a/docs/source/tutorials/first_finetune_tutorial.rst
+++ b/docs/source/tutorials/first_finetune_tutorial.rst
@@ -70,7 +70,9 @@ Each recipe consists of three components:
 
 torchtune provides built-in recipes for finetuning on single device, on multiple devices with `FSDP <https://pytorch.org/blog/introducing-pytorch-fully-sharded-data-parallel-api/>`_,
 using memory efficient techniques like `LoRA <https://arxiv.org/abs/2106.09685>`_, and more! You can view all built-in recipes `on GitHub <https://github.com/pytorch/torchtune/tree/main/recipes>`_. You can also utilize the
-:code:`tune ls` command to print out all recipes and corresponding configs.
+:ref:`tune ls <tune_ls_label>` command to print out all recipes and corresponding configs.
+
+.. TODO (SalmanMohammadi) point to recipe index page here.
 
 .. code-block:: bash
 
@@ -92,7 +94,7 @@ a single device. For a more in-depth discussion on LoRA in torchtune, you can se
 .. note::
 
   **Why have a separate recipe for single device vs. distributed?** This is discussed in
-  :ref:`recipe_deepdive` but one of our core principles in torchtune is minimal abstraction and boilerplate code.
+  ":ref:`recipe_deepdive`" but one of our :ref:`core principles <design_principles_label>` in torchtune is minimal abstraction and boilerplate code.
   If you only want to train on a single GPU, our single-device recipe ensures you don't have to worry about additional
   features like FSDP that are only required for distributed training.
 
@@ -119,7 +121,7 @@ you want to set the number of training epochs to 1.
 
 **Copy the config through `tune cp` and modify directly**
 
-If you want to make more substantial changes to the config, you can use the :code:`tune` CLI to copy it to your local directory.
+If you want to make more substantial changes to the config, you can use the :ref:`tune <cli_label>` CLI to copy it to your local directory.
 
 .. code-block:: bash
 
@@ -139,7 +141,7 @@ Training a model
 ----------------
 Now that you have a model in the proper format and a config that suits your needs, let's get training!
 
-Just like all the other steps, you will be using the :code:`tune` CLI tool to launch your finetuning run.
+Just like all the other steps, you will be using the :ref:`tune <cli_label>` CLI tool to launch your finetuning run.
 
 .. code-block:: bash
 

--- a/docs/source/tutorials/llama3.rst
+++ b/docs/source/tutorials/llama3.rst
@@ -69,7 +69,7 @@ for one epoch on a common instruct dataset for illustrative purposes. The basic 
 .. note::
     To see a full list of recipes and their corresponding configs, simply run ``tune ls`` from the command line.
 
-We can also add command-line overrides as needed, e.g.
+We can also add :ref:`command-line overrides <cli_override>` as needed, e.g.
 
 .. code-block:: bash
 
@@ -78,15 +78,15 @@ We can also add command-line overrides as needed, e.g.
         tokenizer.path=<checkpoint_dir>/tokenizer.model \
         checkpointer.output_dir=<checkpoint_dir>
 
-This will load the Llama3-8B-Instruct checkpoint and tokenizer from ``<checkpoint_dir>`` used in the ``tune download`` command above,
+This will load the Llama3-8B-Instruct checkpoint and tokenizer from ``<checkpoint_dir>`` used in the :ref:`tune download <tune_download_label>` command above,
 then save a final checkpoint in the same directory following the original format. For more details on the
 checkpoint formats supported in torchtune, see our :ref:`checkpointing deep-dive <understand_checkpointer>`.
 
 .. note::
-    To see the full set of configurable parameters for this (and other) configs we can use ``tune cp`` to copy (and modify)
-    the default config. ``tune cp`` can be used with recipe scripts too, in case you want to make more custom changes
-    that cannot be achieved by directly modifying existing configurable parameters. For more on ``tune cp`` see the section on
-    :ref:`modifying configs <tune_cp_label>`.
+    To see the full set of configurable parameters for this (and other) configs we can use :ref:`tune cp <tune_cp_cli_label>` to copy (and modify)
+    the default config. :ref:`tune cp <tune_cp_cli_label>` can be used with recipe scripts too, in case you want to make more custom changes
+    that cannot be achieved by directly modifying existing configurable parameters. For more on :ref:`tune cp <tune_cp_cli_label>` see the section on
+    :ref:`modifying configs <tune_cp_label>` in our ":ref:`finetune_llama_label`" tutorial.
 
 Once training is complete, the model checkpoints will be saved and their locations will be logged. For
 LoRA fine-tuning, the final checkpoint will contain the merged weights, and a copy of just the (much smaller) LoRA weights
@@ -104,6 +104,8 @@ For example, on two devices:
     tune run --nproc_per_node 2 lora_finetune_distributed --config llama3/8B_lora
 
 Finally, if we want to use even less memory, we can leverage torchtune's QLoRA recipe via:
+
+.. TODO (SalmanMohammadi) ref qlora recipe page
 
 .. code-block:: bash
 
@@ -129,7 +131,7 @@ for model evaluation on common benchmark tasks.
 .. note::
     Make sure you've first installed the evaluation harness via :code:`pip install "lm_eval==0.4.*"`.
 
-For this tutorial we'll use the ``truthfulqa_mc2`` task from the harness.
+For this tutorial we'll use the `truthfulqa_mc2 <https://github.com/sylinrl/TruthfulQA>`_ task from the harness.
 This task measures a model's propensity to be truthful when answering questions and
 measures the model's zero-shot accuracy on a question followed by one or more true
 responses and one or more false responses. First, let's copy the config so we can point the YAML
@@ -181,6 +183,8 @@ Try it for yourself and see what accuracy your model gets!
 
 Generating text with our fine-tuned Llama3 model
 ------------------------------------------------
+
+.. TODO (SalmanMohammadi) ref generate recipe page
 
 Next, let's look at one other way we can evaluate our model: generating text! torchtune provides a
 `recipe for generation <https://github.com/pytorch/torchtune/blob/main/recipes/generate.py>`_ as well.
@@ -335,7 +339,7 @@ Let's re-run generation!
     ...
     Time for inference: 1.62 sec total, 57.95 tokens/sec
 
-By quantizing the model and running ``torch.compile`` we get over a 3x speedup!
+By quantizing the model and running `torch.compile <https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html>`_ we get over a 3x speedup!
 
 This is just the beginning of what you can do with Meta Llama3 using torchtune and the broader ecosystem.
 We look forward to seeing what you build!

--- a/docs/source/tutorials/lora_finetune.rst
+++ b/docs/source/tutorials/lora_finetune.rst
@@ -324,7 +324,7 @@ with torchtune's EleutherAI evaluation harness integration, see our :ref:`End-to
 
 Previously, we only enabled LoRA for the linear layers in each self-attention module, but in fact there are other linear
 layers we can apply LoRA to: MLP layers and our model's final output projection. Note that for Llama-2-7B the final output
-projection maps to the vocability dimension (32000 instead of 4096 as in the other linear layers), so enabling LoRA for this layer will increase
+projection maps to the vocabulary dimension (32000 instead of 4096 as in the other linear layers), so enabling LoRA for this layer will increase
 our peak memory a bit more than the other layers. We can make the following changes to our config:
 
 .. code-block:: yaml

--- a/docs/source/tutorials/lora_finetune.rst
+++ b/docs/source/tutorials/lora_finetune.rst
@@ -152,7 +152,7 @@ Let's take a look at how to construct Llama2 models in torchtune with and withou
 
 .. note::
 
-    Calling :code:`lora_llama_2_7b` alone will not handle the definition of which parameters are trainable.
+    Calling :func:`lora_llama_2_7b <torchtune.models.llama2.lora_llama2_7b>` alone will not handle the definition of which parameters are trainable.
     See :ref:`below<setting_trainable_params>` for how to do this.
 
 Let's inspect each of these models a bit more closely.
@@ -205,7 +205,8 @@ model without any wrappers or custom checkpoint conversion logic.
 .. note::
     Whenever loading weights with :code:`strict=False`, you should verify that any missing or extra keys in
     the loaded :code:`state_dict` are as expected. torchtune's LoRA recipes do this by default via e.g.
-    :func:`torchtune.modules.peft.validate_state_dict_for_lora`.
+    :func:`validate_state_dict_for_lora() <torchtune.modules.peft.validate_state_dict_for_lora>` or
+    :func:`validate_missing_and_unexpected_for_lora() <torchtune.modules.peft.validate_missing_and_unexpected_for_lora>`.
 
 Once we've loaded the base model weights, we also want to set only LoRA parameters to trainable.
 
@@ -258,7 +259,7 @@ You can then run the following command to perform a LoRA finetune of Llama2-7B w
 .. note::
     Make sure to point to the location of your Llama2 weights and tokenizer. This can be done
     either by adding :code:`checkpointer.checkpoint_files=[my_model_checkpoint_path] tokenizer_checkpoint=my_tokenizer_checkpoint_path`
-    or by directly modifying the :code:`7B_lora.yaml` file. See our :ref:`config_tutorial_label`
+    or by directly modifying the :code:`7B_lora.yaml` file. See our "":ref:`config_tutorial_label`" recipe
     for more details on how you can easily clone and modify torchtune configs.
 
 .. note::
@@ -297,14 +298,16 @@ A comparison of the (smoothed) loss curves between this run and our baseline ove
 
 .. note::
     The above figure was generated with W&B. You can use torchtune's :class:`~torchtune.utils.metric_logging.WandBLogger`
-    to generate similar loss curves, but you will need to install W&B and setup an account separately.
+    to generate similar loss curves, but you will need to install W&B and setup an account separately. For more details on
+    using W&B in torchtune, see our ":ref:`wandb_logging`" recipe.
 
 
 Trading off memory and model performance with LoRA
 --------------------------------------------------
 
 In the preceding example, we ran LoRA on two devices. But given LoRA's low memory footprint, we can run fine-tuning
-on a single device using most commodity GPUs which support bfloat16 floating-point format. This can be done via the command:
+on a single device using most commodity GPUs which support `bfloat16 <https://en.wikipedia.org/wiki/Bfloat16_floating-point_format#bfloat16_floating-point_format>`_
+floating-point format. This can be done via the command:
 
 .. code-block:: bash
 
@@ -315,13 +318,13 @@ to see our peak memory during a finetune. We will experiment along two axes:
 first, which model layers have LoRA applied, and second, the rank of each LoRA layer. (We will scale
 alpha in parallel to LoRA rank, as discussed above.)
 
-To compare the results of our experiments, we can evaluate our models on :code:`truthfulqa_mc2`, a task from
+To compare the results of our experiments, we can evaluate our models on `truthfulqa_mc2 <https://github.com/sylinrl/TruthfulQA>`_, a task from
 the `TruthfulQA <https://arxiv.org/abs/2109.07958>`_ benchmark for language models. For more details on how to run this and other evaluation tasks
 with torchtune's EleutherAI evaluation harness integration, see our :ref:`End-to-End Workflow Tutorial <eval_harness_label>`.
 
 Previously, we only enabled LoRA for the linear layers in each self-attention module, but in fact there are other linear
 layers we can apply LoRA to: MLP layers and our model's final output projection. Note that for Llama-2-7B the final output
-projection maps to dimension 32000 (instead of 4096 as in the other linear layers), so enabling LoRA for this layer will increase
+projection maps to the vocability dimension (32000 instead of 4096 as in the other linear layers), so enabling LoRA for this layer will increase
 our peak memory a bit more than the other layers. We can make the following changes to our config:
 
 .. code-block:: yaml

--- a/docs/source/tutorials/qat_finetune.rst
+++ b/docs/source/tutorials/qat_finetune.rst
@@ -26,7 +26,7 @@ resulting model, and evaluate your quantized model using torchtune.
 What is QAT?
 ------------
 
-Quantization-Aware Training (QAT) refers to simulating quantization numerics during
+`Quantization-Aware Training <https://pytorch.org/blog/introduction-to-quantization-on-pytorch/#quantization-aware-training>`_ (QAT) refers to simulating quantization numerics during
 training or fine-tuning, with the end goal of ultimately producing a higher quality
 quantized model compared to simple post-training quantization (PTQ). During QAT,
 the weights and/or activations are “fake quantized”, meaning they are transformed
@@ -106,7 +106,7 @@ is ready for fine-tuning.
 
 After fine-tuning, we can convert the model to get an actual quantized model.
 If we print the converted model, we’ll see that the QAT linears have been
-swapped with :code:`Int8DynActInt4WeightLinear`, which are the quantized versions
+swapped with `Int8DynActInt4WeightLinear <https://github.com/pytorch/ao/blob/428084356ace4ea94c22a3a9b3d74cff8ee41db3/torchao/quantization/prototype/qat.py#L38>`_, which are the quantized versions
 of the linear layers. This quantized model can then be saved to checkpoint and
 used for inference or generation.
 
@@ -167,7 +167,8 @@ modifications accordingly:
 
 .. note::
 
-  QAT in torchtune is currently not compatible with :code:`memory_efficient_fsdp_wrap`. This is a known issue and will be fixed in a future torchtune version.
+  QAT in torchtune is currently not compatible with `memory_efficient_fsdp_wrap <https://pytorch.org/torchtune/stable/generated/torchtune.utils.get_full_finetune_fsdp_wrap_policy.html#torchtune.utils.get_full_finetune_fsdp_wrap_policy>`_.
+  This is a known issue and will be fixed in a future torchtune version.
 
 Empirically, we observed that disabling fake quantization for the first N steps
 led to better results, presumably because doing so allows the weights to stabilize

--- a/docs/source/tutorials/qlora_finetune.rst
+++ b/docs/source/tutorials/qlora_finetune.rst
@@ -31,10 +31,10 @@ What is QLoRA?
 QLoRA builds on top of LoRA to enable further
 memory savings. In LoRA, model parameters can be thought of as existing in two partitions: adapters, which are
 low-rank matrices added to different layers of a neural network, and base model parameters, which are parameters that are part of
-the original model. In vanilla LoRA-style training, both these parameters are held in the same precision (typically fp32 or bf16), and
+the original model. In vanilla LoRA-style training, both these parameters are held in the same precision (typically fp32 or `bf16 <https://en.wikipedia.org/wiki/Bfloat16_floating-point_format#bfloat16_floating-point_format>`_.), and
 therefore activations and intermediate gradients computed are in fp32/bf16.
 
-QLoRA further quantizes the base model parameters into a bespoke 4-bit NormalFloat (NF4) data type, resulting in 4-8x less parameter memory usage while
+QLoRA further quantizes the base model parameters into a bespoke 4-bit NormalFloat (`NF4 <https://www.youtube.com/watch?v=TPcXVJ1VSRI&t=563s>`_) data type, resulting in 4-8x less parameter memory usage while
 largely retaining model accuracy. As a result, the vast majority of parameters only take up 4 bits (as opposed to 16 or 32 bits by bf16/fp32 dtypes). This
 quantization is done through the method highlighted in the original `QLoRA paper <https://arxiv.org/abs/2305.14314>`_. Adapter
 parameters are still held in the original precision, and activations, gradients, and optimizer states still exist in the higher precision to preserve
@@ -86,7 +86,7 @@ Using QLoRA in torchtune
 We'll now cover how you can initialize a QLoRA-enabled Llama2-7b model as well as some details around
 checkpointing with QLoRA.
 
-With torchtune, you can use a simple builder similar to the LoRA builder (:code:`lora_llama_2_7b`) to apply QLoRA to Llama2 models. Here's a simple example of
+With torchtune, you can use a simple builder similar to the LoRA builder (:func:`lora_llama_2_7b <torchtune.models.llama2.lora_llama2_7b>`) to apply QLoRA to Llama2 models. Here's a simple example of
 initializing a Llama2-7b model with QLoRA enabled:
 
 .. code-block:: python
@@ -113,7 +113,8 @@ original precision (generally fp32/bf16). This allows QLoRA-trained checkpoints 
 torchtune and beyond (e.g. post-training quantization, evaluation, inference). This conversion process also allows LoRA adapter weights to be merged back into the base model as done
 in a typical LoRA training flow.
 
-To achieve this, when using torchtune's ``qlora_llama2_7b`` builder, we automatically register a hook, :code:`reparametrize_as_dtype_state_dict_post_hook`,
+To achieve this, when using torchtune's :func:`lora_llama_2_7b <torchtune.models.llama2.lora_llama2_7b>` builder, we automatically register a hook,
+:func:`reparametrize_as_dtype_state_dict_post_hook <torchtune.modules.common_utils.reparametrize_as_dtype_state_dict_post_hook>`,
 that runs after calling ``.state_dict()`` on the top level model. This hook converts ``NF4Tensors`` back to their original precision, while also offloading these
 converted tensors to the CPU. This offloading is to avoid peaking memory; if we did not, we would have to maintain an entire bf16/fp32 copy of the ``state_dict``
 on GPU.
@@ -122,6 +123,8 @@ on GPU.
 
 Putting it all together: QLoRA finetune
 -----------------------------------------
+
+.. TODO (SalmanMohammadi) ref lora recipe w qlora conf.
 
 Putting it all together, we can now finetune a model using torchtune's `LoRA recipe <https://github.com/pytorch/torchtune/blob/48626d19d2108f92c749411fbd5f0ff140023a25/recipes/lora_finetune.py>`_,
 with a `QLoRA configuration <https://github.com/pytorch/torchtune/blob/main/recipes/configs/llama2/7B_qlora_single_device.yaml>`_.
@@ -136,7 +139,7 @@ You can then run the following command to perform a QLoRA finetune of Llama2-7B 
 .. note::
     Make sure to correctly point to the location of your Llama2 weights and tokenizer. This can be done
     either by adding :code:`checkpointer.checkpoint_files=[my_model_checkpoint_path] tokenizer_checkpoint=my_tokenizer_checkpoint_path`
-    or by directly modifying the :code:`7B_qlora_single_device.yaml` file. See our :ref:`config_tutorial_label`
+    or by directly modifying the :code:`7B_qlora_single_device.yaml` file. See our ":ref:`config_tutorial_label`" recipe
     for more details on how you can easily clone and modify torchtune configs.
 
 By default, this run should log peak memory stats at model initialization time and every 100
@@ -173,7 +176,7 @@ second:
 
   1|149|Loss: 0.9157477021217346:   1%|          | 149/25880 [02:08<6:14:19,  1.15it/s
 
-To speed things up, we can leverage ``torch.compile`` to compile our model and run the compiled result. To work with
+To speed things up, we can leverage `torch.compile <https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html>`_ to compile our model and run the compiled result. To work with
 QLoRA training, a nightly build of PyTorch must be used. To update PyTorch to the latest nightly,
 please see `the installation instructions <https://pytorch.org/get-started/locally/>`_. Once updated,
 you can specify the compile flag as ``True`` via a config override:
@@ -194,7 +197,8 @@ A comparison of the smoothed loss curves between QLoRA and LoRA can be seen belo
 
 .. note::
     The above figure was generated with W&B. You can use torchtune's :class:`~torchtune.utils.metric_logging.WandBLogger`
-    to generate similar loss curves, but you will need to install W&B and setup an account separately.
+    to generate similar loss curves, but you will need to install W&B and setup an account separately. For more details on
+    using W&B in torchtune, see our ":ref:`wandb_logging`" recipe.
 
 As an exercise, you can also try running some evaluation tasks or manually inspecting generations
 output by your saved checkpoints (which can be found in :code:`output_dir`).


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

As I've been combing through our docs to write a recipe landing page, I've found we sometimes link directly to our GitHub code when there's an API doc page that exists. Our API docs are 🤌🏽. Our deep dives and tutorials are 🤌🏽. Let's make sure they're properly cross-referenced 🤌🏽🤌🏽 so our users don't have to go hunting for any details when reading.

#### Test plan

```
👁️                          👁️
        __
```