### PR TITLE
[memory improvement] pre-allocate memory before training starts

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -135,6 +135,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
 
+        # Arguments to pre allocte memory
+        self._batch_size = cfg.batch_size
+        self._max_seq_len = cfg.dataset.max_seq_len
+
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
         Extract the checkpoint state from file and validate. If resume_from_checkpoint
@@ -467,6 +471,53 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 intermediate_checkpoint=(epoch + 1 < self.total_epochs),
             )
 
+    def preallocate_memory(self):
+        """
+        Preallocates memory by doing one forward/backward pass with a dummy batch,
+        with the maximum sequence length, without updating the weights.
+        This reduces peak memory reserved during training, and also garantess that
+        you wont run into out-of-memory issues because of the batch size or sequence length.
+
+        For more info, check please check
+        `https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#preallocate-memory-in-case-of-variable-input-length`.
+        """
+        # Generate a random batch with maximum sequence length
+        tokens = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        labels = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        mask = torch.ones(
+            (self._batch_size, self._max_seq_len, self._max_seq_len),
+            device=self._device,
+            dtype=torch.bool,
+        )
+        input_pos = (
+            torch.arange(self._max_seq_len, device=self._device, dtype=torch.int64)
+            .unsqueeze(0)
+            .repeat(self._batch_size, 1)
+        )
+
+        # Forward pass
+        logits = self._model(tokens, mask=mask, input_pos=input_pos)
+        logits = logits[..., :-1, :].contiguous()
+        labels = labels[..., 1:].contiguous()
+        logits = logits.transpose(1, 2)
+
+        # Compute loss
+        loss = self._loss_fn(logits, labels)
+        # free logits otherwise it peaks backward memory
+        del logits
+        loss.backward()
+
+        # Zero out gradients
+        self._optimizer.zero_grad(set_to_none=True)
+
     def train(self) -> None:
         """
         The core training loop. Supports training on subsets of the dataset using the
@@ -478,7 +529,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         _, rank = utils.get_world_size_and_rank()
 
         # zero out the gradients before starting training
-        self._optimizer.zero_grad()
+        self._optimizer.zero_grad(set_to_none=True)
+
+        # Preallocate memory before training starts
+        self.preallocate_memory()
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -137,7 +137,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
         # Arguments to pre allocte memory
         self._batch_size = cfg.batch_size
-        self._max_seq_len = cfg.dataset.max_seq_len
+        self._max_seq_len = cfg.dataset.get("max_seq_len", None)
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -532,7 +532,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         self._optimizer.zero_grad(set_to_none=True)
 
         # Preallocate memory before training starts
-        self.preallocate_memory()
+        # max_seq_len needs to be defined in the config to generate
+        # the buffer
+        if self._max_seq_len:
+            self.preallocate_memory()
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -130,6 +130,10 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
 
+        # Arguments to pre allocte memory
+        self._batch_size = cfg.batch_size
+        self._max_seq_len = cfg.dataset.max_seq_len
+
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
         Extract the checkpoint state from file and validate. If resume_from_checkpoint
@@ -397,6 +401,53 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             intermediate_checkpoint=(epoch + 1 < self.total_epochs),
         )
 
+    def preallocate_memory(self):
+        """
+        Preallocates memory by doing one forward/backward pass with a dummy batch,
+        with the maximum sequence length, without updating the weights.
+        This reduces peak memory reserved during training, and also garantess that
+        you wont run into out-of-memory issues because of the batch size or sequence length.
+
+        For more info, check please check
+        `https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#preallocate-memory-in-case-of-variable-input-length`.
+        """
+        # Generate a random batch with maximum sequence length
+        tokens = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        labels = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        mask = torch.ones(
+            (self._batch_size, self._max_seq_len, self._max_seq_len),
+            device=self._device,
+            dtype=torch.bool,
+        )
+        input_pos = (
+            torch.arange(self._max_seq_len, device=self._device, dtype=torch.int64)
+            .unsqueeze(0)
+            .repeat(self._batch_size, 1)
+        )
+
+        # Forward pass
+        logits = self._model(tokens, mask=mask, input_pos=input_pos)
+        logits = logits[..., :-1, :].contiguous()
+        labels = labels[..., 1:].contiguous()
+        logits = logits.transpose(1, 2)
+
+        # Compute loss
+        loss = self._loss_fn(logits, labels)
+        # free logits otherwise it peaks backward memory
+        del logits
+        loss.backward()
+
+        # Zero out gradients
+        self._optimizer.zero_grad(set_to_none=True)
+
     def train(self) -> None:
         """
         The core training loop. Supports training on subsets of the dataset using the
@@ -406,9 +457,16 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             log.info(
                 "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."
             )
+
+        # clean up before training begins
+        utils.cleanup_before_training()
+
         # zero out the gradients before starting training
         if not self._optimizer_in_bwd:
-            self._optimizer.zero_grad()
+            self._optimizer.zero_grad(set_to_none=True)
+
+            # Preallocate memory before training starts
+            self.preallocate_memory()
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()
@@ -452,7 +510,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 logits = logits.transpose(1, 2)
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
-
+                del logits
                 loss = loss / self._gradient_accumulation_steps
                 running_loss += loss
                 loss.backward()

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -510,7 +510,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 logits = logits.transpose(1, 2)
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
-                del logits
                 loss = loss / self._gradient_accumulation_steps
                 running_loss += loss
                 loss.backward()

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -458,9 +458,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."
             )
 
-        # clean up before training begins
-        utils.cleanup_before_training()
-
         # zero out the gradients before starting training
         if not self._optimizer_in_bwd:
             self._optimizer.zero_grad(set_to_none=True)

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -132,7 +132,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # Arguments to pre allocte memory
         self._batch_size = cfg.batch_size
-        self._max_seq_len = cfg.dataset.max_seq_len
+        self._max_seq_len = cfg.dataset.get("max_seq_len", None)
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -466,7 +466,10 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             self._optimizer.zero_grad(set_to_none=True)
 
             # Preallocate memory before training starts
-            self.preallocate_memory()
+            # max_seq_len needs to be defined in the config to generate
+            # the buffer
+            if self._max_seq_len:
+                self.preallocate_memory()
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -141,7 +141,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # Arguments to pre allocte memory
         self._batch_size = cfg.batch_size
-        self._max_seq_len = cfg.dataset.max_seq_len
+        self._max_seq_len = cfg.dataset.get("max_seq_len", None)
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -675,7 +675,10 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         self._optimizer.zero_grad(set_to_none=True)
 
         # Preallocate memory before training starts
-        self.preallocate_memory()
+        # max_seq_len needs to be defined in the config to generate
+        # the buffer
+        if self._max_seq_len:
+            self.preallocate_memory()
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -576,9 +576,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         The core training loop.
         """
 
-        # clean up before training begins
-        utils.cleanup_before_training()
-
         # zero out the gradients before starting training
         self._optimizer.zero_grad(set_to_none=True)
 

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -134,7 +134,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # Arguments to pre allocte memory
         self._batch_size = cfg.batch_size
-        self._max_seq_len = cfg.dataset.max_seq_len
+        self._max_seq_len = cfg.dataset.get("max_seq_len", None)
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -583,7 +583,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._optimizer.zero_grad(set_to_none=True)
 
         # Preallocate memory before training starts
-        self.preallocate_memory()
+        # max_seq_len needs to be defined in the config to generate
+        # the buffer
+        if self._max_seq_len:
+            self.preallocate_memory()
 
         if self._model_compile:
             log.info(

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -132,6 +132,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
+        # Arguments to pre allocte memory
+        self._batch_size = cfg.batch_size
+        self._max_seq_len = cfg.dataset.max_seq_len
+
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
         Extract the checkpoint state from file and validate. This includes the
@@ -520,10 +524,66 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             intermediate_checkpoint=(epoch + 1 < self.total_epochs),
         )
 
+    def preallocate_memory(self):
+        """
+        Preallocates memory by doing one forward/backward pass with a dummy batch,
+        with the maximum sequence length, without updating the weights.
+        This reduces peak memory reserved during training, and also garantess that
+        you wont run into out-of-memory issues because of the batch size or sequence length.
+
+        For more info, check please check
+        `https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#preallocate-memory-in-case-of-variable-input-length`.
+        """
+        # Generate a random batch with maximum sequence length
+        tokens = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        labels = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        mask = torch.ones(
+            (self._batch_size, self._max_seq_len, self._max_seq_len),
+            device=self._device,
+            dtype=torch.bool,
+        )
+        input_pos = (
+            torch.arange(self._max_seq_len, device=self._device, dtype=torch.int64)
+            .unsqueeze(0)
+            .repeat(self._batch_size, 1)
+        )
+
+        # Forward pass
+        logits = self._model(tokens, mask=mask, input_pos=input_pos)
+        logits = logits[..., :-1, :].contiguous()
+        labels = labels[..., 1:].contiguous()
+        logits = logits.transpose(1, 2)
+
+        # Compute loss
+        loss = self._loss_fn(logits, labels)
+        # free logits otherwise it peaks backward memory
+        del logits
+        loss.backward()
+
+        # Zero out gradients
+        self._optimizer.zero_grad(set_to_none=True)
+
     def train(self) -> None:
         """
         The core training loop.
         """
+
+        # clean up before training begins
+        utils.cleanup_before_training()
+
+        # zero out the gradients before starting training
+        self._optimizer.zero_grad(set_to_none=True)
+
+        # Preallocate memory before training starts
+        self.preallocate_memory()
 
         if self._model_compile:
             log.info(

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -148,6 +148,10 @@ class QATRecipeDistributed(FTRecipeInterface):
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
 
+        # Arguments to pre allocte memory
+        self._batch_size = cfg.batch_size
+        self._max_seq_len = cfg.dataset.max_seq_len
+
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
         Extract the checkpoint state from file and validate. If resume_from_checkpoint
@@ -495,6 +499,53 @@ class QATRecipeDistributed(FTRecipeInterface):
                 intermediate_checkpoint=(epoch + 1 < self.total_epochs),
             )
 
+    def preallocate_memory(self):
+        """
+        Preallocates memory by doing one forward/backward pass with a dummy batch,
+        with the maximum sequence length, without updating the weights.
+        This reduces peak memory reserved during training, and also garantess that
+        you wont run into out-of-memory issues because of the batch size or sequence length.
+
+        For more info, check please check
+        `https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#preallocate-memory-in-case-of-variable-input-length`.
+        """
+        # Generate a random batch with maximum sequence length
+        tokens = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        labels = torch.zeros(
+            size=(self._batch_size, self._max_seq_len),
+            device=self._device,
+            dtype=torch.int64,
+        )
+        mask = torch.ones(
+            (self._batch_size, self._max_seq_len, self._max_seq_len),
+            device=self._device,
+            dtype=torch.bool,
+        )
+        input_pos = (
+            torch.arange(self._max_seq_len, device=self._device, dtype=torch.int64)
+            .unsqueeze(0)
+            .repeat(self._batch_size, 1)
+        )
+
+        # Forward pass
+        logits = self._model(tokens, mask=mask, input_pos=input_pos)
+        logits = logits[..., :-1, :].contiguous()
+        labels = labels[..., 1:].contiguous()
+        logits = logits.transpose(1, 2)
+
+        # Compute loss
+        loss = self._loss_fn(logits, labels)
+        # free logits otherwise it peaks backward memory
+        del logits
+        loss.backward()
+
+        # Zero out gradients
+        self._optimizer.zero_grad(set_to_none=True)
+
     def train(self) -> None:
         """
         The core training loop. Supports training on subsets of the dataset using the
@@ -506,7 +557,10 @@ class QATRecipeDistributed(FTRecipeInterface):
         _, rank = utils.get_world_size_and_rank()
 
         # zero out the gradients before starting training
-        self._optimizer.zero_grad()
+        self._optimizer.zero_grad(set_to_none=True)
+
+        # Preallocate memory before training starts
+        self.preallocate_memory()
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -150,7 +150,7 @@ class QATRecipeDistributed(FTRecipeInterface):
 
         # Arguments to pre allocte memory
         self._batch_size = cfg.batch_size
-        self._max_seq_len = cfg.dataset.max_seq_len
+        self._max_seq_len = cfg.dataset.get("max_seq_len", None)
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -560,7 +560,10 @@ class QATRecipeDistributed(FTRecipeInterface):
         self._optimizer.zero_grad(set_to_none=True)
 
         # Preallocate memory before training starts
-        self.preallocate_memory()
+        # max_seq_len needs to be defined in the config to generate
+        # the buffer
+        if self._max_seq_len:
+            self.preallocate_memory()
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

As suggested in [pytorch tuning guide](https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#preallocate-memory-in-case-of-variable-input-length): 

> "reallocate memory in case of variable input length
> Models for speech recognition or for NLP are often trained on input tensors with variable sequence length. Variable length can be problematic for PyTorch caching allocator and can lead to reduced performance or to unexpected out-of-memory errors. If a batch with a short sequence length is followed by an another batch with longer sequence length, then PyTorch is forced to release intermediate buffers from previous iteration and to re-allocate new buffers. This process is time consuming and causes fragmentation in the caching allocator which may result in out-of-memory errors.
> 
> A typical solution is to implement preallocation. It consists of the following steps:
> 
> - generate a (usually random) batch of inputs with maximum sequence length (either corresponding to max length in the training dataset or to some predefined threshold)
> - execute a forward and a backward pass with the generated batch, do not execute an optimizer or a learning rate scheduler, this step preallocates buffers of maximum size, which can be reused in subsequent training iterations
> - zero out gradients
> - proceed to regular training"

It greatly decreases max reserved memory, and if the batch or max_seq is too large, it should raise OOM before training starts, instead of during training.

To reproduce: https://gist.github.com/felipemello1/17871d69435a2f6f22fa333f31dfe020

#### Changelog
- Added memory pre-allocation to Full FT, LoRA and QAT scripts. It is the same function for all scripts. I wonder if this should be some utils function.
- Changed `self._optimizer.zero_grad()` to `self._optimizer.zero_grad(set_to_none=True)`

notes:
- IMPORTANT: I noticed that in the distributed frameworks, memory consumption still increases after batch one (images below). I think its worth investigating if some memory is not being released, or if thats just a property of distributed training. @ebsmothers 
- It requires for max_seq_len to be defined in the config. One additional thing we could do is check if dataset == packed, and if so, use the model hardcoded max_seq_len. But I am not sure if its worth the trouble.
- RL scripts are a bit more complex and would need to be addressed in another PR

#### Test plan
Ran it before and after the change
![image](https://github.com/user-attachments/assets/b63147f4-cb6a-4a92-b216-07345bb9d2de)
![image](https://github.com/user-attachments/assets/3d520a30-dc78-4a14-9cb6-140fcd8f8bf0)
![image](https://github.com/user-attachments/assets/1aca0d5f-13ff-4cda-836a-65e4b99dda4a)
![image](https://github.com/user-attachments/assets/e1a781fd-3486-40ca-9fd8-44423c84cedc)
![image](https://github.com/user-attachments/assets/4808ed87-9bc6-489f-97d1-098e41a45199)
![image](https://github.com/user-attachments/assets/07b157dc-59a8-4ddb-a7fe-520e35e96a3c)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
