### PR TITLE
[Memory Improvement] delete logits before bwd - DPO style

### DIFF
--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -645,6 +645,11 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     policy_rejected_logits,
                 ) = self.concatenated_forward(self._model, batch)
 
+                policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
+                policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
+
+                del policy_chosen_logits, policy_rejected_logits
+
                 with torch.no_grad(), disable_adapter(self._model):
                     (
                         reference_chosen_log_probs,
@@ -703,10 +708,8 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                             "log_probs/chosen": policy_chosen_log_probs.detach()
                             .mean()
                             .cpu(),
-                            "logits/rejected": policy_rejected_logits.detach()
-                            .mean()
-                            .cpu(),
-                            "logits/chosen": policy_chosen_logits.detach().mean().cpu(),
+                            "logits/rejected": policy_rejected_logits_mean.cpu(),
+                            "logits/chosen": policy_chosen_logits_mean.cpu(),
                         }
                         if self._log_peak_memory_stats:
                             log_dict.update(utils.get_memory_stats(device=self._device))

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -506,6 +506,11 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                     policy_rejected_logits,
                 ) = self.concatenated_forward(self._model, batch)
 
+                policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
+                policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
+
+                del policy_chosen_logits, policy_rejected_logits
+
                 with torch.no_grad(), disable_adapter(self._model):
                     (
                         reference_chosen_log_probs,
@@ -560,10 +565,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                             "log_probs/chosen": policy_chosen_log_probs.detach()
                             .mean()
                             .cpu(),
-                            "logits/rejected": policy_rejected_logits.detach()
-                            .mean()
-                            .cpu(),
-                            "logits/chosen": policy_chosen_logits.detach().mean().cpu(),
+                            "logits/rejected": policy_rejected_logits_mean.cpu(),
+                            "logits/chosen": policy_chosen_logits_mean.cpu(),
                         }
                         if self._log_peak_memory_stats:
                             log_dict.update(utils.get_memory_stats(device=self._device))


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

https://github.com/pytorch/torchtune/pull/1235 
https://github.com/pytorch/torchtune/pull/1046

I uphold the findings from @felipemello1 in #1235; deleting logits in the LoRA DPO recipes before the backward pass, also reduces memory consumption. Isn't it just wonderful?
![image](https://github.com/user-attachments/assets/00772afe-71ff-41e3-a651-329611aae47f)

Credit to the authors of the pull requests above for the excellent suggestions. Thanks @felipemello1 for pointing this out for me to try.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
