### PR TITLE
Call out limitations of Eleuther generation capabilities

### DIFF
--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -130,6 +130,12 @@ class _EvalWrapper(HFLM):
     ) -> torch.Tensor:
         curr_batch_size = context.size(0)
 
+        if curr_batch_size > 1:
+            raise ValueError(
+                f"Got a batch size of '{curr_batch_size}'. Batch size > 1 is not supported for "
+                "generation. See https://github.com/pytorch/torchtune/issues/1250 for more info."
+            )
+
         # Setup caches for a given batch size
         # Technically this is not necessary, but it's a good way to ensure that
         # the caches won't error on a different batch size. In addition, caches


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
* Add error

#### Test plan

```
(joe-torchtune) [jrcummings@devgpu012.cln5 ~/projects/joe-torchtune (fix-mask-for-eval)]$ tune run eleuther_eval --config eleuther_evaluation tasks=["truthfulqa_gen"] batch_size=8
2024-08-01:19:59:40,534 INFO     [_utils.py:33] Running EleutherEvalRecipe with resolved config:

batch_size: 8
checkpointer:
  _component_: torchtune.utils.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
  checkpoint_files:
  - model-00001-of-00004.safetensors
  - model-00002-of-00004.safetensors
  - model-00003-of-00004.safetensors
  - model-00004-of-00004.safetensors
  model_type: LLAMA3
  output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
  recipe_checkpoint: null
device: cuda
dtype: bf16
limit: null
max_seq_length: 4096
model:
  _component_: torchtune.models.llama3.llama3_8b
quantizer: null
seed: 1234
tasks:
- truthfulqa_gen
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model

2024-08-01:19:59:42,559 DEBUG    [seed.py:60] Setting manual seed to local seed 1234. Local seed is seed + rank = 1234 + 0
2024-08-01:19:59:48,122 INFO     [eleuther_eval.py:236] Model is initialized with precision torch.bfloat16.
2024-08-01:19:59:48,541 INFO     [eleuther_eval.py:214] Tokenizer is initialized from file.
2024-08-01:19:59:48,934 INFO     [huggingface.py:162] Using device 'cuda:0'
/home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
2024-08-01:19:59:58,512 INFO     [eleuther_eval.py:261] Running evaluation on ['truthfulqa_gen'] tasks.
2024-08-01:19:59:58,514 INFO     [task.py:395] Building contexts for truthfulqa_gen on rank 0...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 817/817 [00:00<00:00, 1328.37it/s]
2024-08-01:19:59:59,189 INFO     [evaluator.py:362] Running generate_until requests
Running generate_until requests:   0%|                                                                                                                                                                                       | 0/817 [00:00<?, ?it/s]Traceback (most recent call last):
  File "/home/jrcummings/.conda/envs/joe-torchtune/bin/tune", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/jrcummings/projects/joe-torchtune/torchtune/_cli/tune.py", line 49, in main
    parser.run(args)
  File "/home/jrcummings/projects/joe-torchtune/torchtune/_cli/tune.py", line 43, in run
    args.func(args)
  File "/home/jrcummings/projects/joe-torchtune/torchtune/_cli/run.py", line 179, in _run_cmd
    self._run_single_device(args)
  File "/home/jrcummings/projects/joe-torchtune/torchtune/_cli/run.py", line 93, in _run_single_device
    runpy.run_path(str(args.recipe), run_name="__main__")
  File "<frozen runpy>", line 291, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/home/jrcummings/projects/joe-torchtune/recipes/eleuther_eval.py", line 284, in <module>
    sys.exit(recipe_main())
             ^^^^^^^^^^^^^
  File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_parse.py", line 50, in wrapper
    sys.exit(recipe_main(conf))
             ^^^^^^^^^^^^^^^^^
  File "/home/jrcummings/projects/joe-torchtune/recipes/eleuther_eval.py", line 280, in recipe_main
    recipe.evaluate()
  File "/home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jrcummings/projects/joe-torchtune/recipes/eleuther_eval.py", line 262, in evaluate
    output = evaluate(
             ^^^^^^^^^
  File "/home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/lm_eval/utils.py", line 288, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/lm_eval/evaluator.py", line 373, in evaluate
    resps = getattr(lm, reqtype)(cloned_reqs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jrcummings/.conda/envs/joe-torchtune/lib/python3.11/site-packages/lm_eval/models/huggingface.py", line 1196, in generate_until
    cont = self._model_generate(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jrcummings/projects/joe-torchtune/recipes/eleuther_eval.py", line 134, in _model_generate
    raise ValueError(
ValueError: Got a batch size of '8'. Batch size > 1 is not supported for generation. See https://github.com/pytorch/torchtune/issues/1250 for more info.
```

