### PR TITLE
Add torchvision to build linux workflow

### DIFF
--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -42,3 +42,4 @@ jobs:
       pre-script: .github/scripts/pre_build_script.sh
       trigger-event: ${{ github.event_name }}
       build-platform: 'python-build-package'
+      pip-install-torch-extra-args: torchvision


### PR DESCRIPTION
#### Context
With torchvision as a new dependency, we still need to update the build_linux_wheels workflow to install torchvision along with nightlies of torch.

#### Test plan
- Tested the resultant command: `pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cu121 torchvision`. This installs the latest nightlies for both.
- Checked that this patches the CI in #1234 
