### PR TITLE
Export ClipImageTransform

### DIFF
--- a/docs/source/api_ref_modules.rst
+++ b/docs/source/api_ref_modules.rst
@@ -99,6 +99,7 @@ Functions used for preprocessing images.
 
     transforms.Transform
     transforms.get_canvas_best_fit
+    transforms.get_inscribed_size
     transforms.resize_with_pad
     transforms.tile_crop
     transforms.find_supported_resolutions

--- a/tests/torchtune/modules/transforms/test_get_inscribed_size.py
+++ b/tests/torchtune/modules/transforms/test_get_inscribed_size.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from torchtune.modules.transforms import get_inscribed_size
+
+
+class TestTransforms:
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {
+                "image_size": (200, 100),
+                "target_size": (1000, 1200),
+                "max_size": 600,
+                "expected_inscribed_size": (600, 300),
+            },
+            {
+                "image_size": (2000, 200),
+                "target_size": (1000, 1200),
+                "max_size": 600,
+                "expected_inscribed_size": (1000, 100),
+            },
+            {
+                "image_size": (400, 200),
+                "target_size": (1000, 1200),
+                "max_size": 2000,
+                "expected_inscribed_size": (1000, 500),
+            },
+            {
+                "image_size": (400, 200),
+                "target_size": (1000, 1200),
+                "max_size": None,
+                "expected_inscribed_size": (1000, 500),
+            },
+            {
+                "image_size": (1000, 500),
+                "target_size": (400, 300),
+                "max_size": None,
+                "expected_inscribed_size": (400, 200),
+            },
+        ],
+    )
+    def test_get_inscribed_size(self, params):
+        image_size = params["image_size"]
+        target_size = params["target_size"]
+        max_size = params["max_size"]
+        expected_inscribed_size = params["expected_inscribed_size"]
+
+        inscribed_size = get_inscribed_size(
+            image_size=image_size,
+            target_size=target_size,
+            max_size=max_size,
+        )
+
+        assert inscribed_size == expected_inscribed_size

--- a/tests/torchtune/modules/transforms/test_resize_with_pad.py
+++ b/tests/torchtune/modules/transforms/test_resize_with_pad.py
@@ -19,31 +19,31 @@ class TestTransforms:
             {
                 "image_size": (200, 100),
                 "target_size": (1000, 1200),
-                "max_upscaling_size": 600,
+                "max_size": 600,
                 "expected_resized_size": (600, 300),
             },
             {
                 "image_size": (2000, 200),
                 "target_size": (1000, 1200),
-                "max_upscaling_size": 600,
+                "max_size": 600,
                 "expected_resized_size": (1000, 100),
             },
             {
                 "image_size": (400, 200),
                 "target_size": (1000, 1200),
-                "max_upscaling_size": 2000,
+                "max_size": 2000,
                 "expected_resized_size": (1000, 500),
             },
             {
                 "image_size": (400, 200),
                 "target_size": (1000, 1200),
-                "max_upscaling_size": None,
+                "max_size": None,
                 "expected_resized_size": (1000, 500),
             },
             {
                 "image_size": (1000, 500),
                 "target_size": (400, 300),
-                "max_upscaling_size": None,
+                "max_size": None,
                 "expected_resized_size": [400, 200],
             },
         ],
@@ -52,7 +52,7 @@ class TestTransforms:
 
         image_size = params["image_size"]
         target_size = params["target_size"]
-        max_upscaling_size = params["max_upscaling_size"]
+        max_size = params["max_size"]
         expected_resized_size = params["expected_resized_size"]
 
         image = torch.rand(3, *image_size)  # Create a random image tensor
@@ -61,7 +61,7 @@ class TestTransforms:
             image=image,
             target_size=target_size,
             resample=torchvision.transforms.InterpolationMode["BILINEAR"],
-            max_upscaling_size=max_upscaling_size,
+            max_size=max_size,
         )
 
         # assert everything beyond resize has value == 0

--- a/torchtune/modules/transforms/__init__.py
+++ b/torchtune/modules/transforms/__init__.py
@@ -9,14 +9,21 @@ from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (  # n
     find_supported_resolutions,
     get_canvas_best_fit,
 )
+
+from torchtune.modules.transforms.vision_utils.get_inscribed_size import (  # noqa
+    get_inscribed_size,
+)
+
 from torchtune.modules.transforms.vision_utils.resize_with_pad import (  # noqa
     resize_with_pad,
 )
+
 from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop  # noqa
 
 __all__ = [
     "Transform",
     "get_canvas_best_fit",
+    "get_inscribed_size",
     "resize_with_pad",
     "tile_crop",
     "find_supported_resolutions",

--- a/torchtune/modules/transforms/vision_utils/get_inscribed_size.py
+++ b/torchtune/modules/transforms/vision_utils/get_inscribed_size.py
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+import math
+
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def get_inscribed_size(
+    image_size: Tuple[int], target_size: Tuple[int], max_size: Optional[int]
+) -> Tuple[int]:
+    """
+    Calculates the size of an image, if it was resized to be inscribed within the target_size.
+    It is upscaled or downscaled such that one size is equal to the target_size, and the second
+    size is less than or equal to the target_size.
+
+    The user can set max_size to limit upscaling along the larger dimension when target_size exceeds
+    the image_size.
+
+    Args:
+        image_size (Tuple[int]): The size of the image, in the form [height, width].
+        target_size (Tuple[int]): The desired resolution to fit the image into, in the format [height, width].
+        max_size (Optional[int]): The maximum size to upscale the image to.
+            If None, will upscale to target size.
+
+    Returns:
+        Tuple[int]: The resize dimensions for the image, in the format [height, width].
+
+    Examples:
+
+        Example 1: The image will be upscaled from (300, 800) to (448, 1194), since 448 is the limiting side.
+
+            >>> max_size = None
+            >>> image_size = (300, 800)
+            >>> target_size = (448, 1344)
+            >>> output = get_inscribed_size(image_size, target_size, max_size)
+
+        Example 2: The image will stay as is, since 800 > 600.
+
+            >>> max_size = 600
+            >>> image_size = (300, 800)
+            >>> target_size = (448, 1344)
+            >>> output = get_inscribed_size(image_size, target_size, max_size)
+
+        Example 3: The image will be downscaled from (500, 1000) to (224, 448).
+
+            >>> max_size = 600
+            >>> image_size = (500, 1000)
+            >>> target_size = (448, 488)
+            >>> output = get_inscribed_size(image_size, target_size, max_size)
+    """
+    assert len(image_size) == 2, "Image size must be a list of length 2."
+    assert len(target_size) == 2, "Canvas size must be a list of length 2."
+
+    image_height, image_width = image_size
+
+    # Bound target_size with max_size.
+    if max_size is not None:
+        target_height = min(max(image_height, max_size), target_size[0])
+        target_width = min(max(image_width, max_size), target_size[1])
+    else:
+        target_height, target_width = target_size
+
+    # Calculate the largest aspect ratio preserving size that fits target_size.
+    scale_h = target_height / image_height
+    scale_w = target_width / image_width
+
+    resize_height = min(math.floor(image_height * scale_w), target_height)
+    resize_width = min(math.floor(image_width * scale_h), target_width)
+
+    return (resize_height, resize_width)

--- a/torchtune/modules/transforms/vision_utils/resize_with_pad.py
+++ b/torchtune/modules/transforms/vision_utils/resize_with_pad.py
@@ -21,11 +21,11 @@ def resize_with_pad(
     image: torch.Tensor,
     target_size: Tuple[int, int],
     resample: torchvision.transforms.InterpolationMode,
-    max_upscaling_size: Optional[int] = None,
+    max_size: Optional[int] = None,
 ) -> torch.Tensor:
     """
     Resizes and pads an image to target_size without causing distortion.
-    The user can set max_upscaling_size to limit upscaling when target_size exceeds image_size.
+    The user can set max_size to limit upscaling when target_size exceeds image_size.
 
     Args:
         image (torch.Tensor): The input image tensor in the format [..., H, W].
@@ -33,7 +33,7 @@ def resize_with_pad(
         resample (torchvision.transforms.InterpolationMode): Resampling method used when resizing images.
             Supports torchvision.transforms.InterpolationMode.NEAREST, InterpolationMode.NEAREST_EXACT,
             InterpolationMode.BILINEAR and InterpolationMode.BICUBIC.
-        max_upscaling_size (Optional[int]): The maximum size to upscale the image to.
+        max_size (Optional[int]): The maximum size to upscale the image to.
             If None, will upscale up to target_size.
 
     Returns:
@@ -44,38 +44,38 @@ def resize_with_pad(
         Example 1: The image will be upscaled from (300, 800) to (448, 1194), since 448 is the limiting side,
         and then padded from (448, 1194) to (448, 1344).
 
-            >>> max_upscaling_size = None
+            >>> max_size = None
             >>> image = torch.rand([3, 300, 800])
             >>> target_size = (448, 1344)
             >>> resample = torchvision.transforms.InterpolationMode.BILINEAR
-            >>> output = resize_with_pad(image, target_size, resample, max_upscaling_size)
+            >>> output = resize_with_pad(image, target_size, resample, max_size)
 
         Example 2: The image will stay as is, since 800 > 600, and then padded from (300, 800) to (448, 1344).
 
-            >>> max_upscaling_size = 600
+            >>> max_size = 600
             >>> image = torch.rand([3, 300, 800])
             >>> target_size = (448, 1344)
             >>> resample = torchvision.transforms.InterpolationMode.BILINEAR
-            >>> output = resize_with_pad(image, target_size, resample, max_upscaling_size)
+            >>> output = resize_with_pad(image, target_size, resample, max_size)
 
         Example 3: The image will be downscaled from (500, 1000) to (224, 448),
         and padded from (224, 448) to (448, 448).
 
-            >>> max_upscaling_size = 600
+            >>> max_size = 600
             >>> image = torch.rand([3, 500, 1000])
             >>> target_size = (448, 488)
             >>> resample = torchvision.transforms.InterpolationMode.BILINEAR
-            >>> output = resize_with_pad(image, target_size, resample, max_upscaling_size)
+            >>> output = resize_with_pad(image, target_size, resample, max_size)
 
     """
 
     image_height, image_width = image.shape[-2:]
     image_size = (image_height, image_width)
 
-    # If target_size requires upscaling, we might want to limit the upscaling to max_upscaling_size
-    if max_upscaling_size is not None:
-        new_target_height = min(max(image_height, max_upscaling_size), target_size[0])
-        new_target_width = min(max(image_width, max_upscaling_size), target_size[1])
+    # If target_size requires upscaling, we might want to limit the upscaling to max_size
+    if max_size is not None:
+        new_target_height = min(max(image_height, max_size), target_size[0])
+        new_target_width = min(max(image_width, max_size), target_size[1])
         target_size_resize = (new_target_height, new_target_width)
     else:
         target_size_resize = target_size


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
- Add torchtune/models/clip/inference/_transforms.py, a version of CLIPImageTransform that can be exported. Update transforms tests with a comparison between the two CLIPImageTransforms. 
- Refactor target_size calculations into function `get_resize_dimensions`, add tests.
- Change tile_crop from a function to an nn.Module for module swapping, update callsites.

Note: we cannot add a test for the exported model, as source transforms are required on the nn.Modules to successfully export it. 

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](../tests/torchtune) for any new functionality
- [x] update [docstrings](../docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
