### PR TITLE
Expose max_seq_len in tokenizer builders

### DIFF
--- a/torchtune/models/gemma/_model_builders.py
+++ b/torchtune/models/gemma/_model_builders.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import List
+from typing import List, Optional
 
 from torchtune.models.gemma._component_builders import gemma, lora_gemma
 from torchtune.models.gemma.transformer import GemmaTransformerDecoder
@@ -41,17 +41,19 @@ def gemma_2b() -> GemmaTransformerDecoder:
     )
 
 
-def gemma_tokenizer(path: str) -> GemmaTokenizer:
+def gemma_tokenizer(path: str, max_seq_len: Optional[int] = None) -> GemmaTokenizer:
     """
     Tokenizer for Gemma.
 
     Args:
         path (str): path to the tokenizer
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
 
     Returns:
         GemmaTokenizer: Instantiation of the Gemma tokenizer
     """
-    return GemmaTokenizer(path)
+    return GemmaTokenizer(path=path, max_seq_len=max_seq_len)
 
 
 def lora_gemma_2b(

--- a/torchtune/models/llama2/_model_builders.py
+++ b/torchtune/models/llama2/_model_builders.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import List
+from typing import List, Optional
 from functools import partial
 
 from torchtune.models.llama2._component_builders import llama2, lora_llama2, llama2_classifier, lora_llama2_classifier
@@ -40,17 +40,19 @@ def llama2_7b() -> TransformerDecoder:
     )
 
 
-def llama2_tokenizer(path: str) -> Llama2Tokenizer:
+def llama2_tokenizer(path: str, max_seq_len: Optional[int] = None) -> Llama2Tokenizer:
     """
     Tokenizer for Llama2.
 
     Args:
         path (str): path to the tokenizer
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
 
     Returns:
         Llama2Tokenizer: Instantiation of the Llama2 tokenizer
     """
-    return Llama2Tokenizer(path)
+    return Llama2Tokenizer(path=path, max_seq_len=max_seq_len)
 
 
 def lora_llama2_7b(

--- a/torchtune/models/llama3/_model_builders.py
+++ b/torchtune/models/llama3/_model_builders.py
@@ -63,7 +63,7 @@ def llama3_70b() -> TransformerDecoder:
     )
 
 
-def llama3_tokenizer(path: str, special_tokens_path: Optional[str] = None) -> Llama3Tokenizer:
+def llama3_tokenizer(path: str, special_tokens_path: Optional[str] = None, max_seq_len: Optional[int] = None) -> Llama3Tokenizer:
     """
     Tokenizer for Llama3.
 
@@ -72,12 +72,14 @@ def llama3_tokenizer(path: str, special_tokens_path: Optional[str] = None) -> Ll
         special_tokens_path (Optional[str]): Path to ``tokenizer.json`` from Hugging Face
             model files that contains all registered special tokens, or a local json file 
             structured similarly. Default is None to use the canonical Llama3 special tokens.
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
     
     Returns:
         Llama3Tokenizer: Instantiation of the Llama3 tokenizer
     """
     special_tokens = parse_hf_tokenizer_json(special_tokens_path) if special_tokens_path is not None else None
-    return Llama3Tokenizer(path=path, special_tokens=special_tokens)
+    return Llama3Tokenizer(path=path, special_tokens=special_tokens, max_seq_len=max_seq_len)
 
 
 def lora_llama3_8b(

--- a/torchtune/models/llama3_1/_model_builders.py
+++ b/torchtune/models/llama3_1/_model_builders.py
@@ -63,23 +63,6 @@ def llama3_1_70b() -> TransformerDecoder:
     )
 
 
-def llama3_tokenizer(path: str, special_tokens_path: Optional[str] = None) -> Llama3Tokenizer:
-    """
-    Tokenizer for Llama3 and Llama3.1.
-
-    Args:
-        path (str): path to the tokenizer
-        special_tokens_path (Optional[str]): Path to ``tokenizer.json`` from Hugging Face
-            model files that contains all registered special tokens, or a local json file 
-            structured similarly. Default is None to use the canonical Llama3 special tokens.
-    
-    Returns:
-        Llama3Tokenizer: Instantiation of the Llama3/Llama3.1 tokenizer
-    """
-    special_tokens = parse_hf_tokenizer_json(special_tokens_path) if special_tokens_path is not None else None
-    return Llama3Tokenizer(path=path, special_tokens=special_tokens)
-
-
 def lora_llama3_1_8b(
     lora_attn_modules: List[LORA_ATTN_MODULES],
     apply_lora_to_mlp: bool = False,

--- a/torchtune/models/mistral/_model_builders.py
+++ b/torchtune/models/mistral/_model_builders.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import List
+from typing import List, Optional
 
 from torchtune.models.mistral._component_builders import (
     mistral,
@@ -46,17 +46,19 @@ def mistral_7b() -> TransformerDecoder:
     )
 
 
-def mistral_tokenizer(path: str) -> MistralTokenizer:
+def mistral_tokenizer(path: str, max_seq_len: Optional[int] = None) -> MistralTokenizer:
     """
     Tokenizer for Mistral models.
 
     Args:
         path (str): path to the tokenizer
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
 
     Returns:
         MistralTokenizer: Instantiation of the Mistral tokenizer
     """
-    return MistralTokenizer(path)
+    return MistralTokenizer(path=path, max_seq_len=max_seq_len)
 
 
 def lora_mistral_7b(

--- a/torchtune/models/phi3/_model_builders.py
+++ b/torchtune/models/phi3/_model_builders.py
@@ -6,6 +6,7 @@ from torchtune.models.phi3._tokenizer import Phi3MiniTokenizer
 from torchtune.modules import TransformerDecoder
 from torchtune.modules.peft import LORA_ATTN_MODULES
 from functools import partial
+from torchtune.modules.tokenizers import parse_hf_tokenizer_json
 
 
 """
@@ -38,7 +39,7 @@ def phi3_mini() -> TransformerDecoder:
         norm_eps=1e-5,
     )
 
-def phi3_mini_tokenizer(path: str, special_tokens_path: Optional[str] = None) -> Phi3MiniTokenizer:
+def phi3_mini_tokenizer(path: str, special_tokens_path: Optional[str] = None, max_seq_len: Optional[int] = None) -> Phi3MiniTokenizer:
     """Phi-3 Mini tokenizer.
     Ref: https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/tokenizer_config.json
 
@@ -47,6 +48,8 @@ def phi3_mini_tokenizer(path: str, special_tokens_path: Optional[str] = None) ->
         special_tokens_path (Optional[str]): Path to ``tokenizer.json`` from Hugging Face
             model files that contains all registered special tokens, or a local json file 
             structured similarly. Default is None to use the canonical Phi3 special tokens.
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
 
     Note:
         This tokenizer includes typical LM EOS and BOS tokens like
@@ -58,7 +61,7 @@ def phi3_mini_tokenizer(path: str, special_tokens_path: Optional[str] = None) ->
         Phi3MiniSentencePieceBaseTokenizer: Instantiation of the SPM tokenizer.
     """
     special_tokens = parse_hf_tokenizer_json(special_tokens_path) if special_tokens_path is not None else None
-    return Phi3MiniTokenizer(path=path, special_tokens=special_tokens)
+    return Phi3MiniTokenizer(path=path, special_tokens=special_tokens, max_seq_len=max_seq_len)
 
 
 def lora_phi3_mini(

--- a/torchtune/models/qwen2/_model_builders.py
+++ b/torchtune/models/qwen2/_model_builders.py
@@ -95,8 +95,7 @@ def qwen2_1_5b() -> TiedEmbeddingTransformerDecoder:
 
 
 def qwen2_tokenizer(
-        path: str, merges_file: str = None, special_tokens_path: Optional[str] = None,
-        **kwargs,
+    path: str, merges_file: str = None, special_tokens_path: Optional[str] = None, max_seq_len: Optional[int] = None, **kwargs,
 ) -> Qwen2Tokenizer:
     """
     Tokenizer for Qwen2.
@@ -107,12 +106,14 @@ def qwen2_tokenizer(
         special_tokens_path (Optional[str]): Path to ``tokenizer.json`` from Hugging Face
             model files that contains all registered special tokens, or a local json file
             structured similarly. Default is None to use the canonical Qwen2 special tokens.
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
 
     Returns:
         Qwen2Tokenizer: Instantiation of the Qwen2 tokenizer
     """
     special_tokens = parse_hf_tokenizer_json(special_tokens_path) if special_tokens_path is not None else None
-    return Qwen2Tokenizer(path=path, merges_file=merges_file, special_tokens=special_tokens, **kwargs)
+    return Qwen2Tokenizer(path=path, merges_file=merges_file, special_tokens=special_tokens, max_seq_len=max_seq_len, **kwargs)
 
 
 def lora_qwen2_7b(


### PR DESCRIPTION
#### Context
We moved the `max_seq_len` parameter from dataset builders to tokenizer classes, but we never exposed it in the tokenizer builders. This PR updates all tokenizers with max_seq_len so you can modify max seq len from the config right under the tokenizer. Also fixed a bug in phi3 tokenizer, and removed redundant llama3_tokenizer for Llama3.1

#### Test plan
EYES
