### PR TITLE
Full finetune FSDP2 recipe

### DIFF
--- a/recipes/configs/gemma/2B_full.yaml
+++ b/recipes/configs/gemma/2B_full.yaml
@@ -59,7 +59,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/gemma/7B_full.yaml
+++ b/recipes/configs/gemma/7B_full.yaml
@@ -61,7 +61,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/llama2/7B_full.yaml
+++ b/recipes/configs/llama2/7B_full.yaml
@@ -62,7 +62,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/llama3/70B_full.yaml
+++ b/recipes/configs/llama3/70B_full.yaml
@@ -94,7 +94,7 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: True
+custom_sharded_layers: ['tok_embeddings', 'output']
 fsdp_cpu_offload: True
 
 # Reduced precision

--- a/recipes/configs/llama3/8B_full.yaml
+++ b/recipes/configs/llama3/8B_full.yaml
@@ -64,7 +64,7 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: True
+custom_sharded_layers: ['tok_embeddings', 'output']
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/llama3_1/70B_full.yaml
+++ b/recipes/configs/llama3_1/70B_full.yaml
@@ -94,7 +94,7 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: True
+custom_sharded_layers: ['tok_embeddings', 'output']
 fsdp_cpu_offload: True
 
 # Reduced precision

--- a/recipes/configs/llama3_1/8B_full.yaml
+++ b/recipes/configs/llama3_1/8B_full.yaml
@@ -67,7 +67,7 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: True
+custom_sharded_layers: ['tok_embeddings', 'output']
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/mistral/7B_full.yaml
+++ b/recipes/configs/mistral/7B_full.yaml
@@ -64,7 +64,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/phi3/mini_full.yaml
+++ b/recipes/configs/phi3/mini_full.yaml
@@ -61,7 +61,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 dtype: bf16
 
 # Logging

--- a/recipes/configs/qwen2/0.5B_full.yaml
+++ b/recipes/configs/qwen2/0.5B_full.yaml
@@ -61,7 +61,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/qwen2/0.5B_full.yaml
+++ b/recipes/configs/qwen2/0.5B_full.yaml
@@ -60,7 +60,7 @@ gradient_accumulation_steps: 16
 device: cuda
 
 # Memory management
-enable_activation_checkpointing: True
+enable_activation_checkpointing: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/qwen2/1.5B_full.yaml
+++ b/recipes/configs/qwen2/1.5B_full.yaml
@@ -61,7 +61,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/qwen2/1.5B_full.yaml
+++ b/recipes/configs/qwen2/1.5B_full.yaml
@@ -60,7 +60,7 @@ gradient_accumulation_steps: 1
 device: cuda
 
 # Memory management
-enable_activation_checkpointing: True
+enable_activation_checkpointing: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/configs/qwen2/7B_full.yaml
+++ b/recipes/configs/qwen2/7B_full.yaml
@@ -64,7 +64,6 @@ device: cuda
 
 # Memory management
 enable_activation_checkpointing: True
-memory_efficient_fsdp_wrap: False
 
 # Reduced precision
 dtype: bf16

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -584,6 +584,10 @@ def recipe_main(cfg: DictConfig) -> None:
         )
     os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"
     init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
+    if cfg.get("fsdp_cpu_offload", False):
+        # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
+        # speed up when benchmarking fused AdamW on CPU
+        utils.set_torch_num_threads()
 
     config.log_config(recipe_name="FullFinetuneRecipeDistributed", cfg=cfg)
 

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -27,6 +27,7 @@ from torch.utils.data import DataLoader, DistributedSampler
 from torchtune import config, modules, utils
 from torchtune.datasets import ConcatDataset
 from torchtune.recipe_interfaces import FTRecipeInterface
+from torchtune.utils.activations import apply_selective_activation_checkpointing
 
 from tqdm import tqdm
 

--- a/tests/torchtune/models/llama3_1/test_position_embeddings.py
+++ b/tests/torchtune/models/llama3_1/test_position_embeddings.py
@@ -61,7 +61,7 @@ class TestLlama3ScaledRoPE:
 
     def test_cache_equality(self, input, rope) -> None:
         # Have to explicitly call _rope_init() to initialize theta matrix
-        rope._rope_init()
+        rope.rope_init()
         cache = rope.cache
 
         assert_expected(cache.mean(), self.EXPECTED_FREQS_CIS_MEAN, atol=1e-4)

--- a/tests/torchtune/models/llama3_1/test_position_embeddings.py
+++ b/tests/torchtune/models/llama3_1/test_position_embeddings.py
@@ -132,7 +132,7 @@ class TestLlama3ScaledRoPE:
         with torch.device("meta"):
             meta_rope = Llama3ScaledRoPE(dim=head_dim, max_seq_len=max_seq_len)
 
-        meta_rope._rope_init()
+        meta_rope.rope_init()
         for p1, p2 in zip(rope_on_device.buffers(), meta_rope.buffers()):
             torch.testing.assert_close(p1, p2)
 

--- a/tests/torchtune/modules/test_position_embeddings.py
+++ b/tests/torchtune/modules/test_position_embeddings.py
@@ -128,7 +128,7 @@ class TestRotaryPositionEmbedding:
                 dim=head_dim, max_seq_len=max_seq_len
             )
 
-        meta_rope._rope_init()
+        meta_rope.rope_init()
         for p1, p2 in zip(rope_on_device.buffers(), meta_rope.buffers()):
             torch.testing.assert_close(p1, p2)
 

--- a/torchtune/models/llama3_1/_position_embeddings.py
+++ b/torchtune/models/llama3_1/_position_embeddings.py
@@ -42,12 +42,12 @@ class Llama3ScaledRoPE(nn.Module):
         self.max_seq_len = max_seq_len
         self.is_cache_built = False
 
-    # We need to explicitly define reset_parameters for FSDP initialization, see
-    # https://github.com/pytorch/pytorch/blob/797d4fbdf423dd9320ebe383fb57ffb1135c4a99/torch/distributed/fsdp/_init_utils.py#L885
+    # TODO: delete this once all our recipes are moved off of FSDP1 since we
+    # no longer need to explicitly name our param init method reset_parameters
     def reset_parameters(self):
-        self._rope_init()
+        self.rope_init()
 
-    def _rope_init(self):
+    def rope_init(self):
         freqs = 1.0 / (
             self.base
             ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim)
@@ -118,10 +118,10 @@ class Llama3ScaledRoPE(nn.Module):
             - n_h: num heads
             - h_d: head dim
         """
-        # TODO: Remove this hack for handling scaling for Meta device
+        # TODO: remove once our distributed recipes are on FSDP2
         if not self.is_cache_built:
             with torch.device(x.device):
-                self._rope_init()
+                self.rope_init()
 
         # input tensor has shape [b, s, n_h, h_d]
         seq_len = x.size(1)

--- a/torchtune/models/phi3/_position_embeddings.py
+++ b/torchtune/models/phi3/_position_embeddings.py
@@ -38,9 +38,9 @@ class Phi3RotaryPositionalEmbeddings(nn.Module):
         self.dim = dim
         self.base = base
         self.max_seq_len = max_seq_len
-        self._rope_init()
+        self.rope_init()
 
-    def _rope_init(self):
+    def rope_init(self):
         theta = 1.0 / (
             self.base
             ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim)

--- a/torchtune/models/qwen2/_positional_embeddings.py
+++ b/torchtune/models/qwen2/_positional_embeddings.py
@@ -38,9 +38,9 @@ class Qwen2RotaryPositionalEmbeddings(nn.Module):
         self.dim = dim
         self.base = base
         self.max_seq_len = max_seq_len
-        self._rope_init()
+        self.rope_init()
 
-    def _rope_init(self):
+    def rope_init(self):
         theta = 1.0 / (
             self.base
             ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim)

--- a/torchtune/modules/position_embeddings.py
+++ b/torchtune/modules/position_embeddings.py
@@ -42,14 +42,14 @@ class RotaryPositionalEmbeddings(nn.Module):
         self.dim = dim
         self.base = base
         self.max_seq_len = max_seq_len
-        self._rope_init()
+        self.rope_init()
 
-    # We need to explicitly define reset_parameters for FSDP initialization, see
-    # https://github.com/pytorch/pytorch/blob/797d4fbdf423dd9320ebe383fb57ffb1135c4a99/torch/distributed/fsdp/_init_utils.py#L885
+    # TODO: delete this once all our recipes are moved off of FSDP1 since we
+    # no longer need to explicitly name our param init method reset_parameters
     def reset_parameters(self):
-        self._rope_init()
+        self.rope_init()
 
-    def _rope_init(self):
+    def rope_init(self):
         theta = 1.0 / (
             self.base
             ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim)

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -27,6 +27,7 @@ from ._distributed import (  # noqa
     lora_fsdp_wrap_policy,
     prepare_model_for_fsdp_with_meta_device,
     set_torch_num_threads,
+    shard_model,
     validate_no_params_on_meta_device,
 )
 from ._generation import generate, generate_next_token  # noqa
@@ -103,4 +104,5 @@ __all__ = [
     "get_quantizer_mode",
     "generate",
     "generate_next_token",
+    "shard_model",
 ]

--- a/torchtune/utils/_distributed.py
+++ b/torchtune/utils/_distributed.py
@@ -289,6 +289,7 @@ def load_from_full_model_state_dict(
     full_sd: Dict[str, Any],
     device: torch.device,
     is_rank_zero: bool,
+    strict: bool = False,
 ):
     """
     Converting full state dict into a sharded state dict
@@ -355,7 +356,7 @@ def load_from_full_model_state_dict(
             )
         sharded_sd[param_name] = nn.Parameter(sharded_tensor)
     # choose `assign=True` since we cannot call `copy_` on meta tensor
-    return model.load_state_dict(sharded_sd, strict=False, assign=True)
+    return model.load_state_dict(sharded_sd, strict=strict, assign=True)
 
 
 def get_full_model_state_dict(

--- a/torchtune/utils/_distributed.py
+++ b/torchtune/utils/_distributed.py
@@ -8,13 +8,13 @@
 import logging
 import os
 from itertools import chain
-from typing import Any, Callable, cast, Dict, Set, Tuple, Type
+from typing import Any, Callable, cast, Dict, List, Set, Tuple, Type
 
 import torch
 import torch.distributed as dist
-from packaging import version
 from torch import nn
 
+from torch.distributed._composable.fsdp import CPUOffloadPolicy, fully_shard
 from torch.distributed._tensor import distribute_tensor, DTensor
 from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -25,7 +25,7 @@ from torch.distributed.fsdp import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.optim import Optimizer
 from torchao.dtypes.nf4tensor import NF4Tensor, to_nf4
-from torchtune import modules
+from torchtune.modules import TransformerDecoder
 from torchtune.modules.peft.lora import (
     _lora_a_init_params,
     _lora_b_init_params,
@@ -321,32 +321,21 @@ def load_from_full_model_state_dict(
             chunk = list(torch.chunk(full_tensor, shard_world_size, dim=0))[shard_rank]
             sharded_param = full_tensor.new_zeros(chunk.size())
             sharded_param[: chunk.size(0)].copy_(chunk)
-            # BC-breaking change to DTensor API in https://github.com/pytorch/pytorch/pull/128112
+
             # TODO: change to from_local API (need to add view support for NF4)
-            if version.parse(torch.__version__) >= version.parse("2.4.0.dev20240606"):
-                sharded_tensor = DTensor(
-                    local_tensor=sharded_param,
-                    spec=DTensorSpec(
-                        mesh=sharded_meta_param.device_mesh,
-                        placements=sharded_meta_param.placements,
-                        tensor_meta=TensorMeta(
-                            shape=sharded_meta_param.size(),
-                            dtype=sharded_meta_param.dtype,
-                            stride=sharded_meta_param.stride(),
-                        ),
+            sharded_tensor = DTensor(
+                local_tensor=sharded_param,
+                spec=DTensorSpec(
+                    mesh=sharded_meta_param.device_mesh,
+                    placements=sharded_meta_param.placements,
+                    tensor_meta=TensorMeta(
+                        shape=sharded_meta_param.size(),
+                        dtype=sharded_meta_param.dtype,
+                        stride=sharded_meta_param.stride(),
                     ),
-                    requires_grad=sharded_meta_param.requires_grad,
-                )
-            else:
-                sharded_tensor = DTensor(
-                    sharded_param,
-                    sharded_meta_param.device_mesh,
-                    sharded_meta_param.placements,
-                    shape=sharded_meta_param.size(),
-                    dtype=sharded_meta_param.dtype,
-                    requires_grad=sharded_meta_param.requires_grad,
-                    stride=sharded_meta_param.stride(),
-                )
+                ),
+                requires_grad=sharded_meta_param.requires_grad,
+            )
 
         else:
             sharded_tensor = distribute_tensor(
@@ -549,7 +538,7 @@ def _memory_efficient_wrap_policy(modules_to_wrap: Set[Type]) -> FSDPPolicyType:
 
     def llama3_wrap(module: nn.Module, recurse: bool, **kwargs):
         # Label that output_proj should be wrapped individually.
-        if isinstance(module, modules.TransformerDecoder):
+        if isinstance(module, TransformerDecoder):
             module.output._wrap = True
         if recurse:
             return True
@@ -561,3 +550,43 @@ def _memory_efficient_wrap_policy(modules_to_wrap: Set[Type]) -> FSDPPolicyType:
         return isinstance(module, tuple(modules_to_wrap))
 
     return llama3_wrap
+
+
+def shard_model(
+    model: TransformerDecoder,
+    shard_conditions: List[Callable[[str, nn.Module], bool]],
+    *,
+    cpu_offload: bool,
+    reshard_after_forward: bool = True,
+) -> None:
+    """
+    Utility to shard a model with FSDP using the PyTorch Distributed fully_shard API.
+
+    This method will over the model's named modules from the bottom-up and apply shard modules
+    based on whether they meet any of the criteria from shard_conditions.
+
+    Args:
+        model (TransformerDecoder): Model to shard with FSDP.
+        shard_conditions (List[Callable[[str, nn.Module], bool]]): A list of functions to determine
+            which modules to shard with FSDP. Each function should take module name (relative to root)
+            and the module itself, returning True if FSDP should shard the module and False otherwise.
+            If any of shard_conditions return True for a given module, it will be sharded by FSDP.
+        cpu_offload (bool): If set to True, FSDP will offload parameters, gradients, and optimizer
+            states to CPU.
+        reshard_after_forward (bool): Whether to reshard parameters and buffers after
+            the forward pass. Setting this to True corresponds to the FULL_SHARD sharding strategy
+            from FSDP1, while setting it to False corresponds to the SHARD_GRAD_OP sharding strategy.
+
+    """
+    fsdp_kwargs = {"reshard_after_forward": reshard_after_forward}
+    if cpu_offload:
+        fsdp_kwargs["offload_policy"] = CPUOffloadPolicy()
+
+    # Shard the model with FSDP, iterating in reverse to start with
+    # lowest-level modules first
+    for n, m in reversed(list(model.named_modules())):
+        if any([shard_condition(n, m) for shard_condition in shard_conditions]):
+            fully_shard(m, **fsdp_kwargs)
+
+    # Finally shard the entire model to account for any stragglers
+    fully_shard(model)


### PR DESCRIPTION
This PR migrates our full finetune recipe onto FSDP2. 

## Main changes
- Define a utility `shard_model` for sharding our models with FSDP2. The recommended way to shard FSDP2 models is by iterating over modules in a bottom-up fashion. As a result, this utility takes in a list of `shard_conditions`. Each shard condition is a callable taking a module name and the module itself (i.e. a pair from `model.named_modules()`) and returning True if the module should be sharded (and False otherwise). We use a list of shard conditions to more easily decouple different things we might want to check (e.g. whether a module is using activation checkpointing, whether we are doing any custom sharding, or whether LoRA is applied (coming in a subsequent PR)). If any of `shard_conditions` return True, the module will be sharded. `shard_model` will also take any FSDP-related fields like `cpu_offload` and `reshard_after_forward` (~fka `sharding_strategy`)
- Deprecate `memory_efficient_fsdp_wrap` flag. Instead, we can provide an optional config `custom_sharded_layers` which is more flexible. For our existing Llama3 8B sharding, we can pass `['tok_embeddings', 'output']` to tell FSDP to shard these modules separately

### Other smaller changes:
- Start the process of moving off of `reset_parameters()` and onto `rope_init()`
- Document a couple places we need to change after all our recipes are on FSDP2
- Remove a version check in `load_model_from_full_state_dict` that's no longer needed

## Test plan

Apart from green CI, 

### Test Llama3 8B perf and memory

On both this PR and main, run 

```
tune run --nproc_per_node 2 full_finetune_distributed --config llama3/8B_full \
max_steps_per_epoch=500 epochs=1 log_peak_memory_stats=True
```

Results are as follows (note that tok/sec plots are smoothed in all figures for clarity)

<img width="1365" alt="Screenshot 2024-08-10 at 11 57 12 AM" src="https://github.com/user-attachments/assets/e75060f9-9659-49c1-970d-052b8848a184">

### Other model tests

**Note:** the losses curves for Gemma 7B differ from those with FSDP1. However, Gemma 7B loss curves appear to be non-reproducible with FSDP1, see #1303.

#### Phi3

Command:

```
tune run --nproc_per_node 2 full_finetune_distributed --config phi3/mini_full \
log_peak_memory_stats=True max_steps_per_epoch=500 epochs=1
```

<img width="1374" alt="Screenshot 2024-08-10 at 12 15 23 PM" src="https://github.com/user-attachments/assets/d95a1fcb-b213-43d2-85f5-67f2b73d6da4">


#### Gemma 2B

```
tune run --nnodes 1 --nproc_per_node 2 full_finetune_distributed --config gemma/2B_full  \
max_steps_per_epoch=500 epochs=1 log_peak_memory_stats=True
```

<img width="1626" alt="Screenshot 2024-08-10 at 1 56 49 PM" src="https://github.com/user-attachments/assets/74f186b5-ede0-408d-8794-95eaad10f6e6">

#### Qwen2 0.5B

<img width="1351" alt="Screenshot 2024-08-10 at 1 46 37 PM" src="https://github.com/user-attachments/assets/2d496e2c-9f62-4651-bf4f-ff2a7124eb14">



### Test checkpoint resume

First run

```
tune run --nproc_per_node 2 full_finetune_distributed --config llama3/8B_full max_steps_per_epoch=10 epochs=2
```

Then run

```
tune run --nproc_per_node 2 full_finetune_distributed --config llama3/8B_full max_steps_per_epoch=10 epochs=2 \
resume_from_checkpoint=True checkpointer.checkpoint_dir=/tmp/Meta-Llama-3-8B-Instruct \
checkpointer.recipe_checkpoint=recipe_state.pt checkpointer.checkpoint_files=[meta_model_0.pt] \
...
Model checkpoint of size 16.06 GB saved to /tmp/Meta-Llama-3-8B-Instruct/meta_model_1.pt
2|20|Loss: 1.0202215909957886: 100%|██████████████████=██| 10/10 
```

### Functionality tests

#### Custom wrapping

Tried out with Llama2 7B, can see some reduction in reserved memory with no perf impact

```
tune run --nproc_per_node 2 full_finetune_distributed --config llama2/7B_full \
max_steps_per_epoch=500 epochs=1 log_peak_memory_stats=True \
custom_sharded_layers=['tok_embeddings','output']
```

<img width="1358" alt="Screenshot 2024-08-10 at 2 23 19 PM" src="https://github.com/user-attachments/assets/536e9631-df04-4290-a6ef-b3d6c3f1ace9">

#### Selective AC

```
tune run --nproc_per_node 2 full_finetune_distributed --config llama3/8B_full \
max_steps_per_epoch=500 epochs=1 log_peak_memory_stats=True ac_mode=selective ac_option=3
...
1|45|Loss: 0.9101344347000122:   9%|████████████████▋                                                                                                                                                                         
```

(Not testing memory or perf here, just making sure the run succeeds, since this is still an experimental feature)
