### PR TITLE
fix duplicate logging

### DIFF
--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 from typing import Optional
 
 import torch
 from torch import nn, Tensor
 from torchtune.modules.kv_cache import KVCache
-from torchtune.utils.logging import get_logger
 
-logger = get_logger("DEBUG")
+logger = logging.getLogger(__name__)
 
 
 class CausalSelfAttention(nn.Module):


### PR DESCRIPTION
Fixes #1302 

Tbh I'm not that familiar with the logging module so not sure why this is happening. But our other logs inside modules/ use logging's getLogger. Also **using anything from utils/ inside modules/** creates a circular dependency. Though it seems to resolve somehow (again not familiar with how or why), it also seems to cause our logger to get created twice.

Not to get up on my soapbox here, but **utils/ is a terrible name for our training utilities directory**. As it stands today, our training utilities have dependencies on both our modules and data directories. We should really either

(1) remove these dependencies (the data one is easy, the modules one requires re-thinking both our distributed and generation utilities, which is probably nontrivial), or
(2) rename this directory to something that is clearly training-related, so that we we can have an actual utils directory taking no other dependencies from within our repo (so that they can then be used wherever we want)

Or we can just keep using two separate loggers 😃 