### PR TITLE
Fix eval in regression test

### DIFF
--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
+  pull_request: # TODO: remove (just for testing)
 
 concurrency:
   group: regression-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
-  workflow_dispatch: # TODO: remove (just for testing)
 
 concurrency:
   group: regression-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
-  pull_request: # TODO: remove (just for testing)
+  workflow_dispatch: # TODO: remove (just for testing)
 
 concurrency:
   group: regression-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/tests/regression_tests/test_llama2_7b.py
+++ b/tests/regression_tests/test_llama2_7b.py
@@ -27,7 +27,7 @@ EVAL_CONFIG_PATH = Path.joinpath(
 @gpu_test(gpu_count=2)
 class TestLoRA7BDistributedFinetuneEval:
     @pytest.mark.slow_integration_test
-    def test_finetune_and_eval(self, tmpdir, caplog, monkeypatch):
+    def test_finetune_and_eval(self, tmpdir, capsys, monkeypatch):
 
         ckpt_path = Path(CKPT_MODEL_PATHS[CKPT])
         ckpt_dir = ckpt_path.parent
@@ -65,8 +65,8 @@ class TestLoRA7BDistributedFinetuneEval:
         with pytest.raises(SystemExit):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        err_log = caplog.messages[-1]
-        log_search_results = re.search(r"'acc,none': (\d+\.\d+)", err_log)
-        assert log_search_results is not None
-        acc_result = float(log_search_results.group(1))
+        out = capsys.readouterr().out
+        search_results = re.search(r"acc(?:_norm)?\s*\|?\s*([\d.]+)", out.strip())
+        assert search_results is not None
+        acc_result = float(search_results.group(1))
         assert acc_result >= 0.4

--- a/tests/regression_tests/test_llama2_7b.py
+++ b/tests/regression_tests/test_llama2_7b.py
@@ -50,7 +50,7 @@ class TestLoRA7BDistributedFinetuneEval:
         runpy.run_path(TUNE_PATH, run_name="__main__")
         eval_cmd = f"""
         tune run eleuther_eval \
-            --config eleuther_eval \
+            --config eleuther_evaluation \
             output_dir={tmpdir} \
             checkpointer=torchtune.utils.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir='{tmpdir}' \

--- a/tests/regression_tests/test_llama2_7b.py
+++ b/tests/regression_tests/test_llama2_7b.py
@@ -66,7 +66,9 @@ class TestLoRA7BDistributedFinetuneEval:
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
         out = capsys.readouterr().out
-        search_results = re.search(r"acc(?:_norm)?\s*\|?\s*([\d.]+)", out.strip())
+        search_results = re.search(
+            r"acc(?:_norm)?\s*\|?\s*(?:\↑\s*\|?)?([\d.]+)", out.strip()
+        )
         assert search_results is not None
         acc_result = float(search_results.group(1))
         assert acc_result >= 0.4


### PR DESCRIPTION
The config name and the results parsing in our regression test job are incorrect.

This is actually a bit awkward to test now that we (a) don't allow creating PRs from a fork, and (b) don't let forks access the S3 bucket containing regression test artifacts.

So for now I've tested it locally, which I guess is better than nothing?

```
pytest tests/regression_tests/test_llama2_7b.py -m slow_integration_test
...
====== 1 passed, 1 warning in 267.94s (0:04:27) ======
```