### PR TITLE
adding expandable segments

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -28,6 +28,8 @@ from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
 
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 
 class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
     """
@@ -424,13 +426,15 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             sampler=sampler,
-            collate_fn=partial(
-                utils.padded_collate,
-                padding_idx=self._tokenizer.pad_id,
-                ignore_idx=self._loss_fn.ignore_index,
-            )
-            if not packed
-            else None,
+            collate_fn=(
+                partial(
+                    utils.padded_collate,
+                    padding_idx=self._tokenizer.pad_id,
+                    ignore_idx=self._loss_fn.ignore_index,
+                )
+                if not packed
+                else None
+            ),
         )
 
         log.info("Dataset and Sampler are initialized.")

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import sys
 import time
-
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
 from warnings import warn
@@ -40,6 +40,8 @@ from torchtune.recipe_interfaces import FTRecipeInterface
 from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
+
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 
 class LoRADPORecipeDistributed(FTRecipeInterface):

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -37,6 +37,8 @@ from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
 
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 
 class LoRADPORecipeSingleDevice(FTRecipeInterface):
     """

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -41,6 +41,8 @@ from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
 
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 
 class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
     """

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -34,6 +34,8 @@ from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
 
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 
 class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
     """

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -27,6 +27,8 @@ from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
 
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 
 class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
     """

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import sys
 import time
-
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
 from warnings import warn
@@ -35,6 +35,8 @@ from tqdm import tqdm
 
 
 log = utils.get_logger("DEBUG")
+
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 
 class QATRecipeDistributed(FTRecipeInterface):
@@ -359,11 +361,11 @@ class QATRecipeDistributed(FTRecipeInterface):
             sync_module_states=True,
             # Initialize empty modules on all non-zero ranks
             param_init_fn=(
-                lambda module: module.to_empty(
-                    device=torch.device("cuda"), recurse=False
+                lambda module: (
+                    module.to_empty(device=torch.device("cuda"), recurse=False)
+                    if not self._is_rank_zero
+                    else None
                 )
-                if not self._is_rank_zero
-                else None
             ),
         )
 
@@ -439,13 +441,15 @@ class QATRecipeDistributed(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             sampler=sampler,
-            collate_fn=partial(
-                utils.padded_collate,
-                padding_idx=self._tokenizer.pad_id,
-                ignore_idx=self._loss_fn.ignore_index,
-            )
-            if not packed
-            else None,
+            collate_fn=(
+                partial(
+                    utils.padded_collate,
+                    padding_idx=self._tokenizer.pad_id,
+                    ignore_idx=self._loss_fn.ignore_index,
+                )
+                if not packed
+                else None
+            ),
         )
 
         if self._is_rank_zero:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#1185 

#### Changelog

Adding `os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"` to all our recipes.


#### Test plan
Run on 2080 Super 8GB.
```bash
(tune) salman@combuter:~/torchtune$ echo $PYTORCH_CUDA_ALLOC_CONF

(tune) salman@combuter:~/torchtune$ tune run full_finetune_single_device --config qwen2/0.5B_full_single_device log_peak_memory_stats=True metric_logger=torchtune.utils.metric_logging.WandBLogger metric_logging.project=torchtune_mem checkpointer.checkpoint_dir=/home/salman/models/Qwen2-0.5B-Instruct tokenizer.path=/home/salman/models/Qwen2-0.5B-Instruct/vocab.json tokenizer.merges_file=/home/salman/models/Qwen2-0.5B-Instruct/merges.txt max_steps_per_epoch=250
...
1|250|Loss: 1.0745091438293457: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 250/250 [22:37<00:00,  5.43s/it]
```
[WandB](https://wandb.ai/salman-mohammadi/torchtune/runs/urcs5jpl?nw=nwusersalmanmohammadi) of successful run with all peak memory stats <= 8GB.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](../tests/torchtune) for any new functionality
- [ ] update [docstrings](../docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
