### PR TITLE
Prevent OOM during checkpoint save on colab for llama3-8b qlora recipe

### DIFF
--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -45,7 +45,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: 1372749820
+seed: null
 shuffle: True
 batch_size: 2
 
@@ -62,17 +62,16 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 10
-max_steps_per_epoch: 20
-gradient_accumulation_steps: 2
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 16
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
 metric_logger:
-  _component_: torchtune.utils.metric_logging.WandBLogger
-  # the W&B project to log to
-  project: torchtune
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
 log_every_n_steps: 1
 log_peak_memory_stats: False
 

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -45,7 +45,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: null
+seed: 1372749820
 shuffle: True
 batch_size: 2
 
@@ -62,16 +62,18 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 1
-max_steps_per_epoch: null
-gradient_accumulation_steps: 16
+epochs: 5
+max_steps_per_epoch: 10
+gradient_accumulation_steps: 2
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
+# enable logging to the built-in WandBLogger
 metric_logger:
-  _component_: torchtune.training.metric_logging.DiskLogger
-  log_dir: ${output_dir}
+  _component_: torchtune.training.metric_logging.WandBLogger
+  # the W&B project to log to
+  project: torchtune
 log_every_n_steps: 1
 log_peak_memory_stats: False
 
@@ -105,5 +107,4 @@ profiler:
   active_steps: 2
   num_cycles: 1
 
-# For colab use True
-low_cpu_ram: False
+low_cpu_ram: True

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -105,4 +105,5 @@ profiler:
   active_steps: 2
   num_cycles: 1
 
-low_cpu_ram: True
+# For colab
+low_cpu_ram: False

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -23,7 +23,7 @@ model:
   apply_lora_to_output: False
   lora_rank: 8
   lora_alpha: 16
-  low_cpu_ram: True
+  low_cpu_ram: False
 
 # Tokenizer
 tokenizer:

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -45,7 +45,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: 1372749820
+seed: null
 shuffle: True
 batch_size: 2
 
@@ -59,20 +59,19 @@ lr_scheduler:
   num_warmup_steps: 100
 
 loss:
-  _component_: torch.nn.CrossEntropyLoss
+  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 10
-max_steps_per_epoch: 20
-gradient_accumulation_steps: 2
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 16
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
 metric_logger:
-  _component_: torchtune.utils.metric_logging.WandBLogger
-  # the W&B project to log to
-  project: torchtune
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
 log_every_n_steps: 1
 log_peak_memory_stats: False
 

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -70,7 +70,7 @@ compile: False
 # Logging
 output_dir: /tmp/qlora_finetune_output/
 metric_logger:
-  _component_: torchtune.utils.metric_logging.DiskLogger
+  _component_: torchtune.training.metric_logging.DiskLogger
   log_dir: ${output_dir}
 log_every_n_steps: 1
 log_peak_memory_stats: False

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -46,7 +46,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: 1372749820
+seed: null
 shuffle: True
 batch_size: 2
 
@@ -63,18 +63,16 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 8
-max_steps_per_epoch: 20
-gradient_accumulation_steps: 2
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 16
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
-# enable logging to the built-in WandBLogger
 metric_logger:
-  _component_: torchtune.utils.metric_logging.WandBLogger
-  # the W&B project to log to
-  project: torchtune
+  _component_: torchtune.utils.metric_logging.DiskLogger
+  log_dir: ${output_dir}
 log_every_n_steps: 1
 log_peak_memory_stats: False
 

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -105,5 +105,5 @@ profiler:
   active_steps: 2
   num_cycles: 1
 
-# For colab
+# For colab use True
 low_cpu_ram: False

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -23,7 +23,6 @@ model:
   apply_lora_to_output: False
   lora_rank: 8
   lora_alpha: 16
-  low_cpu_ram: False
 
 # Tokenizer
 tokenizer:
@@ -46,7 +45,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: null
+seed: 1372749820
 shuffle: True
 batch_size: 2
 
@@ -63,16 +62,17 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 1
-max_steps_per_epoch: null
-gradient_accumulation_steps: 16
+epochs: 10
+max_steps_per_epoch: 20
+gradient_accumulation_steps: 2
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
 metric_logger:
-  _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: ${output_dir}
+  _component_: torchtune.utils.metric_logging.WandBLogger
+  # the W&B project to log to
+  project: torchtune
 log_every_n_steps: 1
 log_peak_memory_stats: False
 
@@ -105,3 +105,5 @@ profiler:
   warmup_steps: 5
   active_steps: 2
   num_cycles: 1
+
+low_cpu_ram: True

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -45,7 +45,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: null
+seed: 1372749820
 shuffle: True
 batch_size: 2
 
@@ -59,19 +59,20 @@ lr_scheduler:
   num_warmup_steps: 100
 
 loss:
-  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
+  _component_: torch.nn.CrossEntropyLoss
 
 # Training
-epochs: 1
-max_steps_per_epoch: null
-gradient_accumulation_steps: 16
+epochs: 10
+max_steps_per_epoch: 20
+gradient_accumulation_steps: 2
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
 metric_logger:
-  _component_: torchtune.utils.metric_logging.DiskLogger
-  log_dir: ${output_dir}
+  _component_: torchtune.utils.metric_logging.WandBLogger
+  # the W&B project to log to
+  project: torchtune
 log_every_n_steps: 1
 log_peak_memory_stats: False
 

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -62,16 +62,18 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 2
+epochs: 10
 max_steps_per_epoch: 20
 gradient_accumulation_steps: 2
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
+# enable logging to the built-in WandBLogger
 metric_logger:
-  _component_: torchtune.training.metric_logging.DiskLogger
-  log_dir: ${output_dir}
+  _component_: torchtune.utils.metric_logging.WandBLogger
+  # the W&B project to log to
+  project: torchtune
 log_every_n_steps: 1
 log_peak_memory_stats: False
 

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -23,6 +23,7 @@ model:
   apply_lora_to_output: False
   lora_rank: 8
   lora_alpha: 16
+  low_cpu_ram: True
 
 # Tokenizer
 tokenizer:
@@ -62,7 +63,7 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 10
+epochs: 4
 max_steps_per_epoch: 20
 gradient_accumulation_steps: 2
 compile: False

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -63,7 +63,7 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 4
+epochs: 8
 max_steps_per_epoch: 20
 gradient_accumulation_steps: 2
 compile: False

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -45,7 +45,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: 1372749820
+seed: null
 shuffle: True
 batch_size: 2
 
@@ -62,18 +62,16 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 5
-max_steps_per_epoch: 10
-gradient_accumulation_steps: 2
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 16
 compile: False
 
 # Logging
 output_dir: /tmp/qlora_finetune_output/
-# enable logging to the built-in WandBLogger
 metric_logger:
-  _component_: torchtune.training.metric_logging.WandBLogger
-  # the W&B project to log to
-  project: torchtune
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}
 log_every_n_steps: 1
 log_peak_memory_stats: False
 
@@ -107,4 +105,5 @@ profiler:
   active_steps: 2
   num_cycles: 1
 
-low_cpu_ram: True
+# For colab use True
+low_cpu_ram: False

--- a/recipes/configs/llama3/8B_qlora_single_device.yaml
+++ b/recipes/configs/llama3/8B_qlora_single_device.yaml
@@ -45,7 +45,7 @@ save_adapter_weights_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset
-seed: null
+seed: 1372749820
 shuffle: True
 batch_size: 2
 
@@ -62,9 +62,9 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 
 # Training
-epochs: 1
-max_steps_per_epoch: null
-gradient_accumulation_steps: 16
+epochs: 2
+max_steps_per_epoch: 20
+gradient_accumulation_steps: 2
 compile: False
 
 # Logging

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -698,7 +698,9 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     prof.step()
 
                 self.epochs_run += 1
+                start_save_checkpoint = time.time()
                 self.save_checkpoint(epoch=curr_epoch)
+                log.info("Checkpoint saved in {:.2f} seconds".format(time.time() - start_save_checkpoint))
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -201,17 +201,15 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 "Are you sure you passed in the right recipe checkpoint?"
             ) from e
 
-    def setup(self, cfg: DictConfig, epoch=0, metric_logger=None) -> None:
+    def setup(self, cfg: DictConfig) -> None:
         """
         Setup the recipe state. This includes recipe state (if resume_from_checkpoint is True),
         model, tokenizer, loss, optimizer, learning rate scheduler, sampler, and dataloader.
         """
-        if epoch == 0:
-            self._metric_logger = config.instantiate(cfg.metric_logger)
-            # log config with parameter override
-            self._metric_logger.log_config(cfg)
-        else:
-            self._metric_logger = metric_logger
+        self._metric_logger = config.instantiate(cfg.metric_logger)
+
+        # log config with parameter override
+        self._metric_logger.log_config(cfg)
 
         self._compile = cfg.compile
         checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
@@ -594,7 +592,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         return loss
 
-    def train(self, curr_epoch=0) -> None:
+    def train(self) -> None:
         """
         The core training loop.
         """
@@ -611,7 +609,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         with self._profiler as prof:
             # self.epochs_run should be non-zero when we're resuming from a checkpoint
-            for _ in range(1):
+            for curr_epoch in range(self.epochs_run, self.total_epochs):
                 # Update the sampler to ensure data is correctly shuffled across epochs
                 # in case shuffle is True
                 self._sampler.set_epoch(curr_epoch)
@@ -730,24 +728,8 @@ def recipe_main(cfg: DictConfig) -> None:
     if cfg.get("low_cpu_ram", False):
         common_utils._use_low_cpu_ram = True
     recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
-    # ==== The following changes are to mimic resume_from_checkpoint ====
-    for i in range(cfg.epochs):
-        recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
-        if i == 0:
-            recipe.setup(cfg=cfg, epoch=i)
-            # persist metric_logger across epochs (for wanbd logging)
-            metric_logger = recipe._metric_logger
-        else:
-            recipe.setup(cfg=cfg, epoch=i, metric_logger=metric_logger)
-        recipe.train(curr_epoch=i)
-        # modify config to mimic user modifying .yaml file to resume from checkpoint
-        cfg.resume_from_checkpoint = True
-        cfg.checkpointer.checkpoint_dir = "/tmp/Meta-Llama-3-8B-Instruct/"
-        cfg.checkpointer.checkpoint_files = [f"meta_model_{i}.pt"]
-        cfg.checkpointer.adapter_checkpoint = f"adapter_{i}.pt"
-        cfg.checkpointer.recipe_checkpoint = "recipe_state.pt"
-    # recipe.setup(cfg=cfg)
-    # recipe.train()
+    recipe.setup(cfg=cfg)
+    recipe.train()
     recipe.cleanup()
 
 

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -604,7 +604,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         return loss
 
-    def train(self) -> None:
     def train(self, curr_epoch=0) -> None:
         """
         The core training loop.

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -287,6 +287,11 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
+        # Used to ignore labels for loss computation
+        self.ignore_labels_cache = torch.full(
+            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
+        )
+    
     def _patch_state_dict_hook(self, cfg: DictConfig) -> None:
         """
         Patches the state_dict hook for QLoRA for the `low_cpu_ram` config option.
@@ -309,11 +314,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             common_utils.reparametrize_as_dtype_state_dict_post_hook = (
                 common_utils._low_ram_reparametrize_as_dtype_state_dict_post_hook
             )
-
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
 
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -105,6 +105,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
     """
 
     def __init__(self, cfg: DictConfig) -> None:
+
         self._device = utils.get_device(device=cfg.device)
         # Reduced precision logic
         self._dtype = training.get_dtype(cfg.dtype, device=self._device)

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -292,29 +292,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
         )
 
-    def _patch_state_dict_hook(self, cfg: DictConfig) -> None:
-        """
-        Patches the state_dict hook for QLoRA for the `low_cpu_ram` config option.
-        """
-        self._previous_hook = None
-        if cfg.get("low_cpu_ram", False):
-            if (
-                common_utils._low_ram_reparametrize_as_dtype_state_dict_post_hook
-                is None
-            ):
-                if sys.platform == "win32":
-                    raise RuntimeError("low_cpu_ram=True not supported on Windows.")
-                else:
-                    raise RuntimeError(
-                        "low_cpu_ram=True requires torch.__version__ >= 2.5.0.dev20240830."
-                    )
-            self._previous_hook = (
-                common_utils.reparametrize_as_dtype_state_dict_post_hook
-            )
-            common_utils.reparametrize_as_dtype_state_dict_post_hook = (
-                common_utils._low_ram_reparametrize_as_dtype_state_dict_post_hook
-            )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -735,11 +712,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 )
 
     def cleanup(self) -> None:
-        if self._previous_hook is not None:
-            common_utils.reparametrize_as_dtype_state_dict_post_hook = (
-                self._previous_hook
-            )
-            self._previous_hook = None
         self._metric_logger.close()
 
 
@@ -753,8 +725,9 @@ def recipe_main(cfg: DictConfig) -> None:
         - Overwritten by arguments from the command-line
     """
     config.log_config(recipe_name="LoRAFinetuneRecipeSingleDevice", cfg=cfg)
+    if cfg.get("low_cpu_ram", False):
+        common_utils._use_low_cpu_ram = True
     recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
-    recipe._patch_state_dict_hook(cfg)
     recipe.setup(cfg=cfg)
     recipe.train()
     recipe.cleanup()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -105,7 +105,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
     """
 
     def __init__(self, cfg: DictConfig) -> None:
-
         self._device = utils.get_device(device=cfg.device)
         # Reduced precision logic
         self._dtype = training.get_dtype(cfg.dtype, device=self._device)
@@ -718,7 +717,11 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 start_save_checkpoint = time.time()
                 log.info("Starting checkpoint save...")
                 self.save_checkpoint(epoch=curr_epoch)
-                log.info("Checkpoint saved in {:.2f} seconds".format(time.time() - start_save_checkpoint))
+                log.info(
+                    "Checkpoint saved in {:.2f} seconds".format(
+                        time.time() - start_save_checkpoint
+                    )
+                )
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -221,15 +221,18 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 "Are you sure you passed in the right recipe checkpoint?"
             ) from e
 
-    def setup(self, cfg: DictConfig) -> None:
+    def setup(self, cfg: DictConfig, epoch=0, metric_logger=None) -> None:
         """
         Setup the recipe state. This includes recipe state (if resume_from_checkpoint is True),
         model, tokenizer, loss, optimizer, learning rate scheduler, sampler, and dataloader.
         """
-        self._metric_logger = config.instantiate(cfg.metric_logger)
-
-        # log config with parameter override
-        self._metric_logger.log_config(cfg)
+        # ==== For loss curves: preserve metric logger across setups ====
+        if epoch == 0:
+            self._metric_logger = config.instantiate(cfg.metric_logger)
+            # log config with parameter override
+            self._metric_logger.log_config(cfg)
+        else:
+            self._metric_logger = metric_logger
 
         self._compile = cfg.compile
         checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
@@ -644,6 +647,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         return loss
 
     def train(self) -> None:
+    def train(self, curr_epoch=0) -> None:
         """
         The core training loop.
         """
@@ -660,7 +664,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         with self._profiler as prof:
             # self.epochs_run should be non-zero when we're resuming from a checkpoint
-            for curr_epoch in range(self.epochs_run, self.total_epochs):
+            # (for loss curves) pass in curr_epoch as argument
+            for _ in range(1):
                 # Update the sampler to ensure data is correctly shuffled across epochs
                 # in case shuffle is True
                 self._sampler.set_epoch(curr_epoch)
@@ -771,9 +776,23 @@ def recipe_main(cfg: DictConfig) -> None:
         - Overwritten by arguments from the command-line
     """
     config.log_config(recipe_name="LoRAFinetuneRecipeSingleDevice", cfg=cfg)
-    recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
-    recipe.setup(cfg=cfg)
-    recipe.train()
+    # ==== The following changes are to mimic resume_from_checkpoint ====
+    for i in range(cfg.epochs):
+        recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
+        if i == 0:
+            recipe.setup(cfg=cfg, epoch=i)
+            # persist metric_logger across epochs (for wanbd logging)
+            metric_logger = recipe._metric_logger
+        else:
+            recipe.setup(cfg=cfg, epoch=i, metric_logger=metric_logger)
+        recipe.train(curr_epoch=i)
+        # modify config to mimic user modifying .yaml file to resume from checkpoint
+        cfg.resume_from_checkpoint = True
+        cfg.checkpointer.checkpoint_dir = "/tmp/Meta-Llama-3-8B-Instruct/"
+        cfg.checkpointer.checkpoint_files = [f"meta_model_{i}.pt"]
+        cfg.checkpointer.adapter_checkpoint = f"adapter_{i}.pt"
+        cfg.checkpointer.recipe_checkpoint = "recipe_state.pt"
+
     recipe.cleanup()
 
 

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -559,17 +559,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         )
         ckpt_dict.update({training.MODEL_KEY: merged_state_dict})
 
-<<<<<<< HEAD
-        # Construct the adapter weights
-        adapter_key_filter = lambda x: x in self.adapter_params
-        # adapters are very small ~0.04GB so we don't need to use mmap when offloading to CPU
-        adapter_state_dict = {
-            k: v.cpu() for k, v in self._model.state_dict().items() if adapter_key_filter(k)
-        }
         ckpt_dict.update({training.ADAPTER_KEY: adapter_state_dict})
-=======
-        ckpt_dict.update({utils.ADAPTER_KEY: adapter_state_dict})
->>>>>>> b8dbcfdb (Use core APIs, refactor into state_dict post hook)
         adapter_config = {
             "r": self._lora_rank,
             "lora_alpha": self._lora_alpha,

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -291,7 +291,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self.ignore_labels_cache = torch.full(
             (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
         )
-    
+
     def _patch_state_dict_hook(self, cfg: DictConfig) -> None:
         """
         Patches the state_dict hook for QLoRA for the `low_cpu_ram` config option.

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -201,17 +201,15 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 "Are you sure you passed in the right recipe checkpoint?"
             ) from e
 
-    def setup(self, cfg: DictConfig, epoch=0, metric_logger=None) -> None:
+    def setup(self, cfg: DictConfig) -> None:
         """
         Setup the recipe state. This includes recipe state (if resume_from_checkpoint is True),
         model, tokenizer, loss, optimizer, learning rate scheduler, sampler, and dataloader.
         """
-        if epoch == 0:
-            self._metric_logger = config.instantiate(cfg.metric_logger)
-            # log config with parameter override
-            self._metric_logger.log_config(cfg)
-        else:
-            self._metric_logger = metric_logger
+        self._metric_logger = config.instantiate(cfg.metric_logger)
+
+        # log config with parameter override
+        self._metric_logger.log_config(cfg)
 
         self._compile = cfg.compile
         checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
@@ -598,7 +596,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         return loss
 
-    def train(self, curr_epoch=0) -> None:
+    def train(self) -> None:
         """
         The core training loop.
         """
@@ -615,7 +613,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         with self._profiler as prof:
             # self.epochs_run should be non-zero when we're resuming from a checkpoint
-            for _ in range(1):
+            for curr_epoch in range(self.epochs_run, self.total_epochs):
                 # Update the sampler to ensure data is correctly shuffled across epochs
                 # in case shuffle is True
                 self._sampler.set_epoch(curr_epoch)
@@ -732,22 +730,8 @@ def recipe_main(cfg: DictConfig) -> None:
     """
     config.log_config(recipe_name="LoRAFinetuneRecipeSingleDevice", cfg=cfg)
     recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
-     # ==== The following changes are to mimic resume_from_checkpoint ====
-    for i in range(cfg.epochs):
-        recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
-        if i == 0:
-            recipe.setup(cfg=cfg, epoch=i)
-            # persist metric_logger across epochs (for wanbd logging)
-            metric_logger = recipe._metric_logger
-        else:
-            recipe.setup(cfg=cfg, epoch=i, metric_logger=metric_logger)
-        recipe.train(curr_epoch=i)
-        # modify config to mimic user modifying .yaml file to resume from checkpoint
-        cfg.resume_from_checkpoint = True
-        cfg.checkpointer.checkpoint_dir = "/tmp/Meta-Llama-3-8B-Instruct/"
-        cfg.checkpointer.checkpoint_files = [f"meta_model_{i}.pt"]
-        cfg.checkpointer.adapter_checkpoint = f"adapter_{i}.pt"
-        cfg.checkpointer.recipe_checkpoint = "recipe_state.pt"
+    recipe.setup(cfg=cfg)
+    recipe.train()
     recipe.cleanup()
 
 

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -201,15 +201,17 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 "Are you sure you passed in the right recipe checkpoint?"
             ) from e
 
-    def setup(self, cfg: DictConfig) -> None:
+    def setup(self, cfg: DictConfig, epoch=0, metric_logger=None) -> None:
         """
         Setup the recipe state. This includes recipe state (if resume_from_checkpoint is True),
         model, tokenizer, loss, optimizer, learning rate scheduler, sampler, and dataloader.
         """
-        self._metric_logger = config.instantiate(cfg.metric_logger)
-
-        # log config with parameter override
-        self._metric_logger.log_config(cfg)
+        if epoch == 0:
+            self._metric_logger = config.instantiate(cfg.metric_logger)
+            # log config with parameter override
+            self._metric_logger.log_config(cfg)
+        else:
+            self._metric_logger = metric_logger
 
         self._compile = cfg.compile
         checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
@@ -592,7 +594,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         return loss
 
-    def train(self) -> None:
+    def train(self, curr_epoch=0) -> None:
         """
         The core training loop.
         """
@@ -609,7 +611,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         with self._profiler as prof:
             # self.epochs_run should be non-zero when we're resuming from a checkpoint
-            for curr_epoch in range(self.epochs_run, self.total_epochs):
+            for _ in range(1):
                 # Update the sampler to ensure data is correctly shuffled across epochs
                 # in case shuffle is True
                 self._sampler.set_epoch(curr_epoch)
@@ -728,8 +730,24 @@ def recipe_main(cfg: DictConfig) -> None:
     if cfg.get("low_cpu_ram", False):
         common_utils._use_low_cpu_ram = True
     recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
-    recipe.setup(cfg=cfg)
-    recipe.train()
+    # ==== The following changes are to mimic resume_from_checkpoint ====
+    for i in range(cfg.epochs):
+        recipe = LoRAFinetuneRecipeSingleDevice(cfg=cfg)
+        if i == 0:
+            recipe.setup(cfg=cfg, epoch=i)
+            # persist metric_logger across epochs (for wanbd logging)
+            metric_logger = recipe._metric_logger
+        else:
+            recipe.setup(cfg=cfg, epoch=i, metric_logger=metric_logger)
+        recipe.train(curr_epoch=i)
+        # modify config to mimic user modifying .yaml file to resume from checkpoint
+        cfg.resume_from_checkpoint = True
+        cfg.checkpointer.checkpoint_dir = "/tmp/Meta-Llama-3-8B-Instruct/"
+        cfg.checkpointer.checkpoint_files = [f"meta_model_{i}.pt"]
+        cfg.checkpointer.adapter_checkpoint = f"adapter_{i}.pt"
+        cfg.checkpointer.recipe_checkpoint = "recipe_state.pt"
+    # recipe.setup(cfg=cfg)
+    # recipe.train()
     recipe.cleanup()
 
 

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -13,10 +13,14 @@ from warnings import warn
 
 import torch
 from omegaconf import DictConfig, ListConfig
+from collections import OrderedDict
+from mmap import MAP_SHARED, MAP_PRIVATE
 
 from torch import nn
 from torch.optim import Optimizer
+from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensorConverter, FakeTensor
 from torch.utils.data import DataLoader, DistributedSampler
+from torchao.dtypes.nf4tensor import NF4Tensor
 from torchtune import config, modules, training, utils
 from torchtune.data import padded_collate_sft
 from torchtune.datasets import ConcatDataset
@@ -34,6 +38,23 @@ from torchtune.training import DummyProfiler, PROFILER_KEY
 from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
+
+
+# === This will not live in torchtune, is just for the sake of this prototype ===
+def fake_reduce_ex(tensor, proto):
+    tensor.untyped_storage()._serialize_data = False
+    func, args = tensor._reduce_ex_internal(proto)
+    storage = args[0]
+    # FakeTensor storage device is always meta, we need to tag the storage with
+    # the tensor device to be able to restore it correctly.
+    if isinstance(storage, torch.storage.UntypedStorage):
+        storage._fake_device = tensor.device  # type: ignore[attr-defined]
+    elif isinstance(storage, torch.storage.TypedStorage):
+        storage._untyped_storage._fake_device = tensor.device
+    return (torch._tensor._rebuild_from_type_v2, (func, torch.Tensor, args, None))
+
+FakeTensor.__reduce_ex__ = fake_reduce_ex
+# === This will not live in torchtune ===
 
 
 class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
@@ -523,20 +544,54 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             )
 
         # Move to CPU to avoid a copy on GPU
-        state_dict = {k: v.cpu() for k, v in self._model.state_dict().items()}
+        # state_dict = {k: v.cpu() for k, v in self._model.state_dict().items()}
+
+        # === Create a FakeTensor version of the state_dict (preserves storage aliasing) ===
+        state_dict = self._model.state_dict()
+        mode = FakeTensorMode()
+        converter = FakeTensorConverter()
+        fake_state_dict = OrderedDict()
+        for k, v in state_dict.items():
+            # remove adapters (we don't want them in merged_state_dict)
+            if "lora_a" in k or "lora_b" in k:
+                continue
+            if isinstance(v, NF4Tensor):
+                fake_state_dict[k] = converter.from_real_tensor(mode, v).to(torch.bfloat16).cpu()
+            else:
+                fake_state_dict[k] = converter.from_real_tensor(mode, v).cpu()
+
+        # === Save and load fake state_dict ===
+        # dest_state_dict is now backed by an mmap-ed file that can be written to
+        dest_state_dict_path = "/tmp/llama_state_dict.pt"
+        torch.save(fake_state_dict, dest_state_dict_path)
+        torch.serialization.set_default_mmap_options(MAP_SHARED)
+        dest_state_dict = torch.load(dest_state_dict_path, mmap=True, weights_only=True)
+        torch.serialization.set_default_mmap_options(MAP_PRIVATE)
+
+        # This bit does D2H one by one and since dest_state_dict is backed by mmap --> won't OOM :)
+        for k in state_dict.keys():
+            if 'lora_a' in k or 'lora_b' in k:
+                # adapters are very small ~0.04GB so we don't need to use mmap when offloading to CPU
+                dest_state_dict[k] = state_dict[k].cpu()
+            if isinstance(state_dict[k], NF4Tensor):
+                dest_state_dict[k].copy_(state_dict[k].to(torch.bfloat16))
+            else:
+                dest_state_dict[k].copy_(state_dict[k])
 
         # Construct the full state dict with LoRA weights merged into base LLM weights
         merged_state_dict = get_merged_lora_ckpt(
             state_dict,
             rank=self._lora_rank,
             alpha=self._lora_alpha,
+            dest_state_dict=dest_state_dict,
         )
         ckpt_dict.update({training.MODEL_KEY: merged_state_dict})
 
         # Construct the adapter weights
         adapter_key_filter = lambda x: x in self.adapter_params
+        # adapters are very small ~0.04GB so we don't need to use mmap when offloading to CPU
         adapter_state_dict = {
-            k: v for k, v in self._model.state_dict().items() if adapter_key_filter(k)
+            k: v.cpu() for k, v in self._model.state_dict().items() if adapter_key_filter(k)
         }
         ckpt_dict.update({training.ADAPTER_KEY: adapter_state_dict})
         adapter_config = {

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -253,12 +253,14 @@ def lora_llama3(
         output=output_proj,
     )
 
-    if quantize_base:
-        # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
-        # so as to not increase peak memory
-        model._register_state_dict_hook(
-            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
-        )
+    # Registering this hook will cause OOM on colab
+    # We do the corresponding logic in lora_finetune_single_device.py:save_checkpoint
+    # if quantize_base:
+    #     # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
+    #     # so as to not increase peak memory
+    #     model._register_state_dict_hook(
+    #         partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+    #     )
 
     return model
 

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -22,7 +22,7 @@ from torchtune.modules import (
     TransformerSelfAttentionLayer,
 )
 
-from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
+from torchtune.modules.common_utils import _register_reparametrize_state_dict_hooks
 
 from torchtune.modules.peft import DoRALinear, LORA_ATTN_MODULES, LoRALinear
 
@@ -256,9 +256,7 @@ def lora_llama3(
     if quantize_base:
         # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
         # so as to not increase peak memory
-        model._register_state_dict_hook(
-            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
-        )
+        _register_reparametrize_state_dict_hooks(model)
 
     return model
 

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -22,7 +22,10 @@ from torchtune.modules import (
     TransformerSelfAttentionLayer,
 )
 
-from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook, _low_ram_reparametrize_as_dtype_state_dict_post_hook
+from torchtune.modules.common_utils import (
+    reparametrize_as_dtype_state_dict_post_hook,
+    _low_ram_reparametrize_as_dtype_state_dict_post_hook,
+)
 
 from torchtune.modules.peft import DoRALinear, LORA_ATTN_MODULES, LoRALinear
 
@@ -193,7 +196,7 @@ def lora_llama3(
             weights within linear layers LoRA is applied to. The final output linear projection is not
             supported for quantization currently.
         low_cpu_ram (bool): Whether checkpointing in an environment with low RAM. Setting this flag to
-            ``True`` can avoid CPU OOM when checkpointing on a low RAM machine (e.g. colab)
+            ``True`` can avoid CPU OOM when checkpointing on a low RAM machine (e.g. colab) with QLoRA.
     Returns:
         TransformerDecoder: Instantiation of Llama3 model with LoRA applied to
         a subset of the attention projections in each layer.

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -269,7 +269,7 @@ def lora_llama3(
                     "low_cpu_ram=True not supported on Windows."
                 )
             else:
-                raise RuntimeError("low_cpu_ram=True requires torch.__version__ >= 2.5.0.dev20240829.")
+                raise RuntimeError("low_cpu_ram=True requires torch.__version__ >= 2.5.0.dev20240830.")
         hook = (
             _low_ram_reparametrize_as_dtype_state_dict_post_hook
             if low_cpu_ram

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from functools import partial
 from typing import List, Literal, Optional
 
 from torch import nn

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import partial
 from typing import List, Literal, Optional
 
 from torch import nn

--- a/torchtune/models/llama3/_model_builders.py
+++ b/torchtune/models/llama3/_model_builders.py
@@ -97,6 +97,7 @@ def lora_llama3_8b(
     lora_alpha: float = 16,
     quantize_base: bool = False,
     use_dora: bool = False,
+    low_cpu_ram: bool = False,
 ) -> TransformerDecoder:
     """
     Builder for creating a Llama3 8B model with LoRA enabled.
@@ -141,6 +142,7 @@ def lora_llama3_8b(
         lora_dropout=0.05,
         quantize_base=quantize_base,
         use_dora=use_dora,
+        low_cpu_ram=low_cpu_ram,
     )
 
 

--- a/torchtune/models/llama3/_model_builders.py
+++ b/torchtune/models/llama3/_model_builders.py
@@ -97,7 +97,6 @@ def lora_llama3_8b(
     lora_alpha: float = 16,
     quantize_base: bool = False,
     use_dora: bool = False,
-    low_cpu_ram: bool = False,
 ) -> TransformerDecoder:
     """
     Builder for creating a Llama3 8B model with LoRA enabled.
@@ -142,7 +141,6 @@ def lora_llama3_8b(
         lora_dropout=0.05,
         quantize_base=quantize_base,
         use_dora=use_dora,
-        low_cpu_ram=low_cpu_ram,
     )
 
 

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -116,10 +116,8 @@ def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
         else:
             dest_state_dict[k].copy_(state_dict[k])
 
-    # In place update original state_dict object because we eventually want
-    # to use the public state_dict post hook which does not support out of place
-    # behavior due to buggy semantic
+    # In place update original state_dict object. Although the private state dict
+    # post hook supports out of place behavior, the semantic actually buggy. We eventually want
+    # to use the public state_dict post hook which does not support out of place behavior.
     for k in state_dict.keys():
         state_dict[k] = dest_state_dict[k]
-
-    return state_dict

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -147,6 +147,8 @@ def _register_reparametrize_state_dict_hooks(
 
     Args:
         module (nn.Module): the module to register the hooks to.
+        dtype (torch.dtype): the dtype to restore the weight to. Default is ``torch.bfloat16``.
+        offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
 
     Raises:
         RuntimeError: If the low RAM reparametrize hook is used on Windows or an incompatible torch version.

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorConverter, FakeTensorMode
 from torchao.dtypes.nf4tensor import NF4Tensor
+from torchtune.utils._version import torch_version_ge
 
 
 def reparametrize_as_dtype_state_dict_post_hook(
@@ -55,7 +56,7 @@ def reparametrize_as_dtype_state_dict_post_hook(
 
 
 # mmap.MAP_SHARED is not supported on Windows but this change targets colab.
-if hasattr(torch.serialization, "skip_data") and not sys.platform == "win32":
+if torch_version_ge('2.5.0.dev20240830') and not sys.platform == "win32":
 
     def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
         model: nn.Module,

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -56,82 +56,76 @@ def reparametrize_as_dtype_state_dict_post_hook(
                 state_dict[k] = state_dict[k].cpu()
 
 
-# mmap.MAP_SHARED is not supported on Windows but this change targets colab.
-if torch.__version__ >= "2.5.0.dev20240906" and not sys.platform == "win32":
+def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
+    model: nn.Module,
+    state_dict: Dict[str, Any],
+    *args: Tuple[Any, ...],
+    dtype: torch.dtype = torch.bfloat16,
+    offload_to_cpu: bool = True,
+    **kwargs: Dict[Any, Any],
+):
+    """
+    A state_dict hook that replaces NF4 tensors with their restored
+    higher-precision weight and optionally offloads the restored weight to CPU.
+    Use this hook to avoid increased peak GPU memory usage during checkpoint
+    save when training with QLoRA.
 
-    def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
-        model: nn.Module,
-        state_dict: Dict[str, Any],
-        *args: Tuple[Any, ...],
-        dtype: torch.dtype = torch.bfloat16,
-        offload_to_cpu: bool = True,
-        **kwargs: Dict[Any, Any],
-    ):
-        """
-        A state_dict hook that replaces NF4 tensors with their restored
-        higher-precision weight and optionally offloads the restored weight to CPU.
-        Use this hook to avoid increased peak GPU memory usage during checkpoint
-        save when training with QLoRA.
+    This hook is similar to ``reparametrize_as_dtype_state_dict_post_hook`` but uses
+    FakeTensor and mmap(2) to avoid CPU OOM on colab.
 
-        This hook is similar to ``reparametrize_as_dtype_state_dict_post_hook`` but uses
-        FakeTensor and mmap(2) to avoid CPU OOM on colab.
+    This function is meant to be used with PyTorch's ``nn.Module._register_state_dict_hook``, i.e.
 
-        This function is meant to be used with PyTorch's ``nn.Module._register_state_dict_hook``, i.e.
+    >>> m = MyModule()
+    >>> m._register_state_dict_hook(reparametrize_as_dtype_state_dict_post_hook)
 
-        >>> m = MyModule()
-        >>> m._register_state_dict_hook(reparametrize_as_dtype_state_dict_post_hook)
+    If the hook is registered per the above process, this hook will be called _after_ the module's
+    ``state_dict`` method is called. The hook will replace all ``NF4Tensor`` instances by unquantizing
+    them to the original dtype, and optionally offload the restored weight to CPU.
 
-        If the hook is registered per the above process, this hook will be called _after_ the module's
-        ``state_dict`` method is called. The hook will replace all ``NF4Tensor`` instances by unquantizing
-        them to the original dtype, and optionally offload the restored weight to CPU.
+    Args:
+        model (nn.Module): the model to take ``state_dict()`` on
+        state_dict (Dict[str, Any]): the state dict to modify
+        *args (Tuple[Any, ...]): Unused args passed when running this as a state_dict hook.
+        dtype (torch.dtype): the dtype to restore the weight to. Default is ``torch.bfloat16``.
+        offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
+        **kwargs (Dict[Any, Any]): Unused keyword args passed when running this as a state_dict hook.
+    """
+    # Create a state dict of FakeTensors that matches the state_dict
+    mode = FakeTensorMode()
+    converter = FakeTensorConverter()
+    fake_state_dict = OrderedDict()
+    for k, v in state_dict.items():
+        if isinstance(v, NF4Tensor):
+            fake_state_dict[k] = converter.from_real_tensor(mode, v).to(dtype)
+        else:
+            fake_state_dict[k] = converter.from_real_tensor(mode, v)
 
-        Args:
-            model (nn.Module): the model to take ``state_dict()`` on
-            state_dict (Dict[str, Any]): the state dict to modify
-            *args (Tuple[Any, ...]): Unused args passed when running this as a state_dict hook.
-            dtype (torch.dtype): the dtype to restore the weight to. Default is ``torch.bfloat16``.
-            offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
-            **kwargs (Dict[Any, Any]): Unused keyword args passed when running this as a state_dict hook.
-        """
-        # Create a state dict of FakeTensors that matches the state_dict
-        mode = FakeTensorMode()
-        converter = FakeTensorConverter()
-        fake_state_dict = OrderedDict()
-        for k, v in state_dict.items():
-            if isinstance(v, NF4Tensor):
-                fake_state_dict[k] = converter.from_real_tensor(mode, v).to(dtype)
-            else:
-                fake_state_dict[k] = converter.from_real_tensor(mode, v)
+        if offload_to_cpu:
+            fake_state_dict[k] = fake_state_dict[k].cpu()
 
-            if offload_to_cpu:
-                fake_state_dict[k] = fake_state_dict[k].cpu()
+    # Create a state_dict on disk with space reserved for storage bytes
+    # Then load with mmap and MAP_SHARED (can writeback to disk file)
+    dest_state_dict_path = "/tmp/fake_state_dict.pt"
+    with torch.serialization.skip_data(materialize_fake_tensors=True):
+        torch.save(fake_state_dict, dest_state_dict_path)
+    with torch.serialization.set_default_mmap_options(mmap.MAP_SHARED):
+        dest_state_dict = torch.load(
+            dest_state_dict_path, mmap=True, weights_only=True
+        )
 
-        # Create a state_dict on disk with space reserved for storage bytes
-        # Then load with mmap and MAP_SHARED (can writeback to disk file)
-        dest_state_dict_path = "/tmp/fake_state_dict.pt"
-        with torch.serialization.skip_data(materialize_fake_tensors=True):
-            torch.save(fake_state_dict, dest_state_dict_path)
-        with torch.serialization.set_default_mmap_options(mmap.MAP_SHARED):
-            dest_state_dict = torch.load(
-                dest_state_dict_path, mmap=True, weights_only=True
-            )
+    # Do D2H and upcast one by one and since dest_state_dict is backed by mmap --> won't OOM
+    # even when there is no swap space (e.g. colab)
+    for k in state_dict.keys():
+        if isinstance(state_dict[k], NF4Tensor):
+            dest_state_dict[k].copy_(state_dict[k].to(dtype))
+        else:
+            dest_state_dict[k].copy_(state_dict[k])
 
-        # Do D2H and upcast one by one and since dest_state_dict is backed by mmap --> won't OOM
-        # even when there is no swap space (e.g. colab)
-        for k in state_dict.keys():
-            if isinstance(state_dict[k], NF4Tensor):
-                dest_state_dict[k].copy_(state_dict[k].to(torch.bfloat16))
-            else:
-                dest_state_dict[k].copy_(state_dict[k])
-
-        # In place update original state_dict object. Although the private state dict
-        # post hook supports out of place behavior, the semantic actually buggy. We eventually want
-        # to use the public state_dict post hook which does not support out of place behavior.
-        for k in state_dict.keys():
-            state_dict[k] = dest_state_dict[k]
-
-else:
-    _low_ram_reparametrize_as_dtype_state_dict_post_hook = None
+    # In place update original state_dict object. Although the private state dict
+    # post hook supports out of place behavior, the semantic actually buggy. We eventually want
+    # to use the public state_dict post hook which does not support out of place behavior.
+    for k in state_dict.keys():
+        state_dict[k] = dest_state_dict[k]
 
 
 def _register_reparametrize_state_dict_hooks(
@@ -159,6 +153,7 @@ def _register_reparametrize_state_dict_hooks(
                 "Low RAM reparametrize_as_dtype_state_dict_post_hook requires PyTorch 2.5.0.dev20240906 or later."
             )
         elif sys.platform == "win32":
+            # mmap.MAP_SHARED is not supported on Windows but this change targets colab.
             raise RuntimeError(
                 "Low RAM reparametrize_as_dtype_state_dict_post_hook is not supported on Windows."
             )

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -57,7 +57,7 @@ def reparametrize_as_dtype_state_dict_post_hook(
 
 
 # mmap.MAP_SHARED is not supported on Windows but this change targets colab.
-if torch.__version__ >= "2.5.0.dev20240830" and not sys.platform == "win32":
+if torch.__version__ >= "2.5.0.dev20240906" and not sys.platform == "win32":
 
     def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
         model: nn.Module,
@@ -154,9 +154,9 @@ def _register_reparametrize_state_dict_hooks(
         RuntimeError: If the low RAM reparametrize hook is used on Windows or an incompatible torch version.
     """
     if _use_low_cpu_ram:
-        if torch.__version__ < "2.5.0.dev20240830":
+        if torch.__version__ < "2.5.0.dev20240906":
             raise RuntimeError(
-                "Low RAM reparametrize_as_dtype_state_dict_post_hook requires PyTorch 2.5.0.dev20240830 or later."
+                "Low RAM reparametrize_as_dtype_state_dict_post_hook requires PyTorch 2.5.0.dev20240906 or later."
             )
         elif sys.platform == "win32":
             raise RuntimeError(

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -17,6 +17,7 @@ from torchao.dtypes.nf4tensor import NF4Tensor
 
 _use_low_cpu_ram: bool = False
 
+
 def reparametrize_as_dtype_state_dict_post_hook(
     model: nn.Module,
     state_dict: Dict[str, Any],
@@ -132,6 +133,7 @@ if torch.__version__ >= "2.5.0.dev20240830" and not sys.platform == "win32":
 else:
     _low_ram_reparametrize_as_dtype_state_dict_post_hook = None
 
+
 def _register_reparametrize_state_dict_hooks(
     module: nn.Module,
     dtype: torch.dtype = torch.bfloat16,
@@ -145,6 +147,9 @@ def _register_reparametrize_state_dict_hooks(
 
     Args:
         module (nn.Module): the module to register the hooks to.
+
+    Raises:
+        RuntimeError: If the low RAM reparametrize hook is used on Windows or an incompatible torch version.
     """
     if _use_low_cpu_ram:
         if torch.__version__ < "2.5.0.dev20240830":
@@ -159,4 +164,6 @@ def _register_reparametrize_state_dict_hooks(
             hook = _low_ram_reparametrize_as_dtype_state_dict_post_hook
     else:
         hook = reparametrize_as_dtype_state_dict_post_hook
-    module._register_state_dict_post_hook(partial(hook, dtype=dtype, offload_to_cpu=offload_to_cpu))
+    module._register_state_dict_post_hook(
+        partial(hook, dtype=dtype, offload_to_cpu=offload_to_cpu)
+    )

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -4,9 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import OrderedDict
 import mmap
 import sys
+from collections import OrderedDict
 from typing import Any, Dict, Tuple
 
 import torch
@@ -53,8 +53,10 @@ def reparametrize_as_dtype_state_dict_post_hook(
             if offload_to_cpu:
                 state_dict[k] = state_dict[k].cpu()
 
+
 # mmap.MAP_SHARED is not supported on Windows but this change targets colab.
 if hasattr(torch.serialization, "skip_data") and not sys.platform == "win32":
+
     def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
         model: nn.Module,
         state_dict: Dict[str, Any],
@@ -108,7 +110,9 @@ if hasattr(torch.serialization, "skip_data") and not sys.platform == "win32":
         with torch.serialization.skip_data(materialize_fake_tensors=True):
             torch.save(fake_state_dict, dest_state_dict_path)
         with torch.serialization.set_default_mmap_options(mmap.MAP_SHARED):
-            dest_state_dict = torch.load(dest_state_dict_path, mmap=True, weights_only=True)
+            dest_state_dict = torch.load(
+                dest_state_dict_path, mmap=True, weights_only=True
+            )
 
         # Do D2H and upcast one by one and since dest_state_dict is backed by mmap --> won't OOM
         # even when there is no swap space (e.g. colab)
@@ -123,5 +127,6 @@ if hasattr(torch.serialization, "skip_data") and not sys.platform == "win32":
         # to use the public state_dict post hook which does not support out of place behavior.
         for k in state_dict.keys():
             state_dict[k] = dest_state_dict[k]
+
 else:
     _low_ram_reparametrize_as_dtype_state_dict_post_hook = None

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -11,8 +11,8 @@ from typing import Any, Dict, Tuple
 import torch
 
 import torch.nn as nn
+from torch._subclasses.fake_tensor import FakeTensorConverter, FakeTensorMode
 from torchao.dtypes.nf4tensor import NF4Tensor
-from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensorConverter
 
 
 def reparametrize_as_dtype_state_dict_post_hook(
@@ -52,6 +52,7 @@ def reparametrize_as_dtype_state_dict_post_hook(
             state_dict[k] = v.to(dtype)
             if offload_to_cpu:
                 state_dict[k] = state_dict[k].cpu()
+
 
 def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
     model: nn.Module,

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -7,6 +7,7 @@
 import mmap
 import sys
 from collections import OrderedDict
+from functools import partial
 from typing import Any, Dict, Tuple
 
 import torch
@@ -159,4 +160,4 @@ def _register_reparametrize_state_dict_hooks(
             hook = _low_ram_reparametrize_as_dtype_state_dict_post_hook
     else:
         hook = reparametrize_as_dtype_state_dict_post_hook
-    module._register_state_dict_post_hook(partial(hook, dtype=dtype, offload_to_cpu=offload_to_cpu))
+    module._register_state_dict_hook(partial(hook, dtype=dtype, offload_to_cpu=offload_to_cpu))

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -4,12 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import OrderedDict
+from mmap import MAP_SHARED
 from typing import Any, Dict, Tuple
 
 import torch
 
 import torch.nn as nn
 from torchao.dtypes.nf4tensor import NF4Tensor
+from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensorConverter
 
 
 def reparametrize_as_dtype_state_dict_post_hook(
@@ -43,8 +46,54 @@ def reparametrize_as_dtype_state_dict_post_hook(
         offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
         **kwargs (Dict[Any, Any]): Unused keyword args passed when running this as a state_dict hook.
     """
+    breakpoint()
     for k, v in state_dict.items():
         if isinstance(v, NF4Tensor):
             state_dict[k] = v.to(dtype)
             if offload_to_cpu:
                 state_dict[k] = state_dict[k].cpu()
+
+def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
+    model: nn.Module,
+    state_dict: Dict[str, Any],
+    *args: Tuple[Any, ...],
+    dtype: torch.dtype = torch.bfloat16,
+    offload_to_cpu: bool = True,
+    **kwargs: Dict[Any, Any],
+):
+    # Create a state dict of FakeTensors that matches the state_dict
+    mode = FakeTensorMode()
+    converter = FakeTensorConverter()
+    fake_state_dict = OrderedDict()
+    for k, v in state_dict.items():
+        if isinstance(v, NF4Tensor):
+            fake_state_dict[k] = converter.from_real_tensor(mode, v).to(dtype)
+        else:
+            fake_state_dict[k] = converter.from_real_tensor(mode, v)
+
+        if offload_to_cpu:
+            fake_state_dict[k] = fake_state_dict[k].cpu()
+
+    # Create a state_dict on disk with space reserved for storage bytes
+    # Then load with mmap and MAP_SHARED (can writeback to disk file)
+    dest_state_dict_path = "/tmp/fake_state_dict.pt"
+    with torch.serialization.skip_data(materialize_fake_tensors=True):
+        torch.save(fake_state_dict, dest_state_dict_path)
+    with torch.serialization.set_default_mmap_options(MAP_SHARED):
+        dest_state_dict = torch.load(dest_state_dict_path, mmap=True, weights_only=True)
+
+    # Do D2H and upcast one by one and since dest_state_dict is backed by mmap --> won't OOM
+    # even when there is no swap space (e.g. colab)
+    for k in state_dict.keys():
+        if isinstance(state_dict[k], NF4Tensor):
+            dest_state_dict[k].copy_(state_dict[k].to(torch.bfloat16))
+        else:
+            dest_state_dict[k].copy_(state_dict[k])
+
+    # In place update original state_dict object because we eventually want
+    # to use the public state_dict post hook which does not support out of place
+    # behavior due to buggy semantic
+    for k in state_dict.keys():
+        state_dict[k] = dest_state_dict[k]
+
+    return state_dict

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -109,9 +109,7 @@ def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
     with torch.serialization.skip_data(materialize_fake_tensors=True):
         torch.save(fake_state_dict, dest_state_dict_path)
     with torch.serialization.set_default_mmap_options(mmap.MAP_SHARED):
-        dest_state_dict = torch.load(
-            dest_state_dict_path, mmap=True, weights_only=True
-        )
+        dest_state_dict = torch.load(dest_state_dict_path, mmap=True, weights_only=True)
 
     # Do D2H and upcast one by one and since dest_state_dict is backed by mmap --> won't OOM
     # even when there is no swap space (e.g. colab)

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -14,7 +14,6 @@ import torch
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorConverter, FakeTensorMode
 from torchao.dtypes.nf4tensor import NF4Tensor
-from torchtune.utils._version import torch_version_ge
 
 
 def reparametrize_as_dtype_state_dict_post_hook(
@@ -56,7 +55,7 @@ def reparametrize_as_dtype_state_dict_post_hook(
 
 
 # mmap.MAP_SHARED is not supported on Windows but this change targets colab.
-if torch_version_ge('2.5.0.dev20240830') and not sys.platform == "win32":
+if torch.__version__ >= '2.5.0.dev20240830' and not sys.platform == "win32":
 
     def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
         model: nn.Module,

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -46,7 +46,6 @@ def reparametrize_as_dtype_state_dict_post_hook(
         offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
         **kwargs (Dict[Any, Any]): Unused keyword args passed when running this as a state_dict hook.
     """
-    breakpoint()
     for k, v in state_dict.items():
         if isinstance(v, NF4Tensor):
             state_dict[k] = v.to(dtype)
@@ -62,6 +61,32 @@ def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
     offload_to_cpu: bool = True,
     **kwargs: Dict[Any, Any],
 ):
+    """
+    A state_dict hook that replaces NF4 tensors with their restored
+    higher-precision weight and optionally offloads the restored weight to CPU.
+    Use this hook to avoid increased peak GPU memory usage during checkpoint
+    save when training with QLoRA.
+
+    This hook is similar to ``reparametrize_as_dtype_state_dict_post_hook`` but uses
+    FakeTensor and mmap(2) to avoid CPU OOM on colab.
+
+    This function is meant to be used with PyTorch's ``nn.Module._register_state_dict_hook``, i.e.
+
+    >>> m = MyModule()
+    >>> m._register_state_dict_hook(reparametrize_as_dtype_state_dict_post_hook)
+
+    If the hook is registered per the above process, this hook will be called _after_ the module's
+    ``state_dict`` method is called. The hook will replace all ``NF4Tensor`` instances by unquantizing
+    them to the original dtype, and optionally offload the restored weight to CPU.
+
+    Args:
+        model (nn.Module): the model to take ``state_dict()`` on
+        state_dict (Dict[str, Any]): the state dict to modify
+        *args (Tuple[Any, ...]): Unused args passed when running this as a state_dict hook.
+        dtype (torch.dtype): the dtype to restore the weight to. Default is ``torch.bfloat16``.
+        offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
+        **kwargs (Dict[Any, Any]): Unused keyword args passed when running this as a state_dict hook.
+    """
     # Create a state dict of FakeTensors that matches the state_dict
     mode = FakeTensorMode()
     converter = FakeTensorConverter()

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -159,6 +159,6 @@ def _register_reparametrize_state_dict_hooks(
             hook = _low_ram_reparametrize_as_dtype_state_dict_post_hook
     else:
         hook = reparametrize_as_dtype_state_dict_post_hook
-    module._register_state_dict_post_hook(
+    module._register_state_dict_hook(
         partial(hook, dtype=dtype, offload_to_cpu=offload_to_cpu)
     )

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -7,6 +7,7 @@
 import mmap
 import sys
 from collections import OrderedDict
+from functools import partial
 from typing import Any, Dict, Tuple
 
 import torch

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import OrderedDict
-from mmap import MAP_SHARED
+import mmap
+import sys
 from typing import Any, Dict, Tuple
 
 import torch
@@ -52,72 +53,75 @@ def reparametrize_as_dtype_state_dict_post_hook(
             if offload_to_cpu:
                 state_dict[k] = state_dict[k].cpu()
 
+# mmap.MAP_SHARED is not supported on Windows but this change targets colab.
+if hasattr(torch.serialization, "skip_data") and not sys.platform == "win32":
+    def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
+        model: nn.Module,
+        state_dict: Dict[str, Any],
+        *args: Tuple[Any, ...],
+        dtype: torch.dtype = torch.bfloat16,
+        offload_to_cpu: bool = True,
+        **kwargs: Dict[Any, Any],
+    ):
+        """
+        A state_dict hook that replaces NF4 tensors with their restored
+        higher-precision weight and optionally offloads the restored weight to CPU.
+        Use this hook to avoid increased peak GPU memory usage during checkpoint
+        save when training with QLoRA.
 
-def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
-    model: nn.Module,
-    state_dict: Dict[str, Any],
-    *args: Tuple[Any, ...],
-    dtype: torch.dtype = torch.bfloat16,
-    offload_to_cpu: bool = True,
-    **kwargs: Dict[Any, Any],
-):
-    """
-    A state_dict hook that replaces NF4 tensors with their restored
-    higher-precision weight and optionally offloads the restored weight to CPU.
-    Use this hook to avoid increased peak GPU memory usage during checkpoint
-    save when training with QLoRA.
+        This hook is similar to ``reparametrize_as_dtype_state_dict_post_hook`` but uses
+        FakeTensor and mmap(2) to avoid CPU OOM on colab.
 
-    This hook is similar to ``reparametrize_as_dtype_state_dict_post_hook`` but uses
-    FakeTensor and mmap(2) to avoid CPU OOM on colab.
+        This function is meant to be used with PyTorch's ``nn.Module._register_state_dict_hook``, i.e.
 
-    This function is meant to be used with PyTorch's ``nn.Module._register_state_dict_hook``, i.e.
+        >>> m = MyModule()
+        >>> m._register_state_dict_hook(reparametrize_as_dtype_state_dict_post_hook)
 
-    >>> m = MyModule()
-    >>> m._register_state_dict_hook(reparametrize_as_dtype_state_dict_post_hook)
+        If the hook is registered per the above process, this hook will be called _after_ the module's
+        ``state_dict`` method is called. The hook will replace all ``NF4Tensor`` instances by unquantizing
+        them to the original dtype, and optionally offload the restored weight to CPU.
 
-    If the hook is registered per the above process, this hook will be called _after_ the module's
-    ``state_dict`` method is called. The hook will replace all ``NF4Tensor`` instances by unquantizing
-    them to the original dtype, and optionally offload the restored weight to CPU.
+        Args:
+            model (nn.Module): the model to take ``state_dict()`` on
+            state_dict (Dict[str, Any]): the state dict to modify
+            *args (Tuple[Any, ...]): Unused args passed when running this as a state_dict hook.
+            dtype (torch.dtype): the dtype to restore the weight to. Default is ``torch.bfloat16``.
+            offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
+            **kwargs (Dict[Any, Any]): Unused keyword args passed when running this as a state_dict hook.
+        """
+        # Create a state dict of FakeTensors that matches the state_dict
+        mode = FakeTensorMode()
+        converter = FakeTensorConverter()
+        fake_state_dict = OrderedDict()
+        for k, v in state_dict.items():
+            if isinstance(v, NF4Tensor):
+                fake_state_dict[k] = converter.from_real_tensor(mode, v).to(dtype)
+            else:
+                fake_state_dict[k] = converter.from_real_tensor(mode, v)
 
-    Args:
-        model (nn.Module): the model to take ``state_dict()`` on
-        state_dict (Dict[str, Any]): the state dict to modify
-        *args (Tuple[Any, ...]): Unused args passed when running this as a state_dict hook.
-        dtype (torch.dtype): the dtype to restore the weight to. Default is ``torch.bfloat16``.
-        offload_to_cpu (bool): whether to offload the restored weight to CPU. Default is ``True``.
-        **kwargs (Dict[Any, Any]): Unused keyword args passed when running this as a state_dict hook.
-    """
-    # Create a state dict of FakeTensors that matches the state_dict
-    mode = FakeTensorMode()
-    converter = FakeTensorConverter()
-    fake_state_dict = OrderedDict()
-    for k, v in state_dict.items():
-        if isinstance(v, NF4Tensor):
-            fake_state_dict[k] = converter.from_real_tensor(mode, v).to(dtype)
-        else:
-            fake_state_dict[k] = converter.from_real_tensor(mode, v)
+            if offload_to_cpu:
+                fake_state_dict[k] = fake_state_dict[k].cpu()
 
-        if offload_to_cpu:
-            fake_state_dict[k] = fake_state_dict[k].cpu()
+        # Create a state_dict on disk with space reserved for storage bytes
+        # Then load with mmap and MAP_SHARED (can writeback to disk file)
+        dest_state_dict_path = "/tmp/fake_state_dict.pt"
+        with torch.serialization.skip_data(materialize_fake_tensors=True):
+            torch.save(fake_state_dict, dest_state_dict_path)
+        with torch.serialization.set_default_mmap_options(mmap.MAP_SHARED):
+            dest_state_dict = torch.load(dest_state_dict_path, mmap=True, weights_only=True)
 
-    # Create a state_dict on disk with space reserved for storage bytes
-    # Then load with mmap and MAP_SHARED (can writeback to disk file)
-    dest_state_dict_path = "/tmp/fake_state_dict.pt"
-    with torch.serialization.skip_data(materialize_fake_tensors=True):
-        torch.save(fake_state_dict, dest_state_dict_path)
-    with torch.serialization.set_default_mmap_options(MAP_SHARED):
-        dest_state_dict = torch.load(dest_state_dict_path, mmap=True, weights_only=True)
+        # Do D2H and upcast one by one and since dest_state_dict is backed by mmap --> won't OOM
+        # even when there is no swap space (e.g. colab)
+        for k in state_dict.keys():
+            if isinstance(state_dict[k], NF4Tensor):
+                dest_state_dict[k].copy_(state_dict[k].to(torch.bfloat16))
+            else:
+                dest_state_dict[k].copy_(state_dict[k])
 
-    # Do D2H and upcast one by one and since dest_state_dict is backed by mmap --> won't OOM
-    # even when there is no swap space (e.g. colab)
-    for k in state_dict.keys():
-        if isinstance(state_dict[k], NF4Tensor):
-            dest_state_dict[k].copy_(state_dict[k].to(torch.bfloat16))
-        else:
-            dest_state_dict[k].copy_(state_dict[k])
-
-    # In place update original state_dict object. Although the private state dict
-    # post hook supports out of place behavior, the semantic actually buggy. We eventually want
-    # to use the public state_dict post hook which does not support out of place behavior.
-    for k in state_dict.keys():
-        state_dict[k] = dest_state_dict[k]
+        # In place update original state_dict object. Although the private state dict
+        # post hook supports out of place behavior, the semantic actually buggy. We eventually want
+        # to use the public state_dict post hook which does not support out of place behavior.
+        for k in state_dict.keys():
+            state_dict[k] = dest_state_dict[k]
+else:
+    _low_ram_reparametrize_as_dtype_state_dict_post_hook = None

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -7,7 +7,6 @@
 import mmap
 import sys
 from collections import OrderedDict
-from functools import partial
 from typing import Any, Dict, Tuple
 
 import torch
@@ -160,4 +159,4 @@ def _register_reparametrize_state_dict_hooks(
             hook = _low_ram_reparametrize_as_dtype_state_dict_post_hook
     else:
         hook = reparametrize_as_dtype_state_dict_post_hook
-    module._register_state_dict_hook(partial(hook, dtype=dtype, offload_to_cpu=offload_to_cpu))
+    module._register_state_dict_post_hook(partial(hook, dtype=dtype, offload_to_cpu=offload_to_cpu))

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -55,7 +55,7 @@ def reparametrize_as_dtype_state_dict_post_hook(
 
 
 # mmap.MAP_SHARED is not supported on Windows but this change targets colab.
-if torch.__version__ >= '2.5.0.dev20240830' and not sys.platform == "win32":
+if torch.__version__ >= "2.5.0.dev20240830" and not sys.platform == "win32":
 
     def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
         model: nn.Module,

--- a/torchtune/modules/peft/_utils.py
+++ b/torchtune/modules/peft/_utils.py
@@ -222,8 +222,6 @@ def get_merged_lora_ckpt(
     state_dict: Dict[str, Any],
     rank: int,
     alpha: float,
-    state_dict: Dict[str, Any], rank: int, alpha: float,
-    dest_state_dict: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
     """
     Merge LoRA weights into the base model format for efficient inference.
@@ -241,8 +239,6 @@ def get_merged_lora_ckpt(
     Returns:
         Dict[str, Any]: The merged state dict.
     """
-    if dest_state_dict:
-        state_dict = dest_state_dict
     lora_modules = _get_lora_modules(state_dict)
     for module in lora_modules:
         lora_a_weight = state_dict[f"{module}.lora_a.weight"]

--- a/torchtune/modules/peft/_utils.py
+++ b/torchtune/modules/peft/_utils.py
@@ -9,6 +9,9 @@ from typing import Any, Dict, Generator, List, Literal, Optional, Protocol, Set
 
 import torch
 from torch import nn
+from torch import bfloat16
+
+from torchao.dtypes.nf4tensor import NF4Tensor
 
 # Modules from MultiHeadAttention that LoRA can be applied to
 LORA_ATTN_MODULES = Literal["q_proj", "k_proj", "v_proj", "output_proj"]
@@ -222,6 +225,8 @@ def get_merged_lora_ckpt(
     state_dict: Dict[str, Any],
     rank: int,
     alpha: float,
+    state_dict: Dict[str, Any], rank: int, alpha: float,
+    dest_state_dict: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
     """
     Merge LoRA weights into the base model format for efficient inference.
@@ -239,6 +244,8 @@ def get_merged_lora_ckpt(
     Returns:
         Dict[str, Any]: The merged state dict.
     """
+    if dest_state_dict:
+        state_dict = dest_state_dict
     lora_modules = _get_lora_modules(state_dict)
     for module in lora_modules:
         lora_a_weight = state_dict[f"{module}.lora_a.weight"]

--- a/torchtune/modules/peft/_utils.py
+++ b/torchtune/modules/peft/_utils.py
@@ -246,7 +246,7 @@ def get_merged_lora_ckpt(
         lora_magnitude = state_dict.get(f"{module}.magnitude", None)
 
         # If magnitude is present, calculate merged DoRA weight
-        if lora_magnitude:
+        if lora_magnitude is not None:
             base_weight = state_dict[f"{module}.weight"].to(lora_a_weight.dtype)
 
             lora_weight = (alpha / rank) * lora_b_weight @ lora_a_weight

--- a/torchtune/modules/peft/_utils.py
+++ b/torchtune/modules/peft/_utils.py
@@ -9,9 +9,6 @@ from typing import Any, Dict, Generator, List, Literal, Optional, Protocol, Set
 
 import torch
 from torch import nn
-from torch import bfloat16
-
-from torchao.dtypes.nf4tensor import NF4Tensor
 
 # Modules from MultiHeadAttention that LoRA can be applied to
 LORA_ATTN_MODULES = Literal["q_proj", "k_proj", "v_proj", "output_proj"]

--- a/torchtune/modules/peft/_utils.py
+++ b/torchtune/modules/peft/_utils.py
@@ -243,21 +243,28 @@ def get_merged_lora_ckpt(
     for module in lora_modules:
         lora_a_weight = state_dict[f"{module}.lora_a.weight"]
         lora_b_weight = state_dict[f"{module}.lora_b.weight"]
-        base_weight = state_dict[f"{module}.weight"].to(lora_a_weight.dtype)
         lora_magnitude = state_dict.get(f"{module}.magnitude", None)
 
-        lora_weight = (alpha / rank) * lora_b_weight @ lora_a_weight
-        merged_weight = base_weight + lora_weight
-        if lora_magnitude is not None:
+        # If magnitude is present, calculate merged DoRA weight
+        if lora_magnitude:
+            base_weight = state_dict[f"{module}.weight"].to(lora_a_weight.dtype)
+
+            lora_weight = (alpha / rank) * lora_b_weight @ lora_a_weight
+            merged_weight = base_weight + lora_weight
             weight_norm = torch.linalg.norm(base_weight + lora_weight, dim=1)
             mag_norm_scale = (lora_magnitude / weight_norm).view(-1, 1)
             merged_weight *= mag_norm_scale
-        state_dict[f"{module}.weight"] = merged_weight
+            state_dict[f"{module}.weight"] = merged_weight
+            del state_dict[f"{module}.magnitude"]
+
+        # Otherwise it is just vanilla LoRA
+        else:
+            state_dict[f"{module}.weight"] += (
+                (alpha / rank) * lora_b_weight @ lora_a_weight
+            )
 
         del state_dict[f"{module}.lora_a.weight"]
         del state_dict[f"{module}.lora_b.weight"]
-        if lora_magnitude is not None:
-            del state_dict[f"{module}.magnitude"]
 
     return state_dict
 


### PR DESCRIPTION
#### Context
This PR prevents OOM during checkpoint save on colab for the following recipe, 

`tune run recipes/lora_finetune_single_device.py --config recipes/configs/llama3/8B_qlora_single_device.yaml`

I do believe it is possible to do better (perf improvements for this colab case) if we refactor the checkpointing logic, but that would be a more invasive refactor imo for now this is the most minimally invasive change that unblocks this use case.


#### Changelog
- Added a new hook `_low_ram_reparametrize_as_dtype_state_dict_post_hook` and `_register_reparametrize_state_dict_hooks` that toggles between the regular reparametrize state_dict hook and this one
- added a model config `low_cpu_ram` -- when `low_cpu_ram` is`True` `_register_reparametrize_state_dict_hooks` toggles to the `low_ram` version of the hook
- PyTorch side changes were landed in https://github.com/pytorch/pytorch/pull/134504 [was reverted, remerging right now as of 9/05] and https://github.com/pytorch/pytorch/pull/134371 **both should be available in the 20240830 nightly**

Old changelog (keeping around for posterity)
- ~Set a seed  in `8B_qlora_single_device.yaml` to make dataloader samples (and hence weights) deterministic~
- ~[for testing velocity purposes]Changed number of epochs to 8, reduced `max_steps_per_epoch` --> 20, `gradient_accumulation_steps` --> 2 to make `save_checkpoint` be called sooner~
- ~[for loss curves] some changes to lora_finetune_single_device.py to mimic a user doing `resume_from_checkpoint` after each epoch (while preserving logger)~
- ~[Not to be landed in torchtune, for PoC purpose] patched [`FakeTensor.__reduce_ex__ `](https://github.com/pytorch/torchtune/pull/1315/files#diff-734dbb110089223adfc465adb1594c2645bc025171e23c67f7b7bece857edbf0R42-R56) which is needed to ensure the `write_record_metadata` utility to create empty checkpoints is called (requires changes in https://github.com/pytorch/pytorch/pull/133272) I need to figure out how to land this piece :)~ 
- ~Skip registration of `reparametrize_as_dtype_state_dict_post_hook` for llama3~
~- Showed an example of how to do the corresponding (using mmap to prevent OOM) in `lora_finetune_single_device.py:save_checkpoint`~

#### Test plan

##### Sanity check 
Ran `tune run` command on devgpu  (with only the changes in `8B_qlora_single_device.yaml` to set seed and decrease steps per epoch)  and verified that `meta_model_0.pt` generated is the same before and after the changes in this PR with small [snippet](https://gist.github.com/mikaylagawarecki/60cf8e77f6230fcd45c62a4a7f479370)

| | Before ckpt save time (s) | After ckpt save time (s) |
|-|-|-|
| devgpu | 178s | ~200s (ranged from 190 to 220ish) |
|colab | OOM (no baseline) | 510s (ranged from 421s to 610s) |

Verified that colab does not OOM
https://colab.research.google.com/drive/1y7Az78ATauK7gkewZkcMO3cNgVWm1233?usp=sharing


##### Loss Curves
The validation was run on commit `abdbd7` which has special logic to mimic `resume_from_checkpoint` for each epoch

Config is per the changes in `recipes/configs/llama3/8B_qlora_single_device.yaml` (8 epochs with 20 steps per epoch and gradient accumulation every 2 steps) on 6cf31b6. For the reloading checkpoint case [I modified `lora_fine_tune_single_device.py:recipe_main` to mimic `resume_from_checkpoint` after each epoch](https://github.com/pytorch/torchtune/pull/1315/files#diff-734dbb110089223adfc465adb1594c2645bc025171e23c67f7b7bece857edbf0R711-R727)

Devgpu:
<img width="1456" alt="Screenshot 2024-09-05 at 10 29 09 PM" src="https://github.com/user-attachments/assets/e6fc5533-e3cc-4dae-b38a-9a69da94c935">



Colab:
<img width="1451" alt="Screenshot 2024-09-05 at 10 26 19 PM" src="https://github.com/user-attachments/assets/c8ac54aa-afff-4522-93dd-2e0536aa8b7f">



