### PR TITLE
[EZ] fix DPO distributed recipe

### DIFF
--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -620,6 +620,9 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     policy_rejected_logits,
                 ) = self.concatenated_forward(self._model, batch)
 
+                policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
+                policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
+
                 if isinstance(self._loss_fn, SimPOLoss):
                     loss, chosen_rewards, rejected_rewards = self._loss_fn(
                         policy_chosen_log_probs, policy_rejected_log_probs

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -623,6 +623,9 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
                 policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
 
+                # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
+                del policy_chosen_logits, policy_rejected_logits
+
                 if isinstance(self._loss_fn, SimPOLoss):
                     loss, chosen_rewards, rejected_rewards = self._loss_fn(
                         policy_chosen_log_probs, policy_rejected_log_probs


### PR DESCRIPTION
## Context
Some variables were left undefined, causing an error when trying to run the lora_dpo_distributed recipe on main when logging metrics. Copied the missing lines over from the single device recipe.

## Test plan
`tune run --nnodes 1 --nproc_per_node 8 lora_dpo_distributed --config llama2/7B_lora_dpo` works now