### PR TITLE
fix QAT version dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "blobfile>=2",
 
     # Miscellaneous
-    "numpy<=1.26.4", # Pin here until https://github.com/tensorflow/tensorboard/issues/6869 is addressed
+    "numpy", # Pin here until https://github.com/tensorflow/tensorboard/issues/6869 is addressed
     "tqdm",
     "omegaconf",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "omegaconf",
 
     # Quantization
-    "torchao==0.3.1",
+    "torchao",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "omegaconf",
 
     # Quantization
-    "torchao",
+    "torchao==0.4.0",
 ]
 dynamic = ["version"]
 

--- a/recipes/configs/llama2/7B_qat_full.yaml
+++ b/recipes/configs/llama2/7B_qat_full.yaml
@@ -65,7 +65,7 @@ enable_activation_checkpointing: True
 memory_efficient_fsdp_wrap: False
 
 # Reduced precision
-dtype: bf16
+dtype: fp32
 
 # Logging
 metric_logger:

--- a/recipes/configs/llama3/8B_qat_full.yaml
+++ b/recipes/configs/llama3/8B_qat_full.yaml
@@ -65,8 +65,8 @@ device: cuda
 enable_activation_checkpointing: True
 memory_efficient_fsdp_wrap: True
 
-# Reduced precision
-dtype: bf16
+# Precision
+dtype: fp32
 
 # Logging
 metric_logger:

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 # importing TORCH_VERSION_AFTER_2_3 because `Int8DynActInt4WeightQuantizer`
 # is only available after 2.3 so we have to guard the pytorch versions to decide
 # the list of supported quantizers
-from torchao.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_2, TORCH_VERSION_AFTER_2_3
 
 __all__ = [
     "get_quantizer_mode",
@@ -20,15 +20,19 @@ _quantizer_to_mode = {}
 _quantizer_mode_to_disable_fake_quant = {}
 _quantizer_mode_to_enable_fake_quant = {}
 
-
-if TORCH_VERSION_AFTER_2_3:
+# TODO: bump this after tochao releases >0.4.0
+# Until 0.4.0, this did not include the version. Eg. AFTER_2_2, does not include 2.2.
+# This should be "TORCH_VERSION_AFTER_2_3" after the fix
+# More info here: https://github.com/pytorch/ao/pull/684
+if TORCH_VERSION_AFTER_2_2:
     from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
 
     __all__.append("Int8DynActInt4WeightQuantizer")
     _quantizer_to_mode[Int8DynActInt4WeightQuantizer] = "8da4w"
 
-
-if TORCH_VERSION_AFTER_2_4:
+# TODO: see comment above
+# This should be TORCH_VERSION_AFTER_2_4
+if TORCH_VERSION_AFTER_2_3:
     from torchao.quantization.prototype.qat import (
         disable_8da4w_fake_quant,
         enable_8da4w_fake_quant,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

We updated torchtune to use torchao 0.4.0. It breaks unless user has pytorch 2.4.0.  In our scripts, we were using import guards: 

https://github.com/felipemello1/torchtune/blob/04ccbf2601653e0e2cceb75e59394df5517d26e3/torchtune/utils/quantization.py#L12

However, "TORCH_VERSION_AFTER_2_4" actually didnt include 2_4. This was fixed in torchao here: https://github.com/pytorch/ao/pull/684, but it wont be available to us until their next release.

After updating TorchAO and the import guards, another error was raised: 
```
[rank0]:   File "/home/felipemello/.conda/envs/test_ao/lib/python3.10/site-packages/torchao/quantization/prototype/qat/utils.py", line 42, in forward
[rank0]:     assert input.dtype == torch.float32
```

This is because QAT recipe now requires the model to be in float32. More context here: https://github.com/pytorch/ao/blob/0b66ff01ab6ba4094823b8cb134ab5b5a744d73a/torchao/quantization/prototype/qat/utils.py#L39

Changing the QAT recipes to have dtpye = fp32 solved it

### Changelog

- Update torchao=0.4.0
- Remove pin from Numpy (this is unrelated to this PR, but it was something we needed to do, so it made sense to test everything together https://github.com/pytorch/torchtune/issues/1344)
- Temporarily change the import guards. They MUST be updated with the next torchao release. (should I add some assertion that checks torchao__version__ <= 0.4.0?)
- QAT configs use fp32

#### Test plan
I was able to run the code below. But I did not try to compare with previous version.
```
tune run --nproc_per_node 8 qat_distributed --config llama3/8B_qat_full 
```

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/3e891145-33a8-496d-ade7-05c85cd8111d">
