### PR TITLE
Update peak memory stats to be logged in GiB

### DIFF
--- a/torchtune/utils/memory.py
+++ b/torchtune/utils/memory.py
@@ -207,9 +207,9 @@ def get_memory_stats(device: torch.device, reset_stats: bool = True) -> dict:
             f"Logging memory stats is only supported on CUDA devices, got {device}"
         )
 
-    peak_memory_active = torch.cuda.memory_stats().get("active_bytes.all.peak", 0) / 1e9
-    peak_mem_alloc = torch.cuda.max_memory_allocated(device) / 1e9
-    peak_mem_reserved = torch.cuda.max_memory_reserved(device) / 1e9
+    peak_memory_active = torch.cuda.memory_stats().get("active_bytes.all.peak", 0) / (1024 ** 3)
+    peak_mem_alloc = torch.cuda.max_memory_allocated(device) / (1024 ** 3)
+    peak_mem_reserved = torch.cuda.max_memory_reserved(device) / (1024 ** 3)
 
     if reset_stats:
         torch.cuda.reset_peak_memory_stats(device)
@@ -234,7 +234,7 @@ def log_memory_stats(stats: Dict[str, float]) -> None:
     """
     _log.info(
         "Memory stats after model init:"
-        f"\n\tGPU peak memory allocation: {stats['peak_memory_alloc']:.2f} GB"
-        f"\n\tGPU peak memory reserved: {stats['peak_memory_reserved']:.2f} GB"
-        f"\n\tGPU peak memory active: {stats['peak_memory_active']:.2f} GB"
+        f"\n\tGPU peak memory allocation: {stats['peak_memory_alloc']:.2f} GiB"
+        f"\n\tGPU peak memory reserved: {stats['peak_memory_reserved']:.2f} GiB"
+        f"\n\tGPU peak memory active: {stats['peak_memory_active']:.2f} GiB"
     )

--- a/torchtune/utils/memory.py
+++ b/torchtune/utils/memory.py
@@ -207,9 +207,11 @@ def get_memory_stats(device: torch.device, reset_stats: bool = True) -> dict:
             f"Logging memory stats is only supported on CUDA devices, got {device}"
         )
 
-    peak_memory_active = torch.cuda.memory_stats().get("active_bytes.all.peak", 0) / (1024 ** 3)
-    peak_mem_alloc = torch.cuda.max_memory_allocated(device) / (1024 ** 3)
-    peak_mem_reserved = torch.cuda.max_memory_reserved(device) / (1024 ** 3)
+    peak_memory_active = torch.cuda.memory_stats().get("active_bytes.all.peak", 0) / (
+        1024**3
+    )
+    peak_mem_alloc = torch.cuda.max_memory_allocated(device) / (1024**3)
+    peak_mem_reserved = torch.cuda.max_memory_reserved(device) / (1024**3)
 
     if reset_stats:
         torch.cuda.reset_peak_memory_stats(device)


### PR DESCRIPTION
#### Context

The difference between GB and GIB is usually pretty small and can be used interchangeably. However, this causes a strange issue when really pushing the boundaries of available memory. For example, we could report that a finetuning run has used up 83 GB of memory on an 80 GB machine. If I'm a user seeing that, I'm thinking that there's a glitch or a bug. 

If we report in GiB, we show that the user is only using ~ 77 GiB of an 80 GiB machine.

#### Changelog
* Log in GiB, not GB

#### Test plan

Check my math:
https://stackoverflow.com/questions/33837689/convert-bytes-into-gigabytes-with-javascript-math

Peak stats when starting for code-llama2 7B now:

```
GPU peak memory allocation: 13.19 GiB
GPU peak memory reserved: 13.27 GiB
GPU peak memory active: 13.19 GiB
```
