### PR TITLE
[regression test] make nightlies and stable independent from each other

### DIFF
--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -6,7 +6,7 @@ on:
     - cron:  '0 0 * * *'
 
 concurrency:
-  group: regression-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: regression-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}-${{ matrix.torch-version }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Currently when nightlies break, it also cancels stable regression tests (https://github.com/pytorch/torchtune/actions/runs/10412450496/job/28838240610)

#### Changelog
The GPT gods told me that if I add {{matrix}} to the group, then one flow failing wont affect the other.

#### Test plan
CI
