### PR TITLE
Improve training display with tps, GPU Peak Mem %, cudaMallocCache retries, and do it in color for pizzaz

### DIFF
--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -55,8 +55,9 @@ from .constants import (  # noqa
     STEPS_KEY,
     TOTAL_EPOCHS_KEY,
 )
-from .logging import get_logger
+from .logging import Color, get_logger
 from .memory import (  # noqa
+    build_gpu_memory_monitor,
     cleanup_before_training,
     create_optim_in_bwd_wrapper,
     get_memory_stats,
@@ -78,6 +79,7 @@ __all__ = [
     "get_device",
     "get_dtype",
     "get_logger",
+    "Color",
     "get_world_size_and_rank",
     "init_distributed",
     "is_distributed",

--- a/torchtune/utils/logging.py
+++ b/torchtune/utils/logging.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+from dataclasses import dataclass
 from typing import Optional
 
 
@@ -25,3 +26,29 @@ def get_logger(level: Optional[str] = None) -> logging.Logger:
         level = getattr(logging, level.upper())
         logger.setLevel(level)
     return logger
+
+
+@dataclass(frozen=True)
+class Color:
+    black = "\033[30m"
+    red = "\033[31m"
+    green = "\033[32m"
+    yellow = "\033[33m"
+    blue = "\033[34m"
+    magenta = "\033[35m"
+    cyan = "\033[36m"
+    white = "\033[37m"
+    reset = "\033[39m"
+
+
+@dataclass(frozen=True)
+class NoColor:
+    black = ""
+    red = ""
+    green = ""
+    yellow = ""
+    blue = ""
+    magenta = ""
+    cyan = ""
+    white = ""
+    reset = ""

--- a/torchtune/utils/memory.py
+++ b/torchtune/utils/memory.py
@@ -6,6 +6,7 @@
 
 import gc
 import logging
+from collections import namedtuple
 
 from typing import Any, Callable, Dict, Set, Type, Union
 
@@ -240,3 +241,79 @@ def log_memory_stats(stats: Dict[str, float]) -> None:
         f"\n\tGPU peak memory reserved: {stats['peak_memory_reserved']:.2f} GiB"
         f"\n\tGPU peak memory active: {stats['peak_memory_active']:.2f} GiB"
     )
+
+
+# named tuple for passing GPU memory stats for logging
+GPUMemStats = namedtuple(
+    "GPUMemStats",
+    [
+        "max_active_gib",
+        "max_active_pct",
+        "max_reserved_gib",
+        "max_reserved_pct",
+        "num_alloc_retries",
+        "num_ooms",
+    ],
+)
+
+
+class GPUMemoryMonitor:
+    def __init__(self, device: str = "cuda:0"):
+        self.device = torch.device(device)  # device object
+        self.device_name = torch.cuda.get_device_name(self.device)
+        self.device_index = torch.cuda.current_device()
+        self.device_capacity = torch.cuda.get_device_properties(
+            self.device
+        ).total_memory
+        self.device_capacity_gib = self._to_gib(self.device_capacity)
+
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.empty_cache()
+
+    def _to_gib(self, memory_in_bytes):
+        # NOTE: GiB (gibibyte) is 1024, vs GB is 1000
+        _gib_in_bytes = 1024 * 1024 * 1024
+        memory_in_gib = memory_in_bytes / _gib_in_bytes
+        return memory_in_gib
+
+    def _to_pct(self, memory):
+        return 100 * memory / self.device_capacity
+
+    def get_peak_stats(self):
+        cuda_info = torch.cuda.memory_stats(self.device)
+
+        max_active = cuda_info["active_bytes.all.peak"]
+        max_active_gib = self._to_gib(max_active)
+        max_active_pct = self._to_pct(max_active)
+
+        max_reserved = cuda_info["reserved_bytes.all.peak"]
+        max_reserved_gib = self._to_gib(max_reserved)
+        max_reserved_pct = self._to_pct(max_reserved)
+
+        num_retries = cuda_info["num_alloc_retries"]
+        num_ooms = cuda_info["num_ooms"]
+
+        if num_retries > 0:
+            _log.warning(f"{num_retries} CUDA memory allocation retries.")
+        if num_ooms > 0:
+            _log.warning(f"{num_ooms} CUDA OOM errors thrown.")
+
+        return max_reserved_pct, num_retries
+        # )# GPUMemStats(
+        # max_active_gib,
+        # max_active_pct,
+        # max_reserved_gib,
+        # num_ooms,
+
+    def reset_peak_stats(self):
+        torch.cuda.reset_peak_memory_stats()
+
+
+def build_gpu_memory_monitor():
+    gpu_memory_monitor = GPUMemoryMonitor("cuda")
+    _log.info(
+        f"GPU capacity: {gpu_memory_monitor.device_name} ({gpu_memory_monitor.device_index}) "
+        f"with {gpu_memory_monitor.device_capacity_gib:.2f}GiB memory"
+    )
+
+    return gpu_memory_monitor


### PR DESCRIPTION
This PR addresses a tune pain point that AWS has complained about for some time...specifically, they want to be able to quickly see a runs tps, gpu peak mem %, and cudaMallocCache retries directly on the console so they can quickly adjust their batch size and optimize throughput. 
Some of this info exists already but it's not shown on the console and is thus available only by pulling up tensorboard or similar, vs seeing it direclty on the console is much faster for optimizing a run. 

Thus:
1 - adds a GPUMemoryMonitor class that monitors mem stats and cudaMalloc retries and reports those
2 - displays GPU total memory at start
3 - integrates these into the tqdm display along with a bit of slight rounding to make things fit nicely.  Note this only changes display re: rounding, does not affect the underlying metrics sent to tensorboard, etc. 
4 - with those changes you get this:
<img width="1294" alt="Screenshot 2024-08-16 at 5 48 25 PM" src="https://github.com/user-attachments/assets/5af43d10-affe-4a9e-95f0-1c5c243312bd">

and finally to add some visual excitement..
5 - adds color class and integrates color into the console display resulting in this:
<img width="1157" alt="Screenshot 2024-08-16 at 6 05 50 PM" src="https://github.com/user-attachments/assets/dd9667cb-0f92-421f-8578-a1d941858a03">

I'm posting this PR now so that AWS can use these changes.  There's probably some discussion to be had as I see there is a couple simpler memory apis already built and maybe this should be consolidated etc. 
But happy to. discuss - in the interim will send this PR over for immediate use. 

#### Context
What is the purpose of this PR? Is it to
- [ X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](../tests/torchtune) for any new functionality
- [ ] update [docstrings](../docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
