### PR TITLE
Add system prompt

### DIFF
--- a/tests/torchtune/data/test_messages.py
+++ b/tests/torchtune/data/test_messages.py
@@ -105,6 +105,19 @@ class TestInputOutputToMessages:
         ]
         assert_dialogue_equal(actual["messages"], expected)
 
+    def test_system_prompt(self, sample):
+        transform = InputOutputToMessages(
+            column_map={"input": "maybe_input", "output": "maybe_output"},
+            system_prompt="you are a robot",
+        )
+        actual = transform(sample)
+        expected = [
+            Message(role="system", content="you are a robot", masked=True, eot=True),
+            Message(role="user", content="hello world", masked=True, eot=True),
+            Message(role="assistant", content="hello world", masked=False, eot=True),
+        ]
+        assert_dialogue_equal(actual["messages"], expected)
+
 
 class TestChosenRejectedToMessages:
     @pytest.fixture
@@ -161,6 +174,29 @@ class TestChosenRejectedToMessages:
         ]
         assert_dialogue_equal(actual["rejected"], expected_rejected)
 
+    def test_system_prompt(self, sample):
+        transform = ChosenRejectedToMessages(
+            column_map={
+                "chosen": "maybe_chosen",
+                "rejected": "maybe_rejected",
+            },
+            system_prompt="you are a robot",
+        )
+        actual = transform(sample)
+        expected_chosen = [
+            Message(role="system", content="you are a robot", masked=True, eot=True),
+            Message(role="user", content="hello world", masked=True, eot=True),
+            Message(role="assistant", content="hello world", masked=False, eot=True),
+        ]
+        assert_dialogue_equal(actual["chosen"], expected_chosen)
+
+        expected_rejected = [
+            Message(role="system", content="you are a robot", masked=True, eot=True),
+            Message(role="user", content="hello world", masked=True, eot=True),
+            Message(role="assistant", content="bye world", masked=False, eot=True),
+        ]
+        assert_dialogue_equal(actual["rejected"], expected_rejected)
+
 
 class TestShareGPTToMessages:
     samples = {
@@ -192,6 +228,19 @@ class TestShareGPTToMessages:
             converted_messages["messages"], MESSAGE_SAMPLE_TRAIN_ON_INPUT
         )
 
+    def test_system_prompt(self):
+        transform = ShareGPTToMessages(system_prompt="you are a robot")
+        converted_messages = transform(self.samples)
+        assert_dialogue_equal(
+            converted_messages["messages"],
+            [
+                Message(
+                    role="system", content="you are a robot", masked=True, eot=True
+                ),
+            ]
+            + MESSAGE_SAMPLE[1:],
+        )
+
 
 class TestJSONToMessages:
     samples = {
@@ -221,4 +270,17 @@ class TestJSONToMessages:
         converted_messages = transform(self.samples)
         assert_dialogue_equal(
             converted_messages["messages"], MESSAGE_SAMPLE_TRAIN_ON_INPUT
+        )
+
+    def test_system_prompt(self):
+        transform = JSONToMessages(system_prompt="you are a robot")
+        converted_messages = transform(self.samples)
+        assert_dialogue_equal(
+            converted_messages["messages"],
+            [
+                Message(
+                    role="system", content="you are a robot", masked=True, eot=True
+                ),
+            ]
+            + MESSAGE_SAMPLE[1:],
         )

--- a/torchtune/datasets/_grammar.py
+++ b/torchtune/datasets/_grammar.py
@@ -19,6 +19,7 @@ def grammar_dataset(
     source: str = "liweili/c4_200m",
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
+    system_prompt: Optional[str] = None,
     packed: bool = False,
     split: str = "train",
 ) -> Union[SFTDataset, PackedDataset]:
@@ -47,6 +48,8 @@ def grammar_dataset(
             :class:`~torchtune.data.InputOutputToMessages` to the new column names in the dataset. If None, use
             the default column names ``"input"`` and ``"output"``in ``liweili/c4_200m``.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
+        system_prompt (Optional[str]): if specified, prepend a system message to every sample. This can
+            serve as instructions to guide the model response. Default is None.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
@@ -63,7 +66,9 @@ def grammar_dataset(
     """
 
     message_transform = InputOutputToMessages(
-        train_on_input=train_on_input, column_map=column_map
+        train_on_input=train_on_input,
+        column_map=column_map,
+        system_prompt=system_prompt,
     )
     ds = SFTDataset(
         source=source,

--- a/torchtune/datasets/_hh_rlhf_helpful.py
+++ b/torchtune/datasets/_hh_rlhf_helpful.py
@@ -17,6 +17,7 @@ def hh_rlhf_helpful_dataset(
     source: str = "RLHFlow/HH-RLHF-Helpful-standard",
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
+    system_prompt: Optional[str] = None,
     split: str = "train",
 ) -> PreferenceDataset:
     """
@@ -35,6 +36,8 @@ def hh_rlhf_helpful_dataset(
         column_map (Optional[Dict[str, str]]): a mapping from the expected columns in the prompt template
             to the new column names in the dataset. If None, assume these are identical.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
+        system_prompt (Optional[str]): if specified, prepend a system message to every sample for both chosen
+            and rejected. This can serve as instructions to guide the model response. Default is None.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
 
@@ -43,7 +46,9 @@ def hh_rlhf_helpful_dataset(
     """
 
     message_transform = ChosenRejectedToMessages(
-        train_on_input=train_on_input, column_map=column_map
+        train_on_input=train_on_input,
+        column_map=column_map,
+        system_prompt=system_prompt,
     )
 
     return PreferenceDataset(

--- a/torchtune/datasets/_samsum.py
+++ b/torchtune/datasets/_samsum.py
@@ -19,6 +19,7 @@ def samsum_dataset(
     source: str = "Samsung/samsum",
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
+    system_prompt: Optional[str] = None,
     packed: bool = False,
     split: str = "train",
 ) -> Union[SFTDataset, PackedDataset]:
@@ -47,6 +48,8 @@ def samsum_dataset(
             :class:`~torchtune.data.InputOutputToMessages` to the new column names in the dataset. If None, use
             the default column names ``{"input": "dialogue", "output": "summary"}`` in ``Samsung/samsum``.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
+        system_prompt (Optional[str]): if specified, prepend a system message to every sample. This can
+            serve as instructions to guide the model response. Default is None.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
@@ -63,7 +66,9 @@ def samsum_dataset(
     """
     column_map = column_map or {"input": "dialogue", "output": "summary"}
     message_transform = InputOutputToMessages(
-        train_on_input=train_on_input, column_map=column_map
+        train_on_input=train_on_input,
+        column_map=column_map,
+        system_prompt=system_prompt,
     )
     ds = SFTDataset(
         source=source,

--- a/torchtune/datasets/_slimorca.py
+++ b/torchtune/datasets/_slimorca.py
@@ -19,6 +19,7 @@ def slimorca_dataset(
     source: str = "Open-Orca/SlimOrca-Dedup",
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
+    system_prompt: Optional[str] = None,
     packed: bool = False,
     split: str = "train",
 ) -> Union[SFTDataset, PackedDataset]:
@@ -44,6 +45,8 @@ def slimorca_dataset(
             :class:`~torchtune.data.ShareGPTToMessages` to the new column names in the dataset. If None, use
             the default column name ``"conversations"`` in ``Open-Orca/SlimOrca-Dedup``.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
+        system_prompt (Optional[str]): if specified, prepend a system message to every sample. This can
+            serve as instructions to guide the model response. Default is None.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
@@ -63,7 +66,9 @@ def slimorca_dataset(
     """
 
     message_transform = ShareGPTToMessages(
-        train_on_input=train_on_input, column_map=column_map
+        train_on_input=train_on_input,
+        column_map=column_map,
+        system_prompt=system_prompt,
     )
     ds = SFTDataset(
         source=source,

--- a/torchtune/datasets/_stack_exchange_paired.py
+++ b/torchtune/datasets/_stack_exchange_paired.py
@@ -46,10 +46,10 @@ class StackExchangePairedToMessages(Transform):
         self, train_on_input: bool = False, column_map: Optional[Dict[str, str]] = None
     ):
         self.train_on_input = train_on_input
-        self._column_map = column_map
+        self.column_map = column_map
 
     def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
-        column_map = self._column_map or {}
+        column_map = self.column_map or {}
         key_prompt = column_map.get("prompt", "prompt")
         key_chosen = column_map.get("chosen", "chosen")
         key_rejected = column_map.get("rejected", "rejected")


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Enable adding an optional system prompt in our built-in message transforms. Expose this parameter in our dataset builders. Any user dataset that uses our common message transforms can leverage this feature.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](../tests/torchtune) for any new functionality
- [ ] update [docstrings](../docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
