### PR TITLE
[STOPGAP] Remove public APIs for vision utils

### DIFF
--- a/docs/source/api_ref_modules.rst
+++ b/docs/source/api_ref_modules.rst
@@ -103,11 +103,6 @@ Functions used for preprocessing images.
    :nosignatures:
 
     transforms.Transform
-    transforms.get_canvas_best_fit
-    transforms.get_inscribed_size
-    transforms.resize_with_pad
-    transforms.tile_crop
-    transforms.find_supported_resolutions
     transforms.VisionCrossAttentionMask
 
 Reinforcement Learning From Human Feedback (RLHF)

--- a/tests/torchtune/modules/transforms/test_get_canvas_best_fit.py
+++ b/tests/torchtune/modules/transforms/test_get_canvas_best_fit.py
@@ -7,7 +7,10 @@
 import pytest
 import torch
 
-from torchtune.modules.transforms import find_supported_resolutions, get_canvas_best_fit
+from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (
+    find_supported_resolutions,
+    get_canvas_best_fit,
+)
 
 
 class TestUtils:

--- a/tests/torchtune/modules/transforms/test_get_inscribed_size.py
+++ b/tests/torchtune/modules/transforms/test_get_inscribed_size.py
@@ -6,7 +6,9 @@
 
 import pytest
 
-from torchtune.modules.transforms import get_inscribed_size
+from torchtune.modules.transforms.vision_utils.get_inscribed_size import (
+    get_inscribed_size,
+)
 
 
 class TestTransforms:

--- a/tests/torchtune/modules/transforms/test_resize_with_pad.py
+++ b/tests/torchtune/modules/transforms/test_resize_with_pad.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 import torchvision
 
-from torchtune.modules.transforms import resize_with_pad
+from torchtune.modules.transforms.vision_utils.resize_with_pad import resize_with_pad
 
 
 class TestTransforms:

--- a/tests/torchtune/modules/transforms/test_tile_crop.py
+++ b/tests/torchtune/modules/transforms/test_tile_crop.py
@@ -8,7 +8,7 @@ import pytest
 
 import torch
 
-from torchtune.modules.transforms import tile_crop
+from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop
 
 
 class TestTransforms:

--- a/torchtune/models/clip/_transforms.py
+++ b/torchtune/models/clip/_transforms.py
@@ -11,12 +11,11 @@ import torch
 import torchvision
 from PIL import Image
 
-from torchtune.modules.transforms import (
-    find_supported_resolutions,
+from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (
     get_canvas_best_fit,
-    resize_with_pad,
-    tile_crop,
 )
+from torchtune.modules.transforms.vision_utils.resize_with_pad import resize_with_pad
+from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop
 
 from torchvision.transforms.v2 import functional as F
 

--- a/torchtune/models/clip/_transforms.py
+++ b/torchtune/models/clip/_transforms.py
@@ -12,6 +12,7 @@ import torchvision
 from PIL import Image
 
 from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (
+    find_supported_resolutions,
     get_canvas_best_fit,
 )
 from torchtune.modules.transforms.vision_utils.resize_with_pad import resize_with_pad

--- a/torchtune/models/clip/inference/_transforms.py
+++ b/torchtune/models/clip/inference/_transforms.py
@@ -12,6 +12,7 @@ import torchvision
 from PIL import Image
 
 from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (
+    find_supported_resolutions,
     get_canvas_best_fit,
 )
 from torchtune.modules.transforms.vision_utils.get_inscribed_size import (

--- a/torchtune/models/clip/inference/_transforms.py
+++ b/torchtune/models/clip/inference/_transforms.py
@@ -11,12 +11,13 @@ import torch
 import torchvision
 from PIL import Image
 
-from torchtune.modules.transforms import (
-    find_supported_resolutions,
+from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (
     get_canvas_best_fit,
-    get_inscribed_size,
-    tile_crop,
 )
+from torchtune.modules.transforms.vision_utils.get_inscribed_size import (
+    get_inscribed_size,
+)
+from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop
 
 from torchvision.transforms.v2 import functional as F
 

--- a/torchtune/modules/transforms/__init__.py
+++ b/torchtune/modules/transforms/__init__.py
@@ -5,27 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtune.modules.transforms._transforms import Transform, VisionCrossAttentionMask
-from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (  # noqa
-    find_supported_resolutions,
-    get_canvas_best_fit,
-)
 
-from torchtune.modules.transforms.vision_utils.get_inscribed_size import (  # noqa
-    get_inscribed_size,
-)
-
-from torchtune.modules.transforms.vision_utils.resize_with_pad import (  # noqa
-    resize_with_pad,
-)
-
-from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop  # noqa
 
 __all__ = [
     "Transform",
-    "get_canvas_best_fit",
-    "get_inscribed_size",
-    "resize_with_pad",
-    "tile_crop",
-    "find_supported_resolutions",
     "VisionCrossAttentionMask",
 ]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

Related to #1352 but does not actually close it.

#### Changelog
* Remove all functions within `vision_utils` from `modules/transforms/__init__.py`
* Update all references to these functions 
* Remove functions from documentation

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](../tests/torchtune) for any new functionality
- [x] update [docstrings](../docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

In addition, I did the following test to ensure that I did not need torchvision installed in order to run basic stuff.

```
1. conda create fresh_env
2. conda activate fresh_env
3. pip install torch
4. pip install -e .
5. tune ls
# Works!
```

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
