### PR TITLE
Fix max_seq_len bug in Qwen2 tokenizer

### DIFF
--- a/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
+++ b/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -15,12 +16,13 @@ ASSETS = Path(__file__).parent.parent.parent.parent / "assets"
 
 
 class TestQwen2Tokenizer:
-    def tokenizer(self, template: bool = False):
+    def tokenizer(self, template: bool = False, max_seq_len: Optional[int] = 2048):
         return qwen2_tokenizer(
             path=str(ASSETS / "tiny_bpe_vocab.json"),
             merges_file=str(ASSETS / "tiny_bpe_merges.txt"),
             special_tokens_path=str(ASSETS / "tiny_bpe_tokenizer.json"),
             prompt_template="torchtune.data.ChatMLTemplate" if template else None,
+            max_seq_len=max_seq_len,
         )
 
     @pytest.fixture
@@ -436,3 +438,10 @@ class TestQwen2Tokenizer:
         expected_mask = [True] * 61 + [False] * 116
         assert expected_tokens == tokens
         assert expected_mask == mask
+
+    def test_tokenize_messages_gt_max_seq_len(self, messages):
+        # Super basic test to make sure max_seq_len is working properly
+        tokenizer = self.tokenizer(template=False, max_seq_len=10)
+        tokens, mask = tokenizer.tokenize_messages(messages)
+        assert len(tokens) == 10
+        assert len(mask) == 10

--- a/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
+++ b/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
@@ -16,7 +16,7 @@ ASSETS = Path(__file__).parent.parent.parent.parent / "assets"
 
 
 class TestQwen2Tokenizer:
-    def tokenizer(self, template: bool = False, max_seq_len: Optional[int] = 2048):
+    def tokenizer(self, template: bool = False, max_seq_len: Optional[int] = None):
         return qwen2_tokenizer(
             path=str(ASSETS / "tiny_bpe_vocab.json"),
             merges_file=str(ASSETS / "tiny_bpe_merges.txt"),

--- a/torchtune/models/qwen2/_tokenizer.py
+++ b/torchtune/models/qwen2/_tokenizer.py
@@ -379,8 +379,10 @@ class Qwen2Tokenizer(ModelTokenizer):
                 break
 
         # Finally, truncate if necessary
-        if self.max_seq_len:
-            tokens = truncate(tokens, self.max_seq_len, self.eos_id)
+        if self.max_seq_len and len(tokenized_messages) >= self.max_seq_len:
+            tokenized_messages = truncate(
+                tokenized_messages, self.max_seq_len, self.eos_id
+            )
             mask = truncate(mask, self.max_seq_len, True)
 
         return tokenized_messages, mask

--- a/torchtune/models/qwen2/_tokenizer.py
+++ b/torchtune/models/qwen2/_tokenizer.py
@@ -379,7 +379,7 @@ class Qwen2Tokenizer(ModelTokenizer):
                 break
 
         # Finally, truncate if necessary
-        if self.max_seq_len and len(tokenized_messages) >= self.max_seq_len:
+        if self.max_seq_len:
             tokenized_messages = truncate(
                 tokenized_messages, self.max_seq_len, self.eos_id
             )


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

There was a typo in the Qwen2 tokenizer wherein the wrong variable was being truncated at ``max_seq_len``. We likely didn't hit this bug yet b/c we weren't testing Qwen2 at long sequence lengths.

#### Changelog
* Used correct name for truncation
* Added a simple test

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](../tests/torchtune) for any new functionality
- [ ] update [docstrings](../docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [x] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
