### PR TITLE
When profile_memory, also export and save the snapshot.pickle for lora_finetune_single_device.py

### DIFF
--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -328,10 +328,11 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         log.info(f" Profiler config after instantiation: {profiler_cfg}")
 
-        self.profiler_wait_steps = profiler_cfg["wait_steps"]
-        self.profiler_warmup_steps = profiler_cfg["warmup_steps"]
-        self.profiler_active_steps = profiler_cfg["active_steps"]
-        self.profiler_profile_memory = profiler_cfg["profile_memory"]
+        self.profiler_profile_memory = profiler_cfg.get("profile_memory", False)
+        if profiler_cfg["enabled"]:
+            self.profiler_wait_steps = profiler_cfg["wait_steps"]
+            self.profiler_warmup_steps = profiler_cfg["warmup_steps"]
+            self.profiler_active_steps = profiler_cfg["active_steps"]
 
         return profiler
 
@@ -584,7 +585,12 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     ):
                         break
 
-                    if curr_epoch == 0 and self.profiler_profile_memory and idx == self.profiler_wait_steps + self.profiler_warmup_steps:
+                    # Start tracking CUDA memory for active steps for just the first epoch
+                    if (
+                        curr_epoch == 0
+                        and self.profiler_profile_memory
+                        and idx == self.profiler_wait_steps + self.profiler_warmup_steps
+                    ):
                         torch.cuda.memory._record_memory_history()
 
                     batch = {k: v.to(self._device) for k, v in batch.items()}
@@ -634,7 +640,15 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         num_tokens = 0
                         t0 = time.perf_counter()
 
-                    if curr_epoch == 0 and self.profiler_profile_memory and idx == self.profiler_wait_steps + self.profiler_warmup_steps + self.profiler_active_steps:
+                    # Stop tracking CUDA memory now that active steps are complete
+                    if (
+                        curr_epoch == 0
+                        and self.profiler_profile_memory
+                        and idx
+                        == self.profiler_wait_steps
+                        + self.profiler_warmup_steps
+                        + self.profiler_active_steps
+                    ):
                         torch.cuda.memory._record_memory_history(enabled=None)
 
                     # Step the profiler

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -328,6 +328,11 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         log.info(f" Profiler config after instantiation: {profiler_cfg}")
 
+        self.profiler_wait_steps = profiler_cfg["wait_steps"]
+        self.profiler_warmup_steps = profiler_cfg["warmup_steps"]
+        self.profiler_active_steps = profiler_cfg["active_steps"]
+        self.profiler_profile_memory = profiler_cfg["profile_memory"]
+
         return profiler
 
     def _setup_model(
@@ -579,6 +584,9 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     ):
                         break
 
+                    if curr_epoch == 0 and self.profiler_profile_memory and idx == self.profiler_wait_steps + self.profiler_warmup_steps:
+                        torch.cuda.memory._record_memory_history()
+
                     batch = {k: v.to(self._device) for k, v in batch.items()}
                     num_tokens += batch["tokens"].numel()
 
@@ -625,6 +633,9 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                         running_loss = 0
                         num_tokens = 0
                         t0 = time.perf_counter()
+
+                    if curr_epoch == 0 and self.profiler_profile_memory and idx == self.profiler_wait_steps + self.profiler_warmup_steps + self.profiler_active_steps:
+                        torch.cuda.memory._record_memory_history(enabled=None)
 
                     # Step the profiler
                     # Note we are stepping each batch, which might not include optimizer step in the trace

--- a/torchtune/utils/_profiler.py
+++ b/torchtune/utils/_profiler.py
@@ -64,7 +64,7 @@ def trace_handler(
     The following artifacts are exported:
     - chrome / tensorboard trace - viewable through tensorboard or perfetto.dev / chrome::/tracing
     - trace event table
-    - memory timeline if ``profile_memory``
+    - memory timeline and snapshot.pickle if ``profile_memory``
     - stacks if ``with_stack`` (note that ``profile_memory`` requires ``with_stack`` to be ``True``),
     viewable as a flamegraph see (https://pytorch.org/docs/stable/profiler.html#torch.profiler._KinetoProfile.export_stacks).
 
@@ -114,6 +114,8 @@ def trace_handler(
                 )
             except Exception as e:
                 log.warn(f" Failed to export memory timeline: {e}")
+
+            torch.cuda.memory._dump_snapshot(f"{curr_trace_dir}/rank{rank}_memory_snapshot.pickle")
 
     # Dump stack traces
     if prof.with_stack:

--- a/torchtune/utils/_profiler.py
+++ b/torchtune/utils/_profiler.py
@@ -115,7 +115,9 @@ def trace_handler(
             except Exception as e:
                 log.warn(f" Failed to export memory timeline: {e}")
 
-            torch.cuda.memory._dump_snapshot(f"{curr_trace_dir}/rank{rank}_memory_snapshot.pickle")
+            torch.cuda.memory._dump_snapshot(
+                f"{curr_trace_dir}/rank{rank}_memory_snapshot.pickle"
+            )
 
     # Dump stack traces
     if prof.with_stack:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* enable the snapshot.pickle to be exported when profile_memory is True.
* the above required adding attributes to self for recipes/lora_finetune_single_device.py
* needing to export the snapshot.pickle _does_ mean that it takes a little longer to export.

Previously, you only had the html from the profiler, which is not interactive:
![image](https://github.com/user-attachments/assets/bf50b6b6-e1c7-4ff7-ac04-dcd3eeb0984d)

Now, you get that in addition to:
![image](https://github.com/user-attachments/assets/44baedbe-cb6b-4698-8730-29aa000f2809)

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](../tests/torchtune) for any new functionality
- [ ] update [docstrings](../docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
