### PR TITLE
enable customize activation functions in clip vision encoder

### DIFF
--- a/torchtune/models/clip/_component_builders.py
+++ b/torchtune/models/clip/_component_builders.py
@@ -19,6 +19,7 @@ def clip_vision_encoder(
     output_cls_projection: bool = False,
     max_num_tiles: int = 4,
     in_channels: int = 3,
+    hidden_act: torch.nn.Module = torch.nn.SiLU(),
 ) -> VisionTransformer:
     """
     Builds the vision encoder associated with the clip model. This includes:
@@ -63,7 +64,7 @@ def clip_vision_encoder(
         nhead=num_heads, 
         dim_feedforward=int(mlp_ratio * embed_dim), 
         dropout=0.0, 
-        activation=torch.nn.SiLU(), 
+        activation=hidden_act, 
         layer_norm_eps=1e-5, 
         batch_first=True, 
         norm_first=True, 

--- a/torchtune/models/clip/_component_builders.py
+++ b/torchtune/models/clip/_component_builders.py
@@ -50,6 +50,7 @@ def clip_vision_encoder(
         max_num_tiles (int): The maximum number of tiles that can be processed. This is used to
             determine the size of the positional embeddings.
         in_channels (int): The number of image input channels.
+        hidden_act (torch.nn.Module): The activation function used in the transformer layers.
 
     Returns:
         A `VisionTransformer` object.

--- a/torchtune/models/clip/_component_builders.py
+++ b/torchtune/models/clip/_component_builders.py
@@ -19,7 +19,7 @@ def clip_vision_encoder(
     output_cls_projection: bool = False,
     max_num_tiles: int = 4,
     in_channels: int = 3,
-    hidden_act: torch.nn.Module = torch.nn.SiLU(),
+    intermediate_act: torch.nn.Module = torch.nn.SiLU(),
 ) -> VisionTransformer:
     """
     Builds the vision encoder associated with the clip model. This includes:
@@ -50,7 +50,7 @@ def clip_vision_encoder(
         max_num_tiles (int): The maximum number of tiles that can be processed. This is used to
             determine the size of the positional embeddings.
         in_channels (int): The number of image input channels.
-        hidden_act (torch.nn.Module): The activation function used in the transformer layers.
+        intermediate_act (torch.nn.Module): The activation function used in the intermediate layers in the transformer encoder.
 
     Returns:
         A `VisionTransformer` object.
@@ -65,7 +65,7 @@ def clip_vision_encoder(
         nhead=num_heads, 
         dim_feedforward=int(mlp_ratio * embed_dim), 
         dropout=0.0, 
-        activation=hidden_act, 
+        activation=intermediate_act, 
         layer_norm_eps=1e-5, 
         batch_first=True, 
         norm_first=True, 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?

This PR enables users to customize activation functions in clip vision encoder

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](../CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](../tests/torchtune) for any new functionality
- [x] update [docstrings](../docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [x] I have added an example to docs or docstrings;
