### PR TITLE
Remove torchao-nightly

### DIFF
--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -49,7 +49,7 @@ jobs:
           python -m pip install lm-eval==0.4.*
       - name: Install torchao nightly
         if: ${{ matrix.torch-version == 'nightly' }}
-        run: pip install --pre torchao-nightly --index-url https://download.pytorch.org/whl/nightly/cu121
+        run: pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
       - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/torchtune/modules/low_precision/_utils.py
+++ b/torchtune/modules/low_precision/_utils.py
@@ -37,9 +37,8 @@ def _get_torchao_version() -> Tuple[Optional[str], Optional[bool]]:
 
     Checks:
         1) is_fbcode, then
-        2) importlib's version(torchao-nightly) for nightlies, then
         3) torchao.__version__ (only defined for torchao >= 0.3.0), then
-        4) importlib's version(torchao) for non-nightly
+        4) importlib's version(torchao)
 
 
     If none of these work, raise an error.
@@ -47,20 +46,12 @@ def _get_torchao_version() -> Tuple[Optional[str], Optional[bool]]:
     """
     if _is_fbcode():
         return None, None
-    # Check for nightly install first
     try:
-        ao_version = version("torchao-nightly")
-        is_nightly = True
-    except PackageNotFoundError:
-        try:
-            ao_version = torchao.__version__
-            is_nightly = False
-        except AttributeError:
-            ao_version = "unknown"
-    if ao_version == "unknown":
+        ao_version = torchao.__version__
+    except AttributeError:
         try:
             ao_version = version("torchao")
-            is_nightly = False
         except Exception as e:
             raise PackageNotFoundError("Could not find torchao version") from e
+    is_nightly = "dev" in ao_version
     return ao_version, is_nightly


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

As discussed in #1355, torchao-nightly no longer exists, so replace references to this with the normal torchao nightly.

#### Test plan
EYES