### PR TITLE
force uninstall of stable torchao on nightly CI jobs

### DIFF
--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -5,6 +5,7 @@ on:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: recipe-test-nightly-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
@@ -49,6 +50,7 @@ jobs:
           python -m pip install lm-eval==0.4.*
       - name: Install torchao nightly
         if: ${{ matrix.torch-version == 'nightly' }}
+        # use force-reinstall to switch from stable ao to nightly
         run: pip install --force-reinstall --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
       - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -49,8 +49,9 @@ jobs:
           python -m pip install lm-eval==0.4.*
       - name: Install torchao nightly
         if: ${{ matrix.torch-version == 'nightly' }}
-        run: pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
-      - name: Run recipe tests with coverage
+        run: |
+          pip uninstall torchao
+          pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121      - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -49,9 +49,7 @@ jobs:
           python -m pip install lm-eval==0.4.*
       - name: Install torchao nightly
         if: ${{ matrix.torch-version == 'nightly' }}
-        run: |
-          pip uninstall torchao
-          pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
+        run: pip install --force-reinstall --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
       - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -5,7 +5,6 @@ on:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
   workflow_dispatch:
-  pull_request: # TODO: remove (just for debug)
 
 concurrency:
   group: recipe-test-nightly-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
@@ -52,7 +51,8 @@ jobs:
         if: ${{ matrix.torch-version == 'nightly' }}
         run: |
           pip uninstall torchao
-          pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121      - name: Run recipe tests with coverage
+          pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
+      - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -5,6 +5,7 @@ on:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
   workflow_dispatch:
+  pull_request: # TODO: remove (just for debug)
 
 concurrency:
   group: recipe-test-nightly-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -58,7 +58,10 @@ jobs:
           python -m pip install lm-eval==0.4.*
       - name: Install torchao nightly
         if: ${{ matrix.torch-version == 'nightly' }}
-        run: pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
+        # need to manually uninstall stable torchao before install nightly version
+        run: |
+          pip uninstall torchao
+          pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
       - name: Run regression tests with coverage
         run: pytest tests -m slow_integration_test --silence-s3-logs --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -59,9 +59,7 @@ jobs:
       - name: Install torchao nightly
         if: ${{ matrix.torch-version == 'nightly' }}
         # need to manually uninstall stable torchao before install nightly version
-        run: |
-          pip uninstall torchao
-          pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
+        run: pip install --force-reinstall --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
       - name: Run regression tests with coverage
         run: pytest tests -m slow_integration_test --silence-s3-logs --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -58,7 +58,7 @@ jobs:
           python -m pip install lm-eval==0.4.*
       - name: Install torchao nightly
         if: ${{ matrix.torch-version == 'nightly' }}
-        # need to manually uninstall stable torchao before install nightly version
+        # use force-reinstall to switch from stable ao to nightly
         run: pip install --force-reinstall --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121
       - name: Run regression tests with coverage
         run: pytest tests -m slow_integration_test --silence-s3-logs --cov=. --cov-report=xml --durations=20 -vv

--- a/tests/recipes/test_qat_distributed.py
+++ b/tests/recipes/test_qat_distributed.py
@@ -26,7 +26,6 @@ from tests.test_utils import (
     gpu_test,
     TOKENIZER_PATHS,
 )
-from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 
 class TestQATDistributedRecipe:
@@ -60,9 +59,6 @@ class TestQATDistributedRecipe:
         ],
     )
     @gpu_test(gpu_count=2)
-    @pytest.mark.skipif(
-        not TORCH_VERSION_AFTER_2_4, reason="QAT only supported for PyTorch 2.4+"
-    )
     def test_loss(self, config, model_type, ckpt_type, tmpdir, monkeypatch):
         ckpt_component = CKPT_COMPONENT_MAP[ckpt_type]
         ckpt = model_type + "_" + ckpt_type

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -6,20 +6,6 @@
 
 from typing import Callable, Optional
 
-# importing TORCH_VERSION_AFTER_2_3 because `Int8DynActInt4WeightQuantizer`
-# is only available after 2.3 so we have to guard the pytorch versions to decide
-# the list of supported quantizers
-from torchtune.modules.low_precision._utils import _get_torchao_version
-
-ao_version, is_nightly = _get_torchao_version()
-if is_nightly and ao_version >= "0.4.0.dev20240815":
-    from torchao.utils import TORCH_VERSION_AT_LEAST_2_3, TORCH_VERSION_AT_LEAST_2_4
-else:
-    from torchao.utils import (
-        TORCH_VERSION_AFTER_2_3 as TORCH_VERSION_AT_LEAST_2_3,
-        TORCH_VERSION_AFTER_2_4 as TORCH_VERSION_AT_LEAST_2_4,
-    )
-
 __all__ = [
     "get_quantizer_mode",
 ]
@@ -30,24 +16,22 @@ _quantizer_mode_to_disable_fake_quant = {}
 _quantizer_mode_to_enable_fake_quant = {}
 
 
-if TORCH_VERSION_AT_LEAST_2_3:
-    from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
+from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
 
-    __all__.append("Int8DynActInt4WeightQuantizer")
-    _quantizer_to_mode[Int8DynActInt4WeightQuantizer] = "8da4w"
+__all__.append("Int8DynActInt4WeightQuantizer")
+_quantizer_to_mode[Int8DynActInt4WeightQuantizer] = "8da4w"
 
 
-if TORCH_VERSION_AT_LEAST_2_4:
-    from torchao.quantization.prototype.qat import (
-        disable_8da4w_fake_quant,
-        enable_8da4w_fake_quant,
-        Int8DynActInt4WeightQATQuantizer,
-    )
+from torchao.quantization.prototype.qat import (
+    disable_8da4w_fake_quant,
+    enable_8da4w_fake_quant,
+    Int8DynActInt4WeightQATQuantizer,
+)
 
-    __all__.append("Int8DynActInt4WeightQATQuantizer")
-    _quantizer_to_mode[Int8DynActInt4WeightQATQuantizer] = "8da4w-qat"
-    _quantizer_mode_to_disable_fake_quant["8da4w-qat"] = disable_8da4w_fake_quant
-    _quantizer_mode_to_enable_fake_quant["8da4w-qat"] = enable_8da4w_fake_quant
+__all__.append("Int8DynActInt4WeightQATQuantizer")
+_quantizer_to_mode[Int8DynActInt4WeightQATQuantizer] = "8da4w-qat"
+_quantizer_mode_to_disable_fake_quant["8da4w-qat"] = disable_8da4w_fake_quant
+_quantizer_mode_to_enable_fake_quant["8da4w-qat"] = enable_8da4w_fake_quant
 
 
 def get_quantizer_mode(quantizer: Optional[Callable]) -> Optional[str]:

--- a/torchtune/utils/quantization.py
+++ b/torchtune/utils/quantization.py
@@ -9,7 +9,16 @@ from typing import Callable, Optional
 # importing TORCH_VERSION_AFTER_2_3 because `Int8DynActInt4WeightQuantizer`
 # is only available after 2.3 so we have to guard the pytorch versions to decide
 # the list of supported quantizers
-from torchao.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4
+from torchtune.modules.low_precision._utils import _get_torchao_version
+
+ao_version, is_nightly = _get_torchao_version()
+if is_nightly and ao_version >= "0.4.0.dev20240815":
+    from torchao.utils import TORCH_VERSION_AT_LEAST_2_3, TORCH_VERSION_AT_LEAST_2_4
+else:
+    from torchao.utils import (
+        TORCH_VERSION_AFTER_2_3 as TORCH_VERSION_AT_LEAST_2_3,
+        TORCH_VERSION_AFTER_2_4 as TORCH_VERSION_AT_LEAST_2_4,
+    )
 
 __all__ = [
     "get_quantizer_mode",
@@ -21,14 +30,14 @@ _quantizer_mode_to_disable_fake_quant = {}
 _quantizer_mode_to_enable_fake_quant = {}
 
 
-if TORCH_VERSION_AFTER_2_3:
+if TORCH_VERSION_AT_LEAST_2_3:
     from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
 
     __all__.append("Int8DynActInt4WeightQuantizer")
     _quantizer_to_mode[Int8DynActInt4WeightQuantizer] = "8da4w"
 
 
-if TORCH_VERSION_AFTER_2_4:
+if TORCH_VERSION_AT_LEAST_2_4:
     from torchao.quantization.prototype.qat import (
         disable_8da4w_fake_quant,
         enable_8da4w_fake_quant,


### PR DESCRIPTION
Right now our install commands always install torchao==0.3.1 regardless of whether we install PyTorch stable or nightly. 

As a result, our CI is (and has been) red: there is a change in core nightlies that breaks ao 0.3.1. 

I claim we should actually just remove ao from our pyproject.toml to give the flexibility to either (a) install a pinned version when using stable PyTorch, or (b) install ao nightlies when using PyTorch nightlies. This might be a bit controversial though, so until then.. 

This PR adds a hack to force uninstall torchao in our failing CI jobs so that nightly torchao can be installed properly. This should make our CI green again.

Test plan: I hacked in a trigger on PRs for the nightly recipe test workflow, so that signal should be green if this works. Will attach a screenshot here once it finishes