### PR TITLE
Added filter_fn to text_completion_dataset v1.0

### DIFF
--- a/torchtune/datasets/_text_completion.py
+++ b/torchtune/datasets/_text_completion.py
@@ -33,6 +33,9 @@ class TextCompletionDataset(Dataset):
             Default is None, disabling truncation. We recommend setting this to the highest you can fit in memory
             and is supported by the model. For example, llama2-7B supports up to 4096 for sequence length.
         add_eos (bool): Whether to add an EOS token to the end of the sequence. Default is True.
+        filter_fn (Optional[Callable]): callable used to filter the dataset prior to any pre-processing. See
+            the Hugging Face `docs <https://huggingface.co/docs/datasets/v2.20.0/process#select-and-filter>`_ for more
+            details.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``,
             such as ``data_files`` or ``split``.
     """

--- a/torchtune/datasets/_text_completion.py
+++ b/torchtune/datasets/_text_completion.py
@@ -45,6 +45,7 @@ class TextCompletionDataset(Dataset):
         max_seq_len: Optional[int] = None,
         add_eos: bool = True,
         custom_filter: bool=False,
+        skip_filter: bool = False,
         filter_fn: Optional[Callable] = None,
         **load_dataset_kwargs: Dict[str, Any],
     ) -> None:
@@ -59,7 +60,10 @@ class TextCompletionDataset(Dataset):
             return "\n".join([line for line in text.splitlines() if line.strip()])
         
         # Set the filter function
-        self.filter_fn=filter_fn if custom_filter else default_filter
+        if not skip_filter:
+            self.filter_fn=filter_fn if custom_filter else default_filter
+        else:
+            self.filter_fn=None
 
     def __len__(self):
         return len(self._data)
@@ -70,7 +74,7 @@ class TextCompletionDataset(Dataset):
 
     def _prepare_sample(self, sample: Mapping[str, Any]) -> Dict[str, List[int]]:
         prompt = sample[self._column]
-        
+
         # Apply the filter function to the text data
         if self.filter_fn:
             prompt = self.filter_fn(prompt)
@@ -96,6 +100,7 @@ def text_completion_dataset(
     packed: bool = False,
     split_across_pack: bool = True,
     custom_filter=False,
+    skip_filter: bool = False,
     filter_fn: Optional[Callable] = None,
     **load_dataset_kwargs: Dict[str, Any],
 ) -> Union[TextCompletionDataset, PackedDataset]:

--- a/torchtune/datasets/_text_completion.py
+++ b/torchtune/datasets/_text_completion.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Mapping, Optional, Union, Callable
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 from datasets import load_dataset
 from torch.utils.data import Dataset
@@ -54,7 +54,7 @@ class TextCompletionDataset(Dataset):
         self.add_eos = add_eos
 
         if filter_fn:
-            self._data=self._data.filter(filter_fn)
+            self._data = self._data.filter(filter_fn)
 
     def __len__(self):
         return len(self._data)

--- a/torchtune/datasets/_text_completion.py
+++ b/torchtune/datasets/_text_completion.py
@@ -119,6 +119,9 @@ def text_completion_dataset(
             For pre-training, typically this is set to True for general text completion. For
             fine-tuning, typically this is set to False to avoid truncating sentences in instruct
             tuning. This argument is ignored if ``packed=False``. Default is True.
+        filter_fn (Optional[Callable]): callable used to filter the dataset prior to any pre-processing. See
+            the Hugging Face `docs <https://huggingface.co/docs/datasets/v2.20.0/process#select-and-filter>`_ for more
+            details.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Examples:

--- a/torchtune/datasets/_text_completion.py
+++ b/torchtune/datasets/_text_completion.py
@@ -56,7 +56,7 @@ class TextCompletionDataset(Dataset):
         self._column = column
         self.add_eos = add_eos
 
-        if filter_fn:
+        if filter_fn is not None:
             self._data = self._data.filter(filter_fn)
 
     def __len__(self):


### PR DESCRIPTION
Towards #1396 

I have made changes to include a filter function to remove empty lines from raw text before tokenization, similar to the implementation in `_sft.py`.

The updates involve adding two new parameters to the TextCompletionDataset class:

custom_filter: bool = False
filter_fn: Optional[Callable] = None
These additions address the need for a filter function to remove empty lines, thereby saving memory before tokenization.

Usage:

If custom_filter is set to True, users can provide their own filter_fn.
If custom_filter is False, the default filter function (default_filter) will automatically remove empty lines from raw text.
The filter_fn is applied in the _prepare_sample method before tokenization.

Addition of that flag adds a lot more flexibility because personally, I’ve often encountered situations where internal filtration was necessary, but there were also cases where I needed to adjust the raw corpus according to specific requirements.

If the additional flag custom_filter is adding unnecessary complexity and you feel its unwanted let me know i will remove it and update it in the PR with a new commit!

@RdoubleA kindly review and advise!



.

