### PR TITLE
Enable skipping of kv cache setup for eval recipe

### DIFF
--- a/recipes/configs/eleuther_evaluation.yaml
+++ b/recipes/configs/eleuther_evaluation.yaml
@@ -32,6 +32,8 @@ tasks: ["truthfulqa_mc2"]
 limit: null
 max_seq_length: 4096
 batch_size: 8
+# It is recommended to set enable_kv_cache=False for long-context models like Llama3.1
+enable_kv_cache: True
 
 # Quantization specific args
 quantizer: null

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -48,6 +48,7 @@ class _EvalWrapper(HFLM):
         max_seq_length (int): The maximum sequence length to use.
         batch_size (int): The batch size per GPU to use.
         dtype (torch.dtype): dtype for the model caches during generation.
+        enable_kv_cache (bool): Whether to enable KV cache for generation.
     """
 
     def __init__(
@@ -59,6 +60,7 @@ class _EvalWrapper(HFLM):
         max_seq_length: int = 4096,
         batch_size: int = 8,
         dtype: torch.dtype = torch.float32,
+        enable_kv_cache: bool = True,
     ):
         super().__init__(pretrained="gpt2", device=str(device))
         self._model = model
@@ -66,6 +68,7 @@ class _EvalWrapper(HFLM):
         self._max_seq_length = max_seq_length
         self._batch_size = batch_size
         self._dtype = dtype
+        self._enable_kv_cache = enable_kv_cache
 
     @property
     def model(self):
@@ -90,6 +93,10 @@ class _EvalWrapper(HFLM):
     @property
     def device(self):
         return self._device
+
+    @property
+    def enable_kv_cache(self):
+        return self._enable_kv_cache
 
     def tok_encode(self, text: str, **kwargs) -> List[int]:
         # Note on add_bos flag: setting to False as this gives better results, for example
@@ -140,8 +147,9 @@ class _EvalWrapper(HFLM):
         # Technically this is not necessary, but it's a good way to ensure that
         # the caches won't error on a different batch size. In addition, caches
         # are not needed for a regular model call, so we just setup here
-        with context.device:
-            self._model.setup_caches(batch_size=curr_batch_size, dtype=self._dtype)
+        if self.enable_kv_cache:
+            with context.device:
+                self._model.setup_caches(batch_size=curr_batch_size, dtype=self._dtype)
 
         temperature = generation_kwargs.get("temperature", 0.0)
         do_sample = generation_kwargs.get("do_sample", False)
@@ -193,6 +201,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
         self._tasks = list(self._cfg.tasks)
         self._quantizer = config.instantiate(self._cfg.quantizer)
         self._quantization_mode = utils.get_quantizer_mode(self._quantizer)
+        self._enable_kv_cache = self._cfg.get("enable_kv_cache", True)
 
         utils.set_seed(seed=self._cfg.seed)
 
@@ -246,6 +255,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
             max_seq_length=self._cfg.max_seq_length,
             batch_size=self._cfg.batch_size,
             dtype=self._dtype,
+            enable_kv_cache=self._enable_kv_cache,
         )
 
         # Task initialization API changed between v0.4.1 and 0.4.2


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
#1428 

#### Changelog
What are the changes made in this PR?
* Introduces a configuration `enable_kv_cache` similar to generate recipes

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [X] run recipe tests via `pytest tests -m integration_test`
- [X] manually run any new or modified recipes with sufficient proof of correctness
- [X] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [X] I did not change any public API;
- [X] I have added an example to docs or docstrings;

Old behavior:
```
tune run eleuther_eval --config eleuther_evaluation.yaml limit=1 enable_kv_cache=True
```
Log:
```
INFO:torchtune.utils.logging:Running EleutherEvalRecipe with resolved config:

batch_size: 1
checkpointer:
  _component_: torchtune.utils.FullModelHFCheckpointer
  checkpoint_dir: /home/mreso//.cache/huggingface/hub/models--meta-llama--Meta-Llama-3.1-8B/snapshots/48d6d0fc4e02fb1269b36940650a1b7233035cbb/
  checkpoint_files:
  - model-00001-of-00004.safetensors
  - model-00002-of-00004.safetensors
  - model-00003-of-00004.safetensors
  - model-00004-of-00004.safetensors
  model_type: LLAMA3
  output_dir: Llama-3-8b-hf-output
device: cuda
dtype: bf16
enable_kv_cache: true
limit: 1
max_seq_length: 4096
model:
  _component_: torchtune.models.llama3_1.llama3_1_8b
quantizer: null
seed: 1234
tasks:
- scrolls_qmsum
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  path: /home/mreso//.cache/huggingface/hub/models--meta-llama--Meta-Llama-3.1-8B/snapshots/48d6d0fc4e02fb1269b36940650a1b7233035cbb/original/tokenizer.model

DEBUG:torchtune.utils.logging:Setting manual seed to local seed 1234. Local seed is seed + rank = 1234 + 0
INFO:torchtune.utils.logging:Model is initialized with precision torch.bfloat16.
INFO:torchtune.utils.logging:Tokenizer is initialized from file.
/home/mreso/.conda/envs/tune/lib/python3.10/site-packages/lm_eval/tasks/scrolls/task.py:122: FutureWarning: load_metric is deprecated and will be removed in the next major version of datasets. Use 'evaluate.load' instead, from the new library 🤗 Evaluate: https://huggingface.co/docs/evaluate
  self.metric = load_metric(_download_metric(), config_name=self.DATASET_NAME)
INFO:torchtune.utils.logging:Running evaluation on ['scrolls_qmsum'] tasks.
INFO:lm-eval:Building contexts for None on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 8559.80it/s]
INFO:lm-eval:Running generate_until requests
Running generate_until requests:   0%|                                                                                                                                                                                                                                                                                                              | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/mreso/.conda/envs/tune/bin/tune", line 8, in <module>
    sys.exit(main())
  File "/home/mreso/torchtune/torchtune/_cli/tune.py", line 49, in main
    parser.run(args)
  File "/home/mreso/torchtune/torchtune/_cli/tune.py", line 43, in run
    args.func(args)
  File "/home/mreso/torchtune/torchtune/_cli/run.py", line 179, in _run_cmd
    self._run_single_device(args)
  File "/home/mreso/torchtune/torchtune/_cli/run.py", line 93, in _run_single_device
    runpy.run_path(str(args.recipe), run_name="__main__")
  File "/home/mreso/.conda/envs/tune/lib/python3.10/runpy.py", line 289, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/mreso/.conda/envs/tune/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/mreso/.conda/envs/tune/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/mreso/torchtune/recipes/eleuther_eval.py", line 293, in <module>
    sys.exit(recipe_main())
  File "/home/mreso/torchtune/torchtune/config/_parse.py", line 50, in wrapper
    sys.exit(recipe_main(conf))
  File "/home/mreso/torchtune/recipes/eleuther_eval.py", line 289, in recipe_main
    recipe.evaluate()
  File "/home/mreso/.conda/envs/tune/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/home/mreso/torchtune/recipes/eleuther_eval.py", line 271, in evaluate
    output = evaluate(
  File "/home/mreso/.conda/envs/tune/lib/python3.10/site-packages/lm_eval/utils.py", line 395, in _wrapper
    return fn(*args, **kwargs)
  File "/home/mreso/.conda/envs/tune/lib/python3.10/site-packages/lm_eval/evaluator.py", line 449, in evaluate
    resps = getattr(lm, reqtype)(cloned_reqs)
  File "/home/mreso/.conda/envs/tune/lib/python3.10/site-packages/lm_eval/models/huggingface.py", line 1250, in generate_until
    cont = self._model_generate(
  File "/home/mreso/torchtune/recipes/eleuther_eval.py", line 152, in _model_generate
    self._model.setup_caches(batch_size=curr_batch_size, dtype=self._dtype)
  File "/home/mreso/torchtune/torchtune/modules/transformer.py", line 350, in setup_caches
    layer.setup_cache(batch_size, dtype)
  File "/home/mreso/torchtune/torchtune/modules/transformer.py", line 53, in setup_cache
    self.attn.setup_cache(batch_size, dtype)
  File "/home/mreso/torchtune/torchtune/modules/attention.py", line 153, in setup_cache
    self.kv_cache = KVCache(
  File "/home/mreso/torchtune/torchtune/modules/kv_cache.py", line 41, in __init__
    "v_cache", torch.zeros(cache_shape, dtype=dtype), persistent=False
  File "/home/mreso/.conda/envs/tune/lib/python3.10/site-packages/torch/utils/_device.py", line 79, in __torch_function__
    return func(*args, **kwargs)
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1024.00 MiB. GPU 0 has a total capacity of 79.15 GiB of which 597.69 MiB is free. Including non-PyTorch memory, this process has 78.57 GiB memory in use. Of the allocated memory 77.96 GiB is allocated by PyTorch, and 129.09 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
Running generate_until requests:   0%|                                                                                                                                                                                                                                                                                                              | 0/1 [00:00<?, ?it/s]
```

Use new config flag:
```
tune run eleuther_eval --config eleuther_evaluation.yaml limit=1 enable_kv_cache=False
```
Log:
```
INFO:torchtune.utils.logging:Running EleutherEvalRecipe with resolved config:

batch_size: 1
checkpointer:
  _component_: torchtune.utils.FullModelHFCheckpointer
  checkpoint_dir: /home/mreso//.cache/huggingface/hub/models--meta-llama--Meta-Llama-3.1-8B/snapshots/48d6d0fc4e02fb1269b36940650a1b7233035cbb/
  checkpoint_files:
  - model-00001-of-00004.safetensors
  - model-00002-of-00004.safetensors
  - model-00003-of-00004.safetensors
  - model-00004-of-00004.safetensors
  model_type: LLAMA3
  output_dir: Llama-3-8b-hf-output
device: cuda
dtype: bf16
enable_kv_cache: false
limit: 1
max_seq_length: 4096
model:
  _component_: torchtune.models.llama3_1.llama3_1_8b
quantizer: null
seed: 1234
tasks:
- scrolls_qmsum
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  path: /home/mreso//.cache/huggingface/hub/models--meta-llama--Meta-Llama-3.1-8B/snapshots/48d6d0fc4e02fb1269b36940650a1b7233035cbb/original/tokenizer.model

DEBUG:torchtune.utils.logging:Setting manual seed to local seed 1234. Local seed is seed + rank = 1234 + 0
INFO:torchtune.utils.logging:Model is initialized with precision torch.bfloat16.
INFO:torchtune.utils.logging:Tokenizer is initialized from file.
/home/mreso/.conda/envs/tune/lib/python3.10/site-packages/lm_eval/tasks/scrolls/task.py:122: FutureWarning: load_metric is deprecated and will be removed in the next major version of datasets. Use 'evaluate.load' instead, from the new library 🤗 Evaluate: https://huggingface.co/docs/evaluate
  self.metric = load_metric(_download_metric(), config_name=self.DATASET_NAME)
INFO:torchtune.utils.logging:Running evaluation on ['scrolls_qmsum'] tasks.
INFO:lm-eval:Building contexts for None on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 8128.50it/s]
INFO:lm-eval:Running generate_until requests
Running generate_until requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [14:45<00:00, 885.32s/it]
INFO:torchtune.utils.logging:Eval completed in 931.70 seconds.
|    Tasks    |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|-------------|------:|------|------|------|---|-----:|---|------|
|scrolls_qmsum|      2|none  |None  |rouge1|↑  |5.7554|±  |N/A   |
|             |       |none  |None  |rouge2|↑  |0.7246|±  |N/A   |
|             |       |none  |None  |rougeL|↑  |5.0360|±  |N/A   |
```
