### PR TITLE
Cast tags parameter from ListConfig to list for CometLogger

### DIFF
--- a/torchtune/utils/metric_logging.py
+++ b/torchtune/utils/metric_logging.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 from numpy import ndarray
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 from torch import Tensor
 
 from torchtune.utils import get_logger
@@ -395,6 +395,10 @@ class CometLogger(MetricLoggerInterface):
         self.experiment = None
 
         if self.rank == 0:
+            # Cast tags extracted from YAML from ListConfig to list
+            if isinstance(tags, ListConfig):
+                tags = list(tags)
+                
             self.experiment = comet_ml.start(
                 api_key=api_key,
                 workspace=workspace,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

When we specify "tags" in configs, the list is passed into CometLogger as a ListConfig type. 

Example YAML:
`metric_logger:
  _component_: torchtune.utils.metric_logging.CometLogger
  project: ${project_name}
  experiment_name: ${xp_name}
  tags: [
    lora, 
    llama2_7B, 
    text_completion, 
    distributed,
    memory_profiling
  ]`

comet_ml.ExperimentConfig expects the tags to be a normal python list and throws the following error right now:
```
COMET ERROR: Experiment.add_tags: parameter 'tags' must be of type(s) 'list' but 'ListConfig' was given
COMET WARNING: Failed to add tag(s) ['lora', 'llama2_7B', 'text_completion', 'distributed', 'memory_profiling'] to the experiment
```

#### Changelog
- Check if "tags" is of type ListConfig, cast to list if it is before passing to comet_ml

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

I installed a local version of torchtune with this fix and tags are now getting created for my experiments.
![image](https://github.com/user-attachments/assets/e9119b18-6aa6-432d-a11a-f13cd227c3e1)

Let me know if I need to create a publicly visible comet project of the runs.

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [x] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
