### PR TITLE
Reduce compile time for single-device and multi-device recipes

### DIFF
--- a/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
@@ -15,46 +15,64 @@
 
 # Model Arguments
 model:
-  _component_: torchtune.models.llama2.qlora_llama2_70b
+  _component_: torchtune.models.llama3.qlora_llama3_70b
   lora_attn_modules: ['q_proj', 'v_proj', 'k_proj', 'output_proj']
   apply_lora_to_mlp: True
   apply_lora_to_output: False
   lora_rank: 16
-  lora_alpha: 32
+  lora_alpha: 16
+  # lora_dropout: 0.0
+  # max_seq_len: 2048
 
 tokenizer:
-  _component_: torchtune.models.llama2.llama2_tokenizer
-  path: /tmp/Llama-2-70b-hf/tokenizer.model
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3-70B-Instruct/original/tokenizer.model
+  max_seq_len: 2048
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir:  /tmp/Llama-2-70b-hf
+  checkpoint_dir:  /tmp/Meta-Llama-3-70B-Instruct
   checkpoint_files: [
-    pytorch_model-00001-of-00015.bin,
-    pytorch_model-00002-of-00015.bin,
-    pytorch_model-00003-of-00015.bin,
-    pytorch_model-00004-of-00015.bin,
-    pytorch_model-00005-of-00015.bin,
-    pytorch_model-00006-of-00015.bin,
-    pytorch_model-00007-of-00015.bin,
-    pytorch_model-00008-of-00015.bin,
-    pytorch_model-00009-of-00015.bin,
-    pytorch_model-00010-of-00015.bin,
-    pytorch_model-00011-of-00015.bin,
-    pytorch_model-00012-of-00015.bin,
-    pytorch_model-00013-of-00015.bin,
-    pytorch_model-00014-of-00015.bin,
-    pytorch_model-00015-of-00015.bin,
+    model-00001-of-00030.safetensors,
+    model-00002-of-00030.safetensors,
+    model-00003-of-00030.safetensors,
+    model-00004-of-00030.safetensors,
+    model-00005-of-00030.safetensors,
+    model-00006-of-00030.safetensors,
+    model-00007-of-00030.safetensors,
+    model-00008-of-00030.safetensors,
+    model-00009-of-00030.safetensors,
+    model-00010-of-00030.safetensors,
+    model-00011-of-00030.safetensors,
+    model-00012-of-00030.safetensors,
+    model-00013-of-00030.safetensors,
+    model-00014-of-00030.safetensors,
+    model-00015-of-00030.safetensors,
+    model-00016-of-00030.safetensors,
+    model-00017-of-00030.safetensors,
+    model-00018-of-00030.safetensors,
+    model-00019-of-00030.safetensors,
+    model-00020-of-00030.safetensors,
+    model-00021-of-00030.safetensors,
+    model-00022-of-00030.safetensors,
+    model-00023-of-00030.safetensors,
+    model-00024-of-00030.safetensors,
+    model-00025-of-00030.safetensors,
+    model-00026-of-00030.safetensors,
+    model-00027-of-00030.safetensors,
+    model-00028-of-00030.safetensors,
+    model-00029-of-00030.safetensors,
+    model-00030-of-00030.safetensors,
   ]
   recipe_checkpoint: null
-  output_dir: /tmp/Llama-2-70b-hf
-  model_type: LLAMA2
+  output_dir: /tmp/Meta-Llama-3-70B-Instruct
+  model_type: LLAMA3
 resume_from_checkpoint: False
 save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:
-  _component_: torchtune.datasets.alpaca_dataset
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
   train_on_input: True
 seed: null
 shuffle: True
@@ -78,7 +96,7 @@ fsdp:
 # Training
 epochs: 1
 max_steps_per_epoch: null
-gradient_accumulation_steps: 1
+gradient_accumulation_steps: 4
 compile: False
 
 # Logging

--- a/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
+++ b/recipes/configs/dev/llama2/70B_qlora_fsdp2.yaml
@@ -15,64 +15,46 @@
 
 # Model Arguments
 model:
-  _component_: torchtune.models.llama3.qlora_llama3_70b
+  _component_: torchtune.models.llama2.qlora_llama2_70b
   lora_attn_modules: ['q_proj', 'v_proj', 'k_proj', 'output_proj']
   apply_lora_to_mlp: True
   apply_lora_to_output: False
   lora_rank: 16
-  lora_alpha: 16
-  # lora_dropout: 0.0
-  # max_seq_len: 2048
+  lora_alpha: 32
 
 tokenizer:
-  _component_: torchtune.models.llama3.llama3_tokenizer
-  path: /tmp/Meta-Llama-3-70B-Instruct/original/tokenizer.model
-  max_seq_len: 2048
+  _component_: torchtune.models.llama2.llama2_tokenizer
+  path: /tmp/Llama-2-70b-hf/tokenizer.model
 
 checkpointer:
   _component_: torchtune.utils.FullModelHFCheckpointer
-  checkpoint_dir:  /tmp/Meta-Llama-3-70B-Instruct
+  checkpoint_dir:  /tmp/Llama-2-70b-hf
   checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
+    pytorch_model-00001-of-00015.bin,
+    pytorch_model-00002-of-00015.bin,
+    pytorch_model-00003-of-00015.bin,
+    pytorch_model-00004-of-00015.bin,
+    pytorch_model-00005-of-00015.bin,
+    pytorch_model-00006-of-00015.bin,
+    pytorch_model-00007-of-00015.bin,
+    pytorch_model-00008-of-00015.bin,
+    pytorch_model-00009-of-00015.bin,
+    pytorch_model-00010-of-00015.bin,
+    pytorch_model-00011-of-00015.bin,
+    pytorch_model-00012-of-00015.bin,
+    pytorch_model-00013-of-00015.bin,
+    pytorch_model-00014-of-00015.bin,
+    pytorch_model-00015-of-00015.bin,
   ]
   recipe_checkpoint: null
-  output_dir: /tmp/Meta-Llama-3-70B-Instruct
-  model_type: LLAMA3
+  output_dir: /tmp/Llama-2-70b-hf
+  model_type: LLAMA2
 resume_from_checkpoint: False
 save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:
-  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  _component_: torchtune.datasets.alpaca_dataset
   train_on_input: True
 seed: null
 shuffle: True
@@ -96,7 +78,7 @@ fsdp:
 # Training
 epochs: 1
 max_steps_per_epoch: null
-gradient_accumulation_steps: 4
+gradient_accumulation_steps: 1
 compile: False
 
 # Logging

--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -640,6 +640,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                         }
                         if self._log_peak_memory_stats:
                             log_dict.update(utils.get_memory_stats(device=self._device))
+                            log.warn(f"Memory stats: {utils.get_memory_stats(device=self._device)}")
                         self._metric_logger.log_dict(
                             log_dict,
                             step=self.global_step,

--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -325,8 +325,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # iterating from lowerer modules to higher
         # eg grouping lora adapters before transformer block
         for m in reversed(list(model.modules())):
-            # if isinstance(m, nn.Linear) and m.weight.requires_grad:
-            #     fully_shard(m, **fsdp_kwargs)
             # TransformerSelfAttentionLayer is wrapped by CheckpointWrapper
             # when enable_activation_checkpointing
             if enable_activation_checkpointing:
@@ -640,7 +638,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                         }
                         if self._log_peak_memory_stats:
                             log_dict.update(utils.get_memory_stats(device=self._device))
-                            log.warn(f"Memory stats: {utils.get_memory_stats(device=self._device)}")
                         self._metric_logger.log_dict(
                             log_dict,
                             step=self.global_step,

--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -601,6 +601,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 logits = logits[..., :-1, :].contiguous()
                 labels = labels[..., 1:].contiguous()
                 logits = logits.transpose(1, 2)
+                torch._dynamo.mark_dynamic(logits, 2)
+                torch._dynamo.mark_dynamic(labels, 1)
                 # Compute loss
                 loss = self._loss_fn(logits, labels)
                 # free logits otherwise it peaks backward memory

--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -325,8 +325,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # iterating from lowerer modules to higher
         # eg grouping lora adapters before transformer block
         for m in reversed(list(model.modules())):
-            if isinstance(m, nn.Linear) and m.weight.requires_grad:
-                fully_shard(m, **fsdp_kwargs)
+            # if isinstance(m, nn.Linear) and m.weight.requires_grad:
+            #     fully_shard(m, **fsdp_kwargs)
             # TransformerSelfAttentionLayer is wrapped by CheckpointWrapper
             # when enable_activation_checkpointing
             if enable_activation_checkpointing:

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -490,6 +490,8 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         labels = labels[..., 1:].contiguous()
         logits = logits.transpose(1, 2)
         # Compute loss
+        torch._dynamo.mark_dynamic(logits, 2)
+        torch._dynamo.mark_dynamic(labels, 1)
         loss = self._loss_fn(logits, labels)
         # free logits otherwise it peaks backward memory
         del logits

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -554,6 +554,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         labels = labels[..., 1:].contiguous()
         logits = logits.transpose(1, 2)
         # Compute loss
+        torch._dynamo.mark_dynamic(logits, 2)
+        torch._dynamo.mark_dynamic(labels, 1)
         loss = self._loss_fn(logits, labels)
         # free logits otherwise it peaks backward memory
         del logits

--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -449,6 +449,7 @@ class TransformerDecoder(nn.Module):
             if i in self.output_hidden_states:
                 hidden.append(h)
             # shape: [b, s, d]
+            torch._dynamo.mark_dynamic(h, 1)
             h = layer(
                 h,
                 mask=mask,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (improve compile time)

Improvements in compile time (on my A100 machine):
Llama3 8B QLoRA single-device: 83s -> 47s (**-43%**)
Llama3 8B full-finetune single-device: 29s -> 20s (**-31%**)
Llama3 70B QLoRA FSDP2: 104s -> 62s (**-40%**)


#### Changelog
- No nested FSDP wrapping for LoRALinear, to reduce some recompiles.
- mark_dynamic for each layer's input `h`, to avoid dynamic sequence length induced recompiles.
- mark_dynamic for loss_fn inputs (`logits` and `labels`), to avoid dynamic sequence length induced recompiles.

#### Test plan

TODO (mentioned by Evan):
- we have CI for our recipes to make sure loss values don't change, we could add something like this to the recipe test: https://fburl.com/pusfwz1n, since we don't have it for our FSDP2 recipe yet
- How about just a stripped-down version of my test from https://github.com/pytorch/torchtune/pull/1419? Basically run for 1-2 models and show that memory and perf look good; I guess you already have compile time covered. Just paste in the memory and toks/sec into the PR desc.

Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
