### PR TITLE
Make new_system_prompt of InputOutputToMessages configurable in instruct_dataset builder

### DIFF
--- a/tests/torchtune/datasets/test_instruct_dataset.py
+++ b/tests/torchtune/datasets/test_instruct_dataset.py
@@ -62,15 +62,17 @@ class TestInstructDataset:
                 assert label == expected_labels[i]
 
         expected_tokenized_prompts = [
-            [0, 4, 4, 2, 2, 2, 7, 2, 2, 5, 2, 2, 6, -1],
-            [0, 2, 2, 8, 2, 15, 8, 3, 15, 3, 4, 9, 3, 15, -1],
+            [0, 6, 4, 6, 4, 4, 2, 2, 2, 7, 2, 2, 5, 2, 2, 6, -1],
+            [0, 6, 4, 6, 2, 2, 8, 2, 15, 8, 3, 15, 3, 4, 9, 3, 15, -1],
         ]
-        prompt_lengths = (7, 6)
+        prompt_lengths = (10, 9)
         expected_labels = [
             [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[0] + [2, 2, 5, 2, 2, 6, -1],
             [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[1]
             + [8, 3, 15, 3, 4, 9, 3, 15, -1],
         ]
+
+        system_prompt = "follow this prompt"
 
         dataset = instruct_dataset(
             tokenizer=DummyTokenizer(),
@@ -79,13 +81,19 @@ class TestInstructDataset:
             data_files=str(ASSETS / "instruct_tiny.json"),
             column_map={"input": "instruction", "output": "response"},
             split="train",
+            new_system_prompt=system_prompt,
         )
+        system_prompt_offset = len(system_prompt.split(" ")) + 1  # +1 for bos token
+
         assert len(dataset) == 2
 
         for i in range(len(dataset)):
             prompt, label = dataset[i]["tokens"], dataset[i]["labels"]
             assert prompt == expected_tokenized_prompts[i]
             if train_on_input:
-                assert label == expected_tokenized_prompts[i]
+                assert (
+                    label[system_prompt_offset:]
+                    == expected_tokenized_prompts[i][system_prompt_offset:]
+                )
             else:
                 assert label == expected_labels[i]

--- a/torchtune/datasets/_instruct.py
+++ b/torchtune/datasets/_instruct.py
@@ -136,6 +136,7 @@ def instruct_dataset(
     source: str,
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
+    new_system_prompt: Optional[str] = None,
     packed: bool = False,
     **load_dataset_kwargs: Dict[str, Any],
 ) -> Union[SFTDataset, PackedDataset]:
@@ -178,6 +179,8 @@ def instruct_dataset(
             and "output" column names.
         train_on_input (bool): Whether the model is trained on the user prompt or not.
             Default is False.
+        new_system_prompt (Optional[str]): if specified, prepend a system message. This can
+            serve as instructions to guide the model response. Default is None.
         packed (bool): Whether or not to pack the dataset to tokenizer's ``max_seq_len`` prior to training. Default is False.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``,
             such as ``data_files`` or ``split``.
@@ -239,9 +242,10 @@ def instruct_dataset(
     Raises:
         ValueError: If ``packed=True`` and ``tokenizer.max_seq_len`` is not set.
     """
-
     message_transform = InputOutputToMessages(
-        train_on_input=train_on_input, column_map=column_map
+        train_on_input=train_on_input,
+        column_map=column_map,
+        new_system_prompt=new_system_prompt,
     )
 
     ds = SFTDataset(


### PR DESCRIPTION


#### Context
What is the purpose of this PR? Is it to
- [X] add a new feature

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
Let's users create a custom instruct dataset with a custom system prompt without creating a custom dataset builder

Users can config their custom instruct dataset like:
```
# Dataset and Sampler
dataset:
  _component_: your.custom.folder.instruct_dataset
  source: "Samsung/samsum"
  train_on_input: False
  column_map:
    input: dialogue
    output: summary
  new_system_prompt: "Summarize the given text into a single sentence" # <<<----
  split: train
```
which previously required a custom builder function

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [X] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [X] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [X] run recipe tests via `pytest tests -m integration_test`
- [X] manually run any new or modified recipes with sufficient proof of correctness
- [X] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [X] I did not change any public API;
- [X] I have added an example to docs or docstrings;
