### PR TITLE
Adds validated_messages into SFTDataset

### DIFF
--- a/tests/torchtune/datasets/test_sft_dataset.py
+++ b/tests/torchtune/datasets/test_sft_dataset.py
@@ -102,3 +102,35 @@ class TestSFTDataset:
         prompt, label = ds[0]["tokens"], ds[0]["labels"]
         assert prompt == expected_tokenized_prompts[0]
         assert label == expected_labels[0]
+
+    @pytest.fixture
+    def invalid_dialogue(self):
+        return [
+            {
+                "dialogue": [
+                    {
+                        "role": "user",
+                        "content": "What is the meaning of life?",
+                        "masked": True,
+                    },
+                    {
+                        "role": "system",
+                        "content": "You are an AI assistant.",
+                        "masked": True,
+                    },
+                ],
+            },
+        ]
+
+    @mock.patch("torchtune.datasets._sft.load_dataset")
+    def test_error_for_validate_diagloue(self, mock_load_dataset, invalid_dialogue):
+        mock_load_dataset.return_value = invalid_dialogue
+
+        ds = SFTDataset(
+            source="iam/agoofy/goober",
+            message_transform=ToDummyMessages(),
+            model_transform=DummyTokenizer(),
+        )
+
+        with pytest.raises(ValueError):
+            ds[0]

--- a/tests/torchtune/datasets/test_sft_dataset.py
+++ b/tests/torchtune/datasets/test_sft_dataset.py
@@ -132,5 +132,6 @@ class TestSFTDataset:
             model_transform=DummyTokenizer(),
         )
 
-        with pytest.raises(ValueError):
+        msg = "system messages must come first"
+        with pytest.raises(ValueError, match=msg):
             ds[0]

--- a/tests/torchtune/datasets/test_sft_dataset.py
+++ b/tests/torchtune/datasets/test_sft_dataset.py
@@ -123,7 +123,7 @@ class TestSFTDataset:
         ]
 
     @mock.patch("torchtune.datasets._sft.load_dataset")
-    def test_error_for_validate_diagloue(self, mock_load_dataset, invalid_dialogue):
+    def test_error_for_invalid_messages(self, mock_load_dataset, invalid_dialogue):
         mock_load_dataset.return_value = invalid_dialogue
 
         ds = SFTDataset(

--- a/torchtune/datasets/_sft.py
+++ b/torchtune/datasets/_sft.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from datasets import load_dataset
 from torch.utils.data import Dataset
-from torchtune.data import CROSS_ENTROPY_IGNORE_IDX
+from torchtune.data import CROSS_ENTROPY_IGNORE_IDX, validate_messages
 from torchtune.modules.transforms import Transform
 
 
@@ -118,6 +118,9 @@ class SFTDataset(Dataset):
 
     def _prepare_sample(self, sample: Mapping[str, Any]) -> Dict[str, Any]:
         transformed_sample = self._message_transform(sample)
+        if "messages" in transformed_sample:
+            validate_messages(transformed_sample["messages"])
+
         tokenized_dict = self._model_transform(transformed_sample)
 
         # Wherever mask == True, set to CROSS_ENTROPY_IGNORE_IDX. Otherwise keep as tokens


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (Restores validation logic to SFTDataset)

Please link to any issues this PR addresses.
Addresses https://github.com/pytorch/torchtune/issues/1391

#### Changelog
Adds `validate_messages` back to SFTDataset.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
