### PR TITLE
Key validation for model transform

### DIFF
--- a/torchtune/datasets/_sft.py
+++ b/torchtune/datasets/_sft.py
@@ -120,6 +120,11 @@ class SFTDataset(Dataset):
         transformed_sample = self._message_transform(sample)
         tokenized_dict = self._model_transform(transformed_sample)
 
+        if not ("tokens" in tokenized_dict and "mask" in tokenized_dict):
+            raise ValueError(
+                "model_transform must return a dictionary with 'tokens' and 'mask' keys"
+            )
+
         # Wherever mask == True, set to CROSS_ENTROPY_IGNORE_IDX. Otherwise keep as tokens
         tokenized_dict["labels"] = list(
             np.where(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

Better engineering practices

Please link to any issues this PR addresses.
https://github.com/pytorch/torchtune/issues/1326

#### Changelog
What are the changes made in this PR?
Validate the output of the model transform in SFTDataset

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [x] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
