### PR TITLE
Properly remove eos_token in llama3 tokenizer if requested by user

### DIFF
--- a/tests/torchtune/models/llama3/test_llama3_tokenizer.py
+++ b/tests/torchtune/models/llama3/test_llama3_tokenizer.py
@@ -17,6 +17,7 @@ class TestLlama3Tokenizer:
         # https://gist.github.com/ebsmothers/54b133dd87db6679b14318545aaa2de4
         return llama3_tokenizer(
             path=str(ASSETS / "tiktoken_small.model"),
+            max_seq_len=2048,
         )
 
     @pytest.fixture
@@ -320,6 +321,21 @@ class TestLlama3Tokenizer:
             + [True]
         )
         tokens, mask = tokenizer.tokenize_messages(text_messages)
+        assert tokens == expected_tokens
+        assert mask == expected_mask
+
+    def test_tokenize_message_drop_eos(
+        self, tokenizer, user_text_message, assistant_text_message
+    ):
+        """Test that the tokenizer will not add an EOS token if user requests it."""
+        text_messages = [user_text_message[0], assistant_text_message[0]]
+        # Chop the end of the assistant message to remove the EOS token
+        expected_tokens = user_text_message[1] + assistant_text_message[1][:-1]
+        # No need to mask out the EOS token at the end since it's not there
+        expected_mask = [True] * len(user_text_message[1]) + [False] * (
+            len(assistant_text_message[1]) - 1
+        )
+        tokens, mask = tokenizer.tokenize_messages(text_messages, add_eos=False)
         assert tokens == expected_tokens
         assert mask == expected_mask
 

--- a/torchtune/models/llama3/_tokenizer.py
+++ b/torchtune/models/llama3/_tokenizer.py
@@ -272,8 +272,10 @@ class Llama3Tokenizer(ModelTokenizer, Transform):
             tokens = tokens + [self.eos_id]
             mask = mask + [True]
         if self.max_seq_len:
-            tokens = truncate(tokens, self.max_seq_len, self.eos_id)
-            mask = truncate(mask, self.max_seq_len, True)
+            tokens = truncate(
+                tokens, self.max_seq_len, self.eos_id if add_eos else None
+            )
+            mask = truncate(mask, self.max_seq_len, True if add_eos else None)
 
         return tokens, mask
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Closes #1474

#### Changelog
* Adds a test to check if we actually strip eos_token if requested by user
* Pass in 'None' for truncate if ``add_eos=False``
* $$$

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [x] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
