### PR TITLE
Expose ``add_eot`` param to ``Llama3Tokenizer.tokenize_messages``

### DIFF
--- a/tests/torchtune/models/llama3/test_llama3_tokenizer.py
+++ b/tests/torchtune/models/llama3/test_llama3_tokenizer.py
@@ -339,6 +339,26 @@ class TestLlama3Tokenizer:
         assert tokens == expected_tokens
         assert mask == expected_mask
 
+    def test_tokenize_message_drop_eot_and_eos(
+        self, tokenizer, user_text_message, assistant_text_message
+    ):
+        """
+        Test that the tokenizer will not add an EOS token or EOT token if user requests it.
+        This is the most common case for inference.
+        """
+        text_messages = [user_text_message[0], assistant_text_message[0]]
+        # Chop the end of the assistant message to remove the EOS token *and* EOT token
+        expected_tokens = user_text_message[1] + assistant_text_message[1][:-2]
+        # No need to mask out the EOS token *or* EOT token at the end since they are not there
+        expected_mask = [True] * len(user_text_message[1]) + [False] * (
+            len(assistant_text_message[1]) - 2
+        )
+        tokens, mask = tokenizer.tokenize_messages(
+            text_messages, add_eos=False, add_eot=False
+        )
+        assert tokens == expected_tokens
+        assert mask == expected_mask
+
     def test_tokenize_image_and_text_messages(
         self, tokenizer, user_image_text_message, assistant_text_message
     ):


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Closes #1475

#### Changelog
* Adds a param to tokenize_messages called ``add_eot`` for "add end-of-turn" token
* Adds a test to ensure that this token is *not* appended if ``add_eot=False``
* Added docstring examples for what this looks like in Llama3

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [x] I have added an example to docs or docstrings;
