### PR TITLE
Add missing quantize_base to llama 3.1

### DIFF
--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -712,7 +712,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     prof.step()
 
                 self.epochs_run += 1
-                # self.save_checkpoint(epoch=curr_epoch)
+                self.save_checkpoint(epoch=curr_epoch)
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -712,7 +712,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     prof.step()
 
                 self.epochs_run += 1
-                self.save_checkpoint(epoch=curr_epoch)
+                # self.save_checkpoint(epoch=curr_epoch)
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/torchtune/models/llama3_1/_component_builders.py
+++ b/torchtune/models/llama3_1/_component_builders.py
@@ -15,6 +15,7 @@ from torchtune.models.llama3_1._position_embeddings import Llama3ScaledRoPE
 from torchtune.modules import (
     MultiHeadAttention,
     FeedForward,
+    FrozenNF4Linear,
     KVCache,
     RMSNorm,
     TransformerDecoder,
@@ -118,14 +119,15 @@ def llama3_1(
         output=output_proj,
     )
 
-def llama3_mlp(dim: int, hidden_dim: int) -> FeedForward:
+def llama3_mlp(dim: int, hidden_dim: int, quantize_base: bool = False) -> FeedForward:
     """
     Build the MLP layer associated with the Llama model.
     """
-    gate_proj = nn.Linear(dim, hidden_dim, bias=False)
-    down_proj = nn.Linear(hidden_dim, dim, bias=False)
-    up_proj = nn.Linear(dim, hidden_dim, bias=False)
+    gate_proj = nn.Linear(dim, hidden_dim, bias=False) if not quantize_base else FrozenNF4Linear(dim, hidden_dim, bias=False)
+    down_proj = nn.Linear(hidden_dim, dim, bias=False) if not quantize_base else FrozenNF4Linear(hidden_dim, dim, bias=False)
+    up_proj = nn.Linear(dim, hidden_dim, bias=False) if not quantize_base else FrozenNF4Linear(dim, hidden_dim, bias=False)
     return FeedForward(gate_proj=gate_proj, down_proj=down_proj, up_proj=up_proj)
+
 
 
 
@@ -223,7 +225,7 @@ def lora_llama3_1(
             use_dora=use_dora,
         )
     else:
-        mlp = llama3_mlp(dim=embed_dim, hidden_dim=hidden_dim)
+        mlp = llama3_mlp(dim=embed_dim, hidden_dim=hidden_dim, quantize_base=quantize_base)
 
     layer = TransformerSelfAttentionLayer(
         attn=self_attn,
@@ -328,7 +330,11 @@ def lora_llama3_1_self_attention(
             quantize_base=quantize_base,
         )
         if "q_proj" in lora_modules
-        else nn.Linear(embed_dim, num_heads * head_dim, bias=False)
+        else (
+            nn.Linear(embed_dim, num_heads * head_dim, bias=False)
+            if not quantize_base
+            else FrozenNF4Linear(embed_dim, num_heads * head_dim, bias=False)
+        )
     )
     k_proj = (
         adapter_cls(
@@ -340,7 +346,11 @@ def lora_llama3_1_self_attention(
             quantize_base=quantize_base,
         )
         if "k_proj" in lora_modules
-        else nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+        else (
+            nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+            if not quantize_base
+            else FrozenNF4Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+        )
     )
     v_proj = (
         adapter_cls(
@@ -352,7 +362,11 @@ def lora_llama3_1_self_attention(
             quantize_base=quantize_base,
         )
         if "v_proj" in lora_modules
-        else nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+        else (
+            nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+            if not quantize_base
+            else FrozenNF4Linear(embed_dim, num_kv_heads * head_dim, bias=False)
+        )
     )
     output_proj = (
         adapter_cls(
@@ -364,7 +378,11 @@ def lora_llama3_1_self_attention(
             quantize_base=quantize_base,
         )
         if "output_proj" in lora_modules
-        else nn.Linear(embed_dim, embed_dim, bias=False)
+        else (
+            nn.Linear(embed_dim, embed_dim, bias=False)
+            if not quantize_base
+            else FrozenNF4Linear(embed_dim, embed_dim, bias=False)
+        )
     )
     rope = Llama3ScaledRoPE(dim=head_dim, max_seq_len=max_seq_len, base=rope_base)
     self_attn = MultiHeadAttention(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Llama 3.1 component_builders were missing quantize_base. I noticed that when finetuning all layers, QLoRA size was ~6.2GB, but when i finetuned only KV, it would take much more memory. Thats because the layers are not quantized when we don't train them.

With this PR, the base model stays 6.2GB regardless of the layers you are finetuning.

#### Test plan

Compare LoRA vs QLoRA when finetuning all layers and only QV. Expected behavior is for memory: LoRA_all > LoRA_QV > QLoRA_all > QLoRA_KV

![image](https://github.com/user-attachments/assets/f2bbfe1e-7a07-482d-9ca6-3686cf621d66)
```
#llama_QLoRA_QV_only
tune run lora_finetune_single_device --config llama3_1/8B_qlora_single_device \
max_steps_per_epoch=25 \
epochs=1 \
model.lora_attn_modules=[q_proj,v_proj] \
model.apply_lora_to_mlp=False \
model.apply_lora_to_output=False \
metric_logger=torchtune.training.metric_logging.WandBLogger  \
metric_logger.name=llama_QLoRA_QV_only \
log_peak_memory_stats=True \
batch_size=4 \
gradient_accumulation_steps=1

#llama_LoRA_QV_only
tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device \
max_steps_per_epoch=25 \
epochs=1  \
model.lora_attn_modules=[q_proj,v_proj] \
model.apply_lora_to_mlp=False \
model.apply_lora_to_output=False \
metric_logger=torchtune.training.metric_logging.WandBLogger  \
metric_logger.name=llama_LoRA_QV_only \
log_peak_memory_stats=True \
batch_size=4 \
gradient_accumulation_steps=1

#llama_QLoRA_all_layers
tune run lora_finetune_single_device --config llama3_1/8B_qlora_single_device \
max_steps_per_epoch=25 \
epochs=1  \
model.lora_attn_modules=[q_proj,v_proj,k_proj,output_proj] \
model.apply_lora_to_mlp=True \
model.apply_lora_to_output=False \
metric_logger=torchtune.training.metric_logging.WandBLogger  \
metric_logger.name=llama_QLoRA_all_layers \
log_peak_memory_stats=True \
batch_size=4 \
gradient_accumulation_steps=1

#llama_LoRA_all_layers
tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device \
max_steps_per_epoch=25 \
epochs=1  \
model.lora_attn_modules=[q_proj,v_proj,k_proj,output_proj] \
model.apply_lora_to_mlp=True \
model.apply_lora_to_output=False \
metric_logger=torchtune.training.metric_logging.WandBLogger  \
metric_logger.name=llama_LoRA_all_layers \
log_peak_memory_stats=True \
batch_size=4 \
gradient_accumulation_steps=1
```