### PR TITLE
Add back support for QAT module swap flow

### DIFF
--- a/torchtune/training/quantization.py
+++ b/torchtune/training/quantization.py
@@ -40,6 +40,31 @@ if TORCH_VERSION_AFTER_2_4:
     _quantizer_mode_to_disable_fake_quant["8da4w-qat"] = disable_8da4w_fake_quant
     _quantizer_mode_to_enable_fake_quant["8da4w-qat"] = enable_8da4w_fake_quant
 
+    try:
+        # Note: QAT tensor subclass implementation in torchao only works
+        # with FSDP2 today. For other distribution strategies like DDP and
+        # FSDP1, users will need to fall back to the old module swap flow.
+        # TODO: remove this try catch once we upgrade to torchao 0.5.0
+
+        from torchao.quantization.prototype.qat._module_swap_api import (
+            disable_8da4w_fake_quant_module_swap,
+            enable_8da4w_fake_quant_module_swap,
+            Int8DynActInt4WeightQATQuantizerModuleSwap,
+        )
+
+        __all__.append("Int8DynActInt4WeightQATQuantizerModuleSwap")
+        _quantizer_to_mode[
+            Int8DynActInt4WeightQATQuantizerModuleSwap
+        ] = "8da4w-qat-module-swap"
+        _quantizer_mode_to_disable_fake_quant[
+            "8da4w-qat-module-swap"
+        ] = disable_8da4w_fake_quant_module_swap
+        _quantizer_mode_to_enable_fake_quant[
+            "8da4w-qat-module-swap"
+        ] = enable_8da4w_fake_quant_module_swap
+    except ImportError:
+        pass
+
 
 def get_quantizer_mode(quantizer: Optional[Callable]) -> Optional[str]:
     """Given a quantizer object, returns a string that specifies the type of quantization.


### PR DESCRIPTION
**Summary:** In torchao, QAT was recently refactored to use tensor subclasses instead of module swap. However, tensor subclass implementation doesn't work with all kinds of distribution strategies yet, e.g. FSDP1 and DDP. As a fallback, users may still wish to use the old module swap flow.

**Test Plan:**
```
CUDA_VISIBLE_DEVICES=2,3,4,5,6,7 tune run --nnodes 1 --nproc_per_node 6 qat_distributed --config llama3/8B_qat_full \
    quantizer._component_=torchtune.training.quantization.Int8DynActInt4WeightQATQuantizerModuleSwap
```