### PR TITLE
Get nightly jobs passing

### DIFF
--- a/.github/workflows/gpu_test.yaml
+++ b/.github/workflows/gpu_test.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: linux.8xlarge.nvidia.gpu
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         torch-version: ["stable"]
     steps:
       - name: Check out repo

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -5,7 +5,6 @@ on:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
   workflow_dispatch:
-  pull_request: # TODO: remove (debug code)
 
 concurrency:
   group: recipe-test-nightly-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -5,6 +5,7 @@ on:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
   workflow_dispatch:
+  pull_request: # TODO: remove (debug code)
 
 concurrency:
   group: recipe-test-nightly-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -5,7 +5,6 @@ on:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
   workflow_dispatch:
-  pull_request: # TODO: remove (just for debugging)
 
 concurrency:
   group: recipe-test-nightly-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: linux.8xlarge.nvidia.gpu
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         torch-version: ["stable", "nightly"]
     steps:
       - name: Check out repo

--- a/.github/workflows/recipe_test_nightly.yaml
+++ b/.github/workflows/recipe_test_nightly.yaml
@@ -5,6 +5,7 @@ on:
     # Runs at midnight every day
     - cron:  '0 0 * * *'
   workflow_dispatch:
+  pull_request: # TODO: remove (just for debugging)
 
 concurrency:
   group: recipe-test-nightly-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 name = "torchtune"
 description = "A native-PyTorch library for LLM fine-tuning"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     { name = "PyTorch Team", email = "packages@pytorch.org" },

--- a/torchtune/training/quantization.py
+++ b/torchtune/training/quantization.py
@@ -6,11 +6,6 @@
 
 from typing import Callable, Optional
 
-# importing TORCH_VERSION_AFTER_2_3 because `Int8DynActInt4WeightQuantizer`
-# is only available after 2.3 so we have to guard the pytorch versions to decide
-# the list of supported quantizers
-from torchao.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4
-
 __all__ = [
     "get_quantizer_mode",
 ]
@@ -21,24 +16,22 @@ _quantizer_mode_to_disable_fake_quant = {}
 _quantizer_mode_to_enable_fake_quant = {}
 
 
-if TORCH_VERSION_AFTER_2_3:
-    from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
+from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
 
-    __all__.append("Int8DynActInt4WeightQuantizer")
-    _quantizer_to_mode[Int8DynActInt4WeightQuantizer] = "8da4w"
+__all__.append("Int8DynActInt4WeightQuantizer")
+_quantizer_to_mode[Int8DynActInt4WeightQuantizer] = "8da4w"
 
 
-if TORCH_VERSION_AFTER_2_4:
-    from torchao.quantization.prototype.qat import (
-        disable_8da4w_fake_quant,
-        enable_8da4w_fake_quant,
-        Int8DynActInt4WeightQATQuantizer,
-    )
+from torchao.quantization.prototype.qat import (
+    disable_8da4w_fake_quant,
+    enable_8da4w_fake_quant,
+    Int8DynActInt4WeightQATQuantizer,
+)
 
-    __all__.append("Int8DynActInt4WeightQATQuantizer")
-    _quantizer_to_mode[Int8DynActInt4WeightQATQuantizer] = "8da4w-qat"
-    _quantizer_mode_to_disable_fake_quant["8da4w-qat"] = disable_8da4w_fake_quant
-    _quantizer_mode_to_enable_fake_quant["8da4w-qat"] = enable_8da4w_fake_quant
+__all__.append("Int8DynActInt4WeightQATQuantizer")
+_quantizer_to_mode[Int8DynActInt4WeightQATQuantizer] = "8da4w-qat"
+_quantizer_mode_to_disable_fake_quant["8da4w-qat"] = disable_8da4w_fake_quant
+_quantizer_mode_to_enable_fake_quant["8da4w-qat"] = enable_8da4w_fake_quant
 
 
 def get_quantizer_mode(quantizer: Optional[Callable]) -> Optional[str]:

--- a/torchtune/training/quantization.py
+++ b/torchtune/training/quantization.py
@@ -33,30 +33,30 @@ _quantizer_to_mode[Int8DynActInt4WeightQATQuantizer] = "8da4w-qat"
 _quantizer_mode_to_disable_fake_quant["8da4w-qat"] = disable_8da4w_fake_quant
 _quantizer_mode_to_enable_fake_quant["8da4w-qat"] = enable_8da4w_fake_quant
 
-    try:
-        # Note: QAT tensor subclass implementation in torchao only works
-        # with FSDP2 today. For other distribution strategies like DDP and
-        # FSDP1, users will need to fall back to the old module swap flow.
-        # TODO: remove this try catch once we upgrade to torchao 0.5.0
+try:
+    # Note: QAT tensor subclass implementation in torchao only works
+    # with FSDP2 today. For other distribution strategies like DDP and
+    # FSDP1, users will need to fall back to the old module swap flow.
+    # TODO: remove this try catch once we upgrade to torchao 0.5.0
 
-        from torchao.quantization.prototype.qat._module_swap_api import (
-            disable_8da4w_fake_quant_module_swap,
-            enable_8da4w_fake_quant_module_swap,
-            Int8DynActInt4WeightQATQuantizerModuleSwap,
-        )
+    from torchao.quantization.prototype.qat._module_swap_api import (
+        disable_8da4w_fake_quant_module_swap,
+        enable_8da4w_fake_quant_module_swap,
+        Int8DynActInt4WeightQATQuantizerModuleSwap,
+    )
 
-        __all__.append("Int8DynActInt4WeightQATQuantizerModuleSwap")
-        _quantizer_to_mode[
-            Int8DynActInt4WeightQATQuantizerModuleSwap
-        ] = "8da4w-qat-module-swap"
-        _quantizer_mode_to_disable_fake_quant[
-            "8da4w-qat-module-swap"
-        ] = disable_8da4w_fake_quant_module_swap
-        _quantizer_mode_to_enable_fake_quant[
-            "8da4w-qat-module-swap"
-        ] = enable_8da4w_fake_quant_module_swap
-    except ImportError:
-        pass
+    __all__.append("Int8DynActInt4WeightQATQuantizerModuleSwap")
+    _quantizer_to_mode[
+        Int8DynActInt4WeightQATQuantizerModuleSwap
+    ] = "8da4w-qat-module-swap"
+    _quantizer_mode_to_disable_fake_quant[
+        "8da4w-qat-module-swap"
+    ] = disable_8da4w_fake_quant_module_swap
+    _quantizer_mode_to_enable_fake_quant[
+        "8da4w-qat-module-swap"
+    ] = enable_8da4w_fake_quant_module_swap
+except ImportError:
+    pass
 
 
 def get_quantizer_mode(quantizer: Optional[Callable]) -> Optional[str]:


### PR DESCRIPTION
Remove usage of deprecated version checks we were importing from ao and drop Python 3.8 support

Test plan:

![Screenshot 2024-09-04 at 12 44 28 PM](https://github.com/user-attachments/assets/fdf9983b-de89-49c0-bb2c-db69232208d7)
