### PR TITLE
[FSDP2] full finetune: move state dict to cpu when cpu offloading

### DIFF
--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -516,20 +516,19 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         checkpoint_dict = {}
 
         intermediate_checkpoint = epoch + 1 < self.total_epochs
-        intermediate_checkpoint = True
         # To prevent GPU memory from spiking during checkpoint save,
         # we consolidate the full model and optim state dicts on CPU for rank 0
         cpu_state_dict = training.get_full_model_state_dict(
             self._model,
             self._is_rank_zero,
-            self._device,
+            device=self._device,
         )
 
         if intermediate_checkpoint:
             opt_state_dict = training.get_full_optimizer_state_dict(
                 self._optimizer,
                 self._is_rank_zero,
-                self._device,
+                device=self._device,
             )
         else:
             opt_state_dict = None

--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -211,7 +211,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             self._metric_logger.log_config(cfg)
 
         checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
-        self._model_compile = cfg.compile
+        self._model_compile = cfg.get("compile", False)
 
         self._model = self._setup_model(
             cfg_model=cfg.model,
@@ -516,17 +516,20 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         checkpoint_dict = {}
 
         intermediate_checkpoint = epoch + 1 < self.total_epochs
+        intermediate_checkpoint = True
         # To prevent GPU memory from spiking during checkpoint save,
         # we consolidate the full model and optim state dicts on CPU for rank 0
         cpu_state_dict = training.get_full_model_state_dict(
             self._model,
             self._is_rank_zero,
+            self._device,
         )
 
         if intermediate_checkpoint:
             opt_state_dict = training.get_full_optimizer_state_dict(
                 self._optimizer,
                 self._is_rank_zero,
+                self._device,
             )
         else:
             opt_state_dict = None

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -431,7 +431,12 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         # This method will convert the full model state dict into a sharded state
         # dict and load into the model
         training.load_from_full_model_state_dict(
-            model, model_state_dict, self._device, self._is_rank_zero, strict=True, cpu_offload=fsdp_cpu_offload
+            model,
+            model_state_dict,
+            self._device,
+            self._is_rank_zero,
+            strict=True,
+            cpu_offload=fsdp_cpu_offload,
         )
 
         # Ensure no params and buffers are on meta device

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -537,12 +537,14 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         cpu_state_dict = training.get_full_model_state_dict(
             self._model,
             self._is_rank_zero,
+            device=self._device,
         )
 
         if intermediate_checkpoint:
             opt_state_dict = training.get_full_optimizer_state_dict(
                 self._optimizer,
                 self._is_rank_zero,
+                device=self._device,
             )
         else:
             opt_state_dict = None

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -15,9 +15,6 @@ from warnings import warn
 import torch
 from omegaconf import DictConfig, ListConfig
 
-import pickle
-torch.cuda.memory._record_memory_history(max_entries=1000000)
-
 from torch import nn
 from torch.distributed import destroy_process_group, init_process_group
 
@@ -654,10 +651,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 if (idx + 1) % self._gradient_accumulation_steps == 0:
                     self._optimizer.step()
                     self._optimizer.zero_grad(set_to_none=True)
-
-                    if torch.distributed.get_rank() == 0:
-                        pickle.dump(torch.cuda.memory._snapshot(), open("full_finetune_fsdp2" + '.pickle', 'wb'))
-                    return
 
                     # Update the number of steps when the weights are updated
                     self.global_step += 1

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -285,6 +285,7 @@ def load_from_full_model_state_dict(
     device: torch.device,
     is_rank_zero: bool,
     strict: bool = False,
+    cpu_offload: bool = False,
 ):
     """
     Converting full state dict into a sharded state dict
@@ -338,6 +339,8 @@ def load_from_full_model_state_dict(
                 sharded_meta_param.device_mesh,
                 sharded_meta_param.placements,
             )
+        if cpu_offload:
+            sharded_tensor = sharded_tensor.cpu()
         sharded_sd[param_name] = nn.Parameter(sharded_tensor)
     # choose `assign=True` since we cannot call `copy_` on meta tensor
     return model.load_state_dict(sharded_sd, strict=strict, assign=True)
@@ -584,4 +587,4 @@ def shard_model(
             fully_shard(m, **fsdp_kwargs)
 
     # Finally shard the entire model to account for any stragglers
-    fully_shard(model)
+    fully_shard(model, **fsdp_kwargs)

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -8,7 +8,7 @@
 import logging
 import os
 from itertools import chain
-from typing import Any, Callable, cast, Dict, List, Set, Tuple, Type
+from typing import Any, Callable, cast, Dict, List, Set, Tuple, Type, Optional
 
 import torch
 import torch.distributed as dist
@@ -349,6 +349,7 @@ def load_from_full_model_state_dict(
 def get_full_model_state_dict(
     model: "FSDPModule",  # noqa
     is_rank_zero: bool,
+    device: Optional[torch.device] = None,
 ) -> Dict[str, Any]:
     """
     Converting sharded state dict into a full state dict on cpu
@@ -396,6 +397,13 @@ def get_full_model_state_dict(
             module.reshard()
     else:
         for param_name, sharded_param in sharded_sd.items():
+            if sharded_param.is_cpu:
+                assert device is not None and device.type == "cuda", (
+                    f"Expect cuda but got device={device}. "
+                    "Please call get_full_model_state_dict(..., device=self._device),"
+                    " so DTensor can communicate over NCCL."
+                )
+                sharded_param = sharded_param.to(device)
             full_param = sharded_param.full_tensor()
             if is_rank_zero:
                 cpu_state_dict[param_name] = full_param.cpu()
@@ -407,6 +415,7 @@ def get_full_model_state_dict(
 def get_full_optimizer_state_dict(
     opt: Optimizer,
     is_rank_zero: bool,
+    device: Optional[torch.device] = None,
 ) -> Dict[str, Any]:
     """
     Converting optimizer state from sharded to full
@@ -420,8 +429,15 @@ def get_full_optimizer_state_dict(
     for group_id, sharded_group in sharded_state.items():
         group_state = {}
         for attr, sharded_tensor in sharded_group.items():
+            # "exp_avg" in AdamW is `DTensor`
             if isinstance(sharded_tensor, DTensor):
-                # "exp_avg" in AdamW is `DTensor`
+                if sharded_tensor.is_cpu:
+                    assert device is not None and device.type == "cuda", (
+                        f"Expect cuda but got device={device}. "
+                        "Please call get_full_optimizer_state_dict(..., device=self._device),"
+                        " so DTensor can communicate over NCCL."
+                    )
+                    sharded_tensor = sharded_tensor.to(device)
                 full_tensor = sharded_tensor.full_tensor()
             else:
                 # "step" in AdamW is plain tensor

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -8,7 +8,7 @@
 import logging
 import os
 from itertools import chain
-from typing import Any, Callable, cast, Dict, List, Set, Tuple, Type, Optional
+from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, Type
 
 import torch
 import torch.distributed as dist


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

resolve: https://github.com/pytorch/torchtune/issues/1412

full finetune with cpu offload: `tune run --nproc_per_node 2 full_finetune_distributed --config llama2/7B_full fsdp_cpu_offload=True`

full finetune without cpu offload: `tune run --nproc_per_node 2 full_finetune_distributed --config llama2/7B_full fsdp_cpu_offload=False`

lora: `tune run --nproc_per_node 2 lora_finetune_fsdp2 --config llama2/7B_lora`

qlora: `tune run --nproc_per_node 2 lora_finetune_fsdp2 --config llama2/7B_qlora`

when cpu offloading, we can move state dict to cpu to avoid peaking memory. As the snapshot shows, peak memory dropped from 7GB to 3GB: 

memory behavior before
<img width="1600" alt="Screenshot 2024-09-04 at 3 29 52 PM" src="https://github.com/user-attachments/assets/c9ff3a0a-5c9c-48d1-b3c3-badf44f59cb3">

memory behavior after
<img width="1423" alt="Screenshot 2024-09-04 at 3 31 29 PM" src="https://github.com/user-attachments/assets/203dbaaf-c0df-4bf7-9d8d-1cf4f0f03253">

