### PR TITLE
hotifx - remove param from input of rope_init

### DIFF
--- a/torchtune/models/llama3_1/_position_embeddings.py
+++ b/torchtune/models/llama3_1/_position_embeddings.py
@@ -65,6 +65,10 @@ class Llama3ScaledRoPE(nn.Module):
         self.rope_init()
 
     def rope_init(self):
+        """
+        Warning: this is called in recipes before torch.compile,
+        so that the cache is built in advance.
+        """
         freqs = 1.0 / (
             self.base
             ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

In https://github.com/pytorch/torchtune/pull/1386 i introduced a bug by requiring parameters in rope_init,i .e. 
```
def rope_init(self, scaling_factor):
	foo = baa(scaling_factor)
```

 instead of:
```
def rope_init(self): 
	foo = baa(self.scaling_factor)
```

When trying to run distributed, it broke, because distributed calls rope_init before compile. This PR fixes it by removing inputs from rope_init.

#### Test plan
ran ```tune run --nproc_per_node 4 full_finetune_distributed --config llama3_1/8B_full``` without errors
