### PR TITLE
[testing] remove compile backend override from recipe test

### DIFF
--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -32,6 +32,7 @@ jobs:
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       # Python=3.10 for now cause bitsandbytes?
+      # also for some reason pip install -e ".[dev]" doesn't work?
       script: |
         conda create -n venv python=3.10 -y
         conda activate venv
@@ -41,5 +42,4 @@ jobs:
         pip install torch torchvision torchao
         pip install .
         pip install lm-eval==0.4.* bitsandbytes>=0.43.0 comet_ml>=3.44.2 pre-commit pytest==7.4.0 pytest-cov pytest-mock pytest-integration tensorboard wandb expecttest
-        pytest test --verbose -s
         pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -25,28 +25,19 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-      - name: Setup conda env
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
-      - name: Install gcc
-        run: |
-          yum install -y  devtoolset-10-binutils
-          export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
-      - name: Update pip
-        run: python -m pip install --upgrade pip
-      - name: Install dependencies
-        run: |
-          python -m pip install torch torchvision torchao
-          python -m pip install -e ".[dev]"
-          python -m pip install lm-eval==0.4.*
-      - name: Run recipe tests with coverage
-        run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      timeout: 60
+      runner: linux.2xlarge
+      script: |
+        conda create -n venv python=3.9 -y
+        conda activate venv
+        echo "::group::Install newer objcopy that supports --set-section-alignment"
+        yum install -y  devtoolset-10-binutils
+        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
+        python -m pip install --upgrade pip
+        python -m pip install torch torchvision torchao
+        python -m pip install -e ".[dev]"
+        python -m pip install lm-eval==0.4.*
+        pytest test --verbose -s
+        pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -24,11 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        include:
+          - name: CPU
+            runs-on: linux.2xlarge
+            gpu-arch-type: "cpu"
+            gpu-arch-version: ""
+
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       timeout: 60
-      runner: linux.2xlarge
+      runner: ${{ matrix.runs-on }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
       script: |
         conda create -n venv python=3.9 -y
         conda activate venv

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -39,7 +39,7 @@ jobs:
         yum install -y  devtoolset-10-binutils
         export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
         python -m pip install --upgrade pip
-        pip install torch torchvision torchao
+        python -m pip install --pre torch torchvision torchao --index-url https://download.pytorch.org/whl/nightly/cu121
         pip install .
         pip install lm-eval==0.4.* bitsandbytes>=0.43.0 comet_ml>=3.44.2 pre-commit pytest==7.4.0 pytest-cov pytest-mock pytest-integration tensorboard wandb expecttest
         pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -35,7 +35,6 @@ jobs:
       script: |
         conda create -n venv python=3.10 -y
         conda activate venv
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
         yum install -y  devtoolset-10-binutils
         export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
         python -m pip install --upgrade pip

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -31,8 +31,9 @@ jobs:
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      # Python=3.10 for now cause bitsandbytes?
       script: |
-        conda create -n venv python=3.9 -y
+        conda create -n venv python=3.10 -y
         conda activate venv
         echo "::group::Install newer objcopy that supports --set-section-alignment"
         yum install -y  devtoolset-10-binutils

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -21,9 +21,9 @@ jobs:
       matrix:
         include:
           - name: CPU
-            runs-on: linux.2xlarge
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
+            runs-on: linux.g5.12xlarge.nvidia.gpu
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.1"
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -35,6 +35,10 @@ jobs:
           miniconda-version: "latest"
           activate-environment: test
           python-version: ${{ matrix.python-version }}
+      - name: Install gcc
+        run: |
+          yum install -y  devtoolset-10-binutils
+          export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -38,8 +38,8 @@ jobs:
         yum install -y  devtoolset-10-binutils
         export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
         python -m pip install --upgrade pip
-        python -m pip install torch torchvision torchao
-        python -m pip install -e ".[dev]"
-        python -m pip install lm-eval==0.4.*
+        pip install torch torchvision torchao
+        pip install .
+        pip install lm-eval==0.4.* bitsandbytes>=0.43.0 comet_ml>=3.44.2 pre-commit pytest==7.4.0 pytest-cov pytest-mock pytest-integration tensorboard wandb expecttest
         pytest test --verbose -s
         pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -15,13 +15,8 @@ permissions:
   id-token: write
   contents: read
 
-defaults:
-  run:
-    shell: bash -l -eo pipefail {0}
-
 jobs:
   recipe_test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "blobfile>=2",
 
     # Miscellaneous
-    "numpy<=1.26.4", # Pin here until https://github.com/tensorflow/tensorboard/issues/6869 is addressed
+    "numpy",
     "tqdm",
     "omegaconf",
 

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -74,9 +74,6 @@ class TestFullFinetuneSingleDeviceRecipe:
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
 
-        # To workaround https://github.com/pytorch/torchtune/issues/676
-        if compile:
-            os.environ["TORCH_COMPILE_BACKEND"] = "aot_eager"
         cmd = f"""
         tune run full_finetune_single_device \
             --config {config} \


### PR DESCRIPTION
Check if this breaks due to gcc version issue as described in #676 

On CPU: same compile error with or without installing dev-toolset 10 (see [here](https://github.com/pytorch/torchtune/actions/runs/10732174739?pr=1508))

On GPU runner:
            runs-on: linux.g5.12xlarge.nvidia.gpu
            gpu-arch-type: "cuda"
            gpu-arch-version: "12.1"
Same error on both nightly and stable versions (both with dev-toolset 10 installed)