### PR TITLE
Make our compile tests actually work

### DIFF
--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -74,9 +74,6 @@ class TestFullFinetuneSingleDeviceRecipe:
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
 
-        # To workaround https://github.com/pytorch/torchtune/issues/676
-        if compile:
-            os.environ["TORCH_COMPILE_BACKEND"] = "aot_eager"
         cmd = f"""
         tune run full_finetune_single_device \
             --config {config} \
@@ -99,8 +96,13 @@ class TestFullFinetuneSingleDeviceRecipe:
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
+        # Make sure to clear compile state in between tests
+        if compile:
+            torch._dynamo.reset()
+
         loss_values = get_loss_values_from_metric_logger(log_file)
         expected_loss_values = self._fetch_expected_loss_values(model_type)
+
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-4, atol=1e-4
         )

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -38,8 +38,8 @@ def compile_model(
         ValueError: Just to make pydoctlint happy, will remove
     """
     backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
-    log.error(f"Backend is {backend}")
-    raise ValueError("Done")
+    if backend != "inductor":
+        raise ValueError(f"Expected inductor backend, got {backend}")
     if torch_version_ge("2.5.0"):
         if verbose:
             log.info("Compiling model layers with torch.compile...")
@@ -69,9 +69,13 @@ def compile_loss(loss: nn.Module, verbose: bool = True) -> None:
     Returns:
         loss (nn.Module): loss with either entire module compiled or (in the case of
             CEWithChunkedOutputLoss) only the upcast and cross-entropy calculation compiled.
+    Raises:
+        ValueError: Just to make pydoctlint happy, will remove
 
     """
     backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
+    if backend != "inductor":
+        raise ValueError(f"Expected inductor backend, got {backend}")
     if verbose:
         log.info("Compiling loss with torch.compile...")
     if isinstance(loss, CEWithChunkedOutputLoss):

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -34,8 +34,12 @@ def compile_model(
         verbose (bool): Whether to log compile info. Default: True
     Returns:
         None
+    Raises:
+        ValueError: Just to make pydoctlint happy, will remove
     """
     backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
+    log.error(f"Backend is {backend}")
+    raise ValueError("Done")
     if torch_version_ge("2.5.0"):
         if verbose:
             log.info("Compiling model layers with torch.compile...")

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -34,12 +34,9 @@ def compile_model(
         verbose (bool): Whether to log compile info. Default: True
     Returns:
         None
-    Raises:
-        ValueError: Just to make pydoctlint happy, will remove
+
     """
     backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
-    if backend != "inductor":
-        raise ValueError(f"Expected inductor backend, got {backend}")
     if torch_version_ge("2.5.0"):
         if verbose:
             log.info("Compiling model layers with torch.compile...")
@@ -69,13 +66,8 @@ def compile_loss(loss: nn.Module, verbose: bool = True) -> None:
     Returns:
         loss (nn.Module): loss with either entire module compiled or (in the case of
             CEWithChunkedOutputLoss) only the upcast and cross-entropy calculation compiled.
-    Raises:
-        ValueError: Just to make pydoctlint happy, will remove
-
     """
     backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
-    if backend != "inductor":
-        raise ValueError(f"Expected inductor backend, got {backend}")
     if verbose:
         log.info("Compiling loss with torch.compile...")
     if isinstance(loss, CEWithChunkedOutputLoss):


### PR DESCRIPTION
Make our recipe tests with `compile=True` not a no-op. Even better yet make them pass. I don't believe that #676 is relevant anymore so we can close that once this lands.

The one problem is that this still would not have caught #1498, since the full finetune test case does still pass (it's possible there was something specifically about the fused optimizer, cause otherwise the run is fairly similar to our test configs). There is also the issue of the compiled version of LoRA not failing for 10+ iterations; this also won't be caught by our current testing. To deal with this we probably need longer-running compile tests (ideally with perf numbers) as part of our (currently very limited) regression test suite. We will file a testing mega-issue soon and this will be included.

Test plan:

```
pytest tests -m integration_test
======== 37 passed, 467 deselected, 8 warnings in 619.62s (0:10:19) =========
```

Also added an assertion to verify that all recipe tests in CI are now using inductor backend (see [this commit](https://github.com/pytorch/torchtune/pull/1522/commits/d97de19118806c398b3894f5e8b2dbeddc3eabad)). As demonstrated in the below screenshot, the CI is green on this commit, which demonstrates that our CI is now running on the inductor backend as it should.

<img width="797" alt="Screenshot 2024-09-07 at 3 23 03 PM" src="https://github.com/user-attachments/assets/cdda3fdf-2127-470f-8b02-8483b0066687">
