### PR TITLE
Fixed left_pad_sequence - correctly flip dims based on batch_first

### DIFF
--- a/tests/torchtune/data/test_collate.py
+++ b/tests/torchtune/data/test_collate.py
@@ -57,6 +57,9 @@ class TestLeftPadSequence:
         expected = torch.tensor([[0, 0, 1, 2, 3], [0, 4, 5, 6, 7], [8, 9, 10, 11, 12]])
         assert torch.equal(result, expected)
 
+        result = left_pad_sequence([a, b, c], batch_first=False, padding_value=0)
+        assert torch.equal(result, expected.transpose(0, 1))
+
 
 class TestPaddedCollate:
     def test_padded_collate_classifier_labels(self):

--- a/tests/torchtune/data/test_collate.py
+++ b/tests/torchtune/data/test_collate.py
@@ -58,7 +58,10 @@ class TestLeftPadSequence:
         assert torch.equal(result, expected)
 
         result = left_pad_sequence([a, b, c], batch_first=False, padding_value=0)
-        assert torch.equal(result, expected.transpose(0, 1))
+        expected = torch.tensor(
+            [[0, 0, 8], [0, 4, 9], [1, 5, 10], [2, 6, 11], [3, 7, 12]]
+        )
+        assert torch.equal(result, expected)
 
 
 class TestPaddedCollate:

--- a/torchtune/data/_collate.py
+++ b/torchtune/data/_collate.py
@@ -49,7 +49,7 @@ def left_pad_sequence(
         map(lambda x: torch.flip(x, dims=[0]), sequences),
         batch_first=batch_first,
         padding_value=padding_value,
-    ).flip(dims=[1])
+    ).flip(dims=[int(batch_first)])
 
 
 def padded_collate(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
- Fix `left_pad_sequence` (from `data/_collate.py`) to have feature parity with `pad_sequence` from `torch.nn.utils.rnn`. Previous version would not account for the case where `batch_first` is `False` when post-flipping the padded sequence.
- Added corresponding test. 

Note that (I believe) future versions of pytorch (> 2.4.1) will expose a `padding_side` argument which could replace this utility altogether.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [x] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
