### PR TITLE
Improve get_mapped_key heuristic

### DIFF
--- a/torchtune/models/convert_weights.py
+++ b/torchtune/models/convert_weights.py
@@ -47,6 +47,7 @@ _FROM_HF = {
 
 def get_mapped_key(key: str, mapping_dict: Dict[str, str]) -> str:
     try:
+        # Checks if there is a layer # in the key
         if any(k.isdigit() for k in key.split(".")):
             # Replace layer number with "{}" to create key for lookup
             abstract_key = re.sub(r"(\.\d+)", ".{}", key)

--- a/torchtune/models/convert_weights.py
+++ b/torchtune/models/convert_weights.py
@@ -47,7 +47,7 @@ _FROM_HF = {
 
 def get_mapped_key(key: str, mapping_dict: Dict[str, str]) -> str:
     try:
-        if "layers" in key:
+        if any(k.isdigit() for k in key.split(".")):
             # Replace layer number with "{}" to create key for lookup
             abstract_key = re.sub(r"(\.\d+)", ".{}", key)
             layer_num = re.search(r"\d+", key).group(0)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Currently get_mapped_key maps any key with the word "layers" in it. This breaks down for models that don't use that naming convention. Since the goal of this function is to map layer numbers, This PR updates get_mapped_key to instead map keys that have ".#." in the key, where # is any numeric number. This is more robust across different state dicts and doesn't change behavior for current models.

#### Changelog
`if "layers" in key:` -> `if any(k.isdigit() for k in key.split("."))`

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [x] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
