### PR TITLE
[RFC] Dataset documentation overhaul

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -137,6 +137,24 @@ torchtune tutorials.
 .. toctree::
    :glob:
    :maxdepth: 1
+   :caption: General Usage
+   :hidden:
+
+   usage/tokenizers
+   usage/messages
+   usage/sample_packing
+   usage/model_transforms
+   usage/message_transforms
+   usage/instruct_datasets
+   usage/chat_datasets
+   usage/multimodal_datasets
+   usage/preference_datasets
+   usage/text_completion_datasets
+   usage/custom_datasets
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
    :caption: API Reference
    :hidden:
 

--- a/docs/source/usage/chat_datasets.rst
+++ b/docs/source/usage/chat_datasets.rst
@@ -1,0 +1,22 @@
+.. _chat_dataset_usage_label:
+
+=============
+Chat Datasets
+=============
+
+Discussion of what classifies as a chat dataset, and a breakdown of the main builder function.
+
+Chat dataset format
+-------------------
+
+Expected format of dataset (one column with a list of messages)
+
+Custom chat datasets
+--------------------
+
+Overview of conversation styles (ShareGPTToMessages, JSONToMessages) and how to customize it
+
+Chat templates
+--------------
+
+Overview of chat prompt templates and how to enable them.

--- a/docs/source/usage/custom_datasets.rst
+++ b/docs/source/usage/custom_datasets.rst
@@ -1,0 +1,12 @@
+.. _custom_dataset_usage_label:
+
+===========================
+Custom Fine-Tuning Datasets
+===========================
+
+Overview of base SFTDataset class and the design concepts (message transform, model transform).
+Walk through how you can configure each component for a fully custom dataset.
+Creating builder function for your dataset that can be specified in the config.
+Launching a fine-tune run with a custom dataset.
+
+Most likely the existing dataset tutorial can be repurposed here.

--- a/docs/source/usage/instruct_datasets.rst
+++ b/docs/source/usage/instruct_datasets.rst
@@ -1,0 +1,22 @@
+.. _instruct_dataset_usage_label:
+
+=================
+Instruct Datasets
+=================
+
+Discussion of what classifies as an instruct dataset, and a breakdown of the main builder function.
+
+Instruct dataset format
+-----------------------
+
+Expected format of dataset (one prompt column, one response column)
+
+Custom instruct datasets
+------------------------
+
+Overview of InputOutputToMessages and how to customize it
+
+Instruct templates
+------------------
+
+Overview of instruct prompt templates and how to enable them.

--- a/docs/source/usage/message_transforms.rst
+++ b/docs/source/usage/message_transforms.rst
@@ -1,0 +1,30 @@
+.. _message_transforms_usage_label:
+
+==================
+Message Transforms
+==================
+
+Discuss the concept of message transforms and how they should be used. This is the core piece
+that a user needs to be most familiar with to fine-tune on custom data.
+
+Common message transforms
+-------------------------
+
+Overview of common dataset formats (like ShareGPT, OpenAI, Instruct data) and the message
+transforms to use for these.
+
+Converting text-data to Messages
+--------------------------------
+
+Show how example text-only data should be converted into a list of Messages.
+
+
+Converting text and image data to Messages
+------------------------------------------
+
+Show how example text and image data should be converted into a list of Messages.
+
+Creating a custom message transform
+-----------------------------------
+
+Walk through how one would design their own message transform and principles they should follow.

--- a/docs/source/usage/messages.rst
+++ b/docs/source/usage/messages.rst
@@ -1,0 +1,33 @@
+.. _messages_usage_label:
+
+========
+Messages
+========
+
+Snappy intro about Messages in general, how they're used in torchtune.
+
+
+What is a Message?
+------------------
+
+Vehicle for containing all information to tokenize a text sample with corresponding special tokens by any model tokenizer.
+Discuss why we need this and how it is central to datasets in torchtune.
+Break down the Message dataclass
+
+
+How do I use the Message?
+-------------------------
+
+Message transforms (point to message transform page but briefly discuss here)
+
+
+Images in Messages
+------------------
+
+Discuss how to add images to Messages.
+
+
+Prompt templating messages
+--------------------------
+
+Briefly discuss how prompt templating modifies messages.

--- a/docs/source/usage/model_transforms.rst
+++ b/docs/source/usage/model_transforms.rst
@@ -1,0 +1,19 @@
+.. _model_transforms_usage_label:
+
+================
+Model Transforms
+================
+
+Discuss the concept of model transforms and how they should be used.
+
+
+Using model transforms in multimodal datasets
+---------------------------------------------
+
+Show how model transforms like Flamingo can be passed into our multimodal dataset builders and what expected keys are
+
+
+Creating a custom model transform
+---------------------------------
+
+Walk through how one would design their own model transform and principles they should follow.

--- a/docs/source/usage/multimodal_datasets.rst
+++ b/docs/source/usage/multimodal_datasets.rst
@@ -1,0 +1,22 @@
+.. _multimodal_dataset_usage_label:
+
+===================
+Multimodal Datasets
+===================
+
+Discussion of what classifies as multimodal dataset (image + text), and a breakdown of the main builder function.
+
+Multimodal dataset format
+-------------------------
+
+Expected format of dataset (image column, text column)
+
+Image handling
+--------------
+
+How images should be handled in multimodal datasets and where they are passed to
+
+Custom multimodal datasets
+--------------------------
+
+Overview of creating your own message transform for multimodal datasets

--- a/docs/source/usage/preference_datasets.rst
+++ b/docs/source/usage/preference_datasets.rst
@@ -1,0 +1,19 @@
+.. _preference_dataset_usage_label:
+
+===================
+Preference Datasets
+===================
+
+Discussion of what classifies as a preference dataset, and a breakdown of the main builder function.
+
+
+Preference dataset format
+-------------------------
+
+Expected format of dataset (one chosen column, one rejected column)
+
+
+Custom instruct datasets
+------------------------
+
+Overview of ChosenRejectedToMessages and how to customize it

--- a/docs/source/usage/sample_packing.rst
+++ b/docs/source/usage/sample_packing.rst
@@ -1,0 +1,7 @@
+.. _sample_packing_usage_label:
+
+==============
+Sample Packing
+==============
+
+What is sample packing and how to enable it. Also brief discussion on document masking, corrected position ids

--- a/docs/source/usage/text_completion_datasets.rst
+++ b/docs/source/usage/text_completion_datasets.rst
@@ -1,0 +1,20 @@
+.. _text_completion_dataset_usage_label:
+
+========================
+Text Completion Datasets
+========================
+
+Discussion of what classifies as a text_completion dataset, and a breakdown of the main builder function.
+Mention that this is used for continued pre-training on a new domain with unstructured text corpuses
+
+
+Text completion dataset format
+------------------------------
+
+Expected format of dataset (one or no columns, unstructured raw text)
+
+
+Custom text completion datasets
+-------------------------------
+
+Overview of how to customize the builder

--- a/docs/source/usage/tokenizers.rst
+++ b/docs/source/usage/tokenizers.rst
@@ -1,0 +1,49 @@
+.. _tokenizers_usage_label:
+
+==========
+Tokenizers
+==========
+
+Snappy intro about tokenizers in general, how they're used in torchtune
+
+
+Downloading tokenizers from Hugging Face
+----------------------------------------
+
+tune download
+
+
+Loading tokenizers from file
+----------------------------
+
+Passing path into tokenizer builder function
+
+
+Base tokenizers
+---------------
+
+SentencePiece, TikToken, and how this is distinct from model tokenizers
+
+
+Model tokenizers
+----------------
+
+Different contract, must implement tokenize_messages, model specific special tokens, and more.
+
+
+Special tokens
+--------------
+
+What are special tokens, how is it different from a template, how can I customize special tokens
+
+
+Prompt templates
+----------------
+
+What are prompt templates, when should I use them, how can I configure them in tokenizer, how can I easily carry this over to inference
+
+
+Setting max sequence length
+---------------------------
+
+Passing this in tokenizer builder


### PR DESCRIPTION
Yet another documentation update for datasets!

There are A LOT of new concepts and modules that we've recently added that are COMPLETELY ABSENT from our documentation (excluding API ref). Here are some of the recent changes that are not mentioned anywhere:
- Prompt templating happens in the tokenizer
- Setting max sequence length happens in the tokenizer
- Hey we have sample packing, how do I use it (this is kinda mentioned but very briefly)
- What is a Message
- What is a message transform and how do I use it
- What is a model transform and how do I use it
- What is SFTDataset
- How do I use PreferenceDataset
- How do I use TextCompletionDataset
- How do I handle images in my custom dataset
- What is the difference base tokenizer and a model tokenizer
- How do I create a custom model tokenizer
- How do I customize a tokenizer's special tokens

...the list goes on. Here, I put up a rough outline of where these concepts should be addressed, so I'm looking for feedback on:
- How/where these topics should go and be organized
- Anything else that I'm missing

I've created a new General Usage category in our sidebar. The intention is for pages under here to serve as a more detailed, casual discussion of our APIs and general concepts. API ref remains for concrete parameter descriptions, tutorials are for e2e workflows, and deep dives are for highly technical investigation into a singular concept. Some of these may belong in tutorials or deep dives, but I would like to push for something in between raw API ref and tutorials that is easy to quickly reference and search.

<img width="245" alt="image" src="https://github.com/user-attachments/assets/c219fd39-f387-4573-8767-b4b38b9e114b">
