### PR TITLE
Exportable pad_max_tiles

### DIFF
--- a/tests/torchtune/models/clip/test_clip_image_transform.py
+++ b/tests/torchtune/models/clip/test_clip_image_transform.py
@@ -37,6 +37,17 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [1.0, 1.0],
                 "expected_tile_min": [0.0, 0.0],
                 "expected_aspect_ratio": [1, 2],
+                "pad_max_tiles": False,
+            },
+            {
+                "image_size": (100, 400, 3),
+                "expected_shape": torch.Size([4, 3, 224, 224]),
+                "resize_to_max_canvas": False,
+                "expected_tile_means": [0.2230, 0.1763, 0.0, 0.0],
+                "expected_tile_max": [1.0, 1.0, 0.0, 0.0],
+                "expected_tile_min": [0.0, 0.0, 0.0, 0.0],
+                "expected_aspect_ratio": [1, 2],
+                "pad_max_tiles": True,
             },
             {
                 "image_size": (1000, 300, 3),
@@ -46,6 +57,7 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [0.9705, 0.9694, 0.9521, 0.9314],
                 "expected_tile_min": [0.0353, 0.0435, 0.0528, 0.0],
                 "expected_aspect_ratio": [4, 1],
+                "pad_max_tiles": False,
             },
             {
                 "image_size": (200, 200, 3),
@@ -55,6 +67,8 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [0.9922, 0.9926, 0.9970, 0.9908],
                 "expected_tile_min": [0.0056, 0.0069, 0.0059, 0.0033],
                 "expected_aspect_ratio": [2, 2],
+                "pad_max_tiles": False,
+                "pad_tiles": 1,
             },
             {
                 "image_size": (600, 200, 3),
@@ -64,6 +78,17 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [1.0, 1.0, 1.0],
                 "expected_tile_min": [0.0, 0.0, 0.0],
                 "expected_aspect_ratio": [3, 1],
+                "pad_max_tiles": False,
+            },
+            {
+                "image_size": (600, 200, 3),
+                "expected_shape": torch.Size([4, 3, 224, 224]),
+                "resize_to_max_canvas": False,
+                "expected_tile_means": [0.4473, 0.4469, 0.3032, 0.0],
+                "expected_tile_max": [1.0, 1.0, 1.0, 0.0],
+                "expected_tile_min": [0.0, 0.0, 0.0, 0.0],
+                "expected_aspect_ratio": [3, 1],
+                "pad_max_tiles": True,
             },
         ],
     )
@@ -78,6 +103,7 @@ class TestCLIPImageTransform:
             resample="bilinear",
             dtype=torch.float32,
             resize_to_max_canvas=params["resize_to_max_canvas"],
+            pad_max_tiles=params["pad_max_tiles"],
         )
 
         image_transform_inference = CLIPImageTransformInference(
@@ -89,6 +115,7 @@ class TestCLIPImageTransform:
             resample="bilinear",
             resize_to_max_canvas=params["resize_to_max_canvas"],
             antialias=True,
+            pad_max_tiles=params["pad_max_tiles"],
         )
 
         # Generate a deterministic image using np.arange for reproducibility
@@ -142,7 +169,13 @@ class TestCLIPImageTransform:
         ), f"Expected aspect ratio {params['expected_aspect_ratio']} but got {tuple(output_ar.numpy())}"
 
         # number of tiles matches the product of the aspect ratio
-        expected_num_tiles = output_ar[0] * output_ar[1]
-        assert (
-            expected_num_tiles == output_image.shape[0]
-        ), f"Expected {expected_num_tiles} tiles but got {output_image.shape[0]}"
+        if params["pad_max_tiles"]:
+            # max_num_tiles=4.
+            assert (
+                4 == output_image.shape[0]
+            ), f"Expected 4 tiles but got {output_image.shape[0]}"
+        else:
+            expected_num_tiles = output_ar[0] * output_ar[1]
+            assert (
+                expected_num_tiles == output_image.shape[0]
+            ), f"Expected {expected_num_tiles} tiles but got {output_image.shape[0]}"

--- a/torchtune/models/clip/inference/_transform.py
+++ b/torchtune/models/clip/inference/_transform.py
@@ -18,6 +18,7 @@ from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (
 from torchtune.modules.transforms.vision_utils.get_inscribed_size import (
     get_inscribed_size,
 )
+from torchtune.modules.transforms.vision_utils.pad_dim_to_size import pad_dim_to_size
 from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop
 
 from torchvision.transforms.v2 import functional as F
@@ -34,6 +35,7 @@ class _CLIPImageTransform(torch.nn.Module):
         tile_size: int,
         max_num_tiles: int,
         antialias: bool,
+        pad_max_tiles: bool = False,
     ):
         super().__init__()
         self.resample = resample
@@ -41,6 +43,7 @@ class _CLIPImageTransform(torch.nn.Module):
         self.image_std = image_std
         self.tile_size = tile_size
         self.max_num_tiles = max_num_tiles
+        self.pad_tile_size = max_num_tiles if pad_max_tiles else None
         self.antialias = antialias
         self.tile_crop = tile_crop
         self.pad = torch.nn.functional.pad
@@ -118,6 +121,9 @@ class _CLIPImageTransform(torch.nn.Module):
         # Reshape.
         tiles = self.tile_crop(output, self.tile_size)
 
+        if self.pad_tile_size:
+            tiles = pad_dim_to_size(tiles, size=self.pad_tile_size, dim=0)
+
         # Calculate aspect ratio.
         aspect_ratio = canvas_size // self.tile_size
 
@@ -175,6 +181,7 @@ class CLIPImageTransform:
             If False, it will pick the resolution that minimizes downscaling, including no downscaling at all.
             In this case, the image will only be upscaled if it's size < tile_size. Default False.
         antialias (bool): Whether to apply antialiasing when resizing the image. Default True.
+        pad_max_tiles (bool): If True, the image will be padded to have tiles == max_num_tiles.
     Examples:
         >>> image_transform = CLIPImageTransform(
         ...    image_mean=None,
@@ -205,6 +212,7 @@ class CLIPImageTransform:
         resample: str = "bilinear",
         resize_to_max_canvas: bool = False,
         antialias: bool = True,
+        pad_max_tiles: bool = False,
     ) -> None:
 
         # get_canvas_best_fit
@@ -250,6 +258,7 @@ class CLIPImageTransform:
             tile_size=self.tile_size,
             max_num_tiles=self.max_num_tiles,
             antialias=self.antialias,
+            pad_max_tiles=pad_max_tiles,
         )
 
     def __call__(self, *, image: Image.Image, **kwargs) -> Mapping[str, Any]:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
Make `pad_max_tiles` exportable. Add tests to CLIP for `pad_max_tiles` = True. 
I can also make these changes specifically for inference if that is preferred.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [x] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
