### PR TITLE
Integrate INT8 mixed-precision from torchao 0.5

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -372,6 +372,11 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             memory_stats = training.get_memory_stats(device=self._device)
             training.log_memory_stats(memory_stats)
 
+        from torchao.prototype.quantized_training import int8_mixed_precision_training
+        from torchao.quantization import quantize_
+
+        quantize_(model.layers, int8_mixed_precision_training())
+
         return model
 
     def _setup_optimizer(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Recent INT8 mixed-precision work in torchao shows very **promising results**.
- Single device A100 -> ~40% speedup
- Single device 4090 -> ~70% speedup (consumer 4000 series GPUs have unusual speedup, which is nice)
- Works with FSDP2 (tested with torchtitan)

**Known major limitations**
- Requires `torch.compile()` to enjoy speedup (to codegen efficient dynamic quantization code)
- Input sizes should not vary too much, since it will trigger autotune for triton INT8 matmul kernel -> this only works well for PackedDataset w/ FlexAttention, since `seq_len` is static.

See https://github.com/pytorch/ao/tree/v0.5.0/torchao/prototype/quantized_training#int8-mixed-precision for more details.

For now, I only added the code to show the necessary changes. I'm open to suggestions on how to expose this in torchtune. One idea from mine:
- Add a global config flag `int8_mixed_precision` (similar to `compile` flag). This will be a boolean
- Handle it inside `_setup_model()` -> repeated code for each recipe

Some concerns:
- It's possible to customize INT8 mixed-precision via `Int8MixedPrecisionTrainingConfig` (see [doc](https://github.com/pytorch/ao/tree/v0.5.0/torchao/prototype/quantized_training#int8-mixed-precision)). Should we expose it to torchtune's users? From my testing, the default config works well. There might be more knobs to customize in the future too.
- Ability to extend to other torchao's subclasses? e.g. Float8 and NF4 (right now they don't use `quantize_()` API, though they can be re-implemented to do so).

These concerns can be addressed in the future I think, when torchao's training subclasses become more mature/stable.

#### Changelog
What are the changes made in this PR?

Integrate INT8 mixed-precision from torchao 0.5

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;

**Llama3.1-8B single device A100** 40% speedup. torch=2.5.0.dev20240911, torchao=0.5.0

> tune run full_finetune_single_device --config llama3_1/8B_full_single_device dataset.packed=True tokenizer.max_seq_len=8192 optimizer=torch.optim.AdamW optimizer.fused=True optimizer_in_bwd=False compile=True metric_logger=torchtune.training.metric_logging.WandBLogger log_peak_memory_stats=True

![Screenshot from 2024-09-12 10-23-02](https://github.com/user-attachments/assets/f6b274f9-6884-4ee7-8f95-adcc52bae845)

(TODO - a small model on 4090 to show 70% speedup)