### PR TITLE
Apply rope on k earlier for efficiency

### DIFF
--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -261,7 +261,7 @@ class MultiHeadAttention(nn.Module):
 
             # Apply positional embeddings
             # k: [b, s_y, n_kv, h_d]
-            k = k.view(b, s_y, self.num_kv_heads, self.head_dim)
+            k = k.view(b, s_y, -1, self.head_dim)
             if self.pos_embeddings is not None:
                 k = self.pos_embeddings(k, input_pos=input_pos)
 
@@ -273,7 +273,7 @@ class MultiHeadAttention(nn.Module):
             k = k.view(b, s_y, self.num_kv_heads, 1, self.head_dim)
             v = v.view(b, s_y, self.num_kv_heads, 1, self.head_dim)
 
-            # Expand the key and value tensors to have the same shape
+            # If needed, expand the key and value tensors to have the same shape
             # as the query tensor by copying values across the relevant dim
             if self.num_heads != self.num_kv_heads:
                 k = k.expand(b, s_y, self.num_kv_heads, q_per_kv, self.head_dim)


### PR DESCRIPTION
#### Context
By performing rotational embeddings early, we can squeeze out a bit more performance. Comparing finetuning statistics on Llama3.1-Instruct 8B w LoRA on GPU (full stats are in the "Appendix" section at the end of this pr description):
- Tokens per second increased from `1246.51852/s` ->`1316.82931/s` (**+70 tokens per second**)
- Loss stayed about the same (`1.48158` -> `1.48607`)
- Peak active memory stayed the same (`18.14733` -> `18.14733`)

#### Changelog
Does rope on an unexpanded k that is still `[b, s_y, n_kv, h_d]` instead of `[b, s_y, n_h, h_d]`.

#### Test plan
- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
No public API changes

#### Appendix
Stats from one epoch of finetuning Llama3.1-Instruct 8B **prior** to this PR:
```
1|25|Loss: 1.481581211090088: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [12:49<00:00, 30.78s/it]
wandb:                                                                                
wandb: 
wandb: Run history:
wandb:               global_step ▁▁▂▂▂▂▃▃▃▄▄▄▅▅▅▅▆▆▆▇▇▇▇██
wandb:                      loss ▆▆▇▇▆▆▇▇▅▇▅▅█▅▆▆▅▅▄▃▃▃▂▂▁
wandb:                        lr ▁▁▂▂▂▂▃▃▃▄▄▄▄▅▅▅▆▆▆▇▇▇▇██
wandb:        peak_memory_active ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:         peak_memory_alloc ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:      peak_memory_reserved ▁▁▃██████████████████████
wandb: tokens_per_second_per_gpu ▄▅▅▅▅▃▂▁▆▃▅█▃▆▁▄▂▅▂▃▄▅▃▂▅
wandb: 
wandb: Run summary:
wandb:               global_step 25
wandb:                      loss 1.48158
wandb:                        lr 7e-05
wandb:        peak_memory_active 18.14733
wandb:         peak_memory_alloc 18.14733
wandb:      peak_memory_reserved 19.43555
wandb: tokens_per_second_per_gpu 1246.51852
wandb: 
wandb: 🚀 View run lilac-puddle-14 at: https://wandb.ai/dvorjackz-meta/torchtune/runs/21e7roul
wandb: ⭐️ View project at: https://wandb.ai/dvorjackz-meta/torchtune
wandb: Synced 5 W&B file(s), 0 media file(s), 2 artifact file(s) and 1 other file(s)
wandb: Find logs at: /tmp/wandb/run-20240916_071220-21e7roul/logs
```

Stats from one epoch of finetuning Llama3.1-Instruct 8B **after** this PR:
```
1|25|Loss: 1.48606538772583: 100%|██████████████████████████████| 25/25 [12:34<00:00, 30.17s/it]
wandb:                                                                                
wandb: 
wandb: Run history:
wandb:               global_step ▁▁▂▂▂▂▃▃▃▄▄▄▅▅▅▅▆▆▆▇▇▇▇██
wandb:                      loss ▆▆▇▆▆▆▇▇▅▇▅▅█▆▆▆▅▅▄▃▃▂▂▂▁
wandb:                        lr ▁▁▂▂▂▂▃▃▃▄▄▄▄▅▅▅▆▆▆▇▇▇▇██
wandb:        peak_memory_active ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:         peak_memory_alloc ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:      peak_memory_reserved ▁▁▃██████████████████████
wandb: tokens_per_second_per_gpu ▅▇▄▆▆▅▅▂▆▄▇█▂▆▂▄▁▄▃▃▄▅▄▄▆
wandb: 
wandb: Run summary:
wandb:               global_step 25
wandb:                      loss 1.48607
wandb:                        lr 7e-05
wandb:        peak_memory_active 18.14733
wandb:         peak_memory_alloc 18.14733
wandb:      peak_memory_reserved 19.43555
wandb: tokens_per_second_per_gpu 1316.82931
wandb: 
wandb: 🚀 View run azure-forest-13 at: https://wandb.ai/dvorjackz-meta/torchtune/runs/uw4eja2j
wandb: ⭐️ View project at: https://wandb.ai/dvorjackz-meta/torchtune
wandb: Synced 4 W&B file(s), 0 media file(s), 3 artifact file(s) and 1 other file(s)
wandb: Find logs at: /tmp/wandb/run-20240916_064527-uw4eja2j/logs
```