### PR TITLE
Expose ``sample`` from generation utils

### DIFF
--- a/docs/source/api_ref_generation.rst
+++ b/docs/source/api_ref_generation.rst
@@ -11,3 +11,4 @@ torchtune.generation
     :nosignatures:
 
     generate
+    sample

--- a/torchtune/generation/__init__.py
+++ b/torchtune/generation/__init__.py
@@ -4,6 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._generation import generate, generate_next_token
+from ._generation import generate, generate_next_token, sample
 
-__all__ = ["generate", "generate_next_token"]
+__all__ = ["generate", "generate_next_token", "sample"]

--- a/torchtune/generation/_generation.py
+++ b/torchtune/generation/_generation.py
@@ -17,9 +17,18 @@ def multinomial_sample_one(probs: torch.Tensor) -> torch.Tensor:
 
 
 def sample(
-    logits: torch.Tensor, temperature: float = 1.0, top_k: int = None
+    logits: torch.Tensor, temperature: float = 1.0, top_k: Optional[int] = None
 ) -> torch.Tensor:
-    """Generic sample from a probability distribution."""
+    """Generic sample from a probability distribution.
+
+    Args:
+        logits (torch.Tensor): logits from which to sample
+        temperature (float): value to scale the predicted logits by, default 1.0.
+        top_k (Optional[int]): If specified, we prune the sampling to only token ids within the top_k probabilities
+
+    Returns:
+        torch.Tensor: sampled token id
+    """
     # scale the logits based on temperature
     logits = logits / max(temperature, 1e-5)
     if top_k is not None:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
* Expose sample in generation/__init__.py
* Update docstring
* Add sample to API ref

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
