### PR TITLE
[DRAFT] Factor out core SDPA

### DIFF
--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -273,7 +273,7 @@ class MultiHeadAttention(nn.Module):
 
             # Update key-value cache
             if self.kv_cache is not None:
-                SDPA.kv_cache_update(input_pos, k, v)
+                self._sdpa.kv_cache_update(input_pos, k, v)
 
-        output = SDPA.sdpa(q, k, v, b, s_x)
+        output = self._sdpa.sdpa(q, k, v, b, s_x)
         return self.output_proj(output)

--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -280,5 +280,5 @@ class MultiHeadAttention(nn.Module):
             if self.kv_cache is not None:
                 self._sdpa.kv_cache_update(input_pos, k, v)
 
-        output = self._sdpa.forward(q, k, v, b, s_x)
+        output = self._sdpa(q, k, v, b, s_x)
         return self.output_proj(output)

--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -143,9 +143,14 @@ class MultiHeadAttention(nn.Module):
         # Use flex attention if supported and we are sample packing
         self._attention_call = _sdpa_or_flex_attention()
         self._sdpa = SDPA(
+            num_kv_heads=self.num_kv_heads,
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            q_per_kv=self.q_per_kv,
+            attn_dropout=self.attn_dropout,
+            is_causal=self.is_causal,
             attention_fn=self._attention_call,
             kv_cache=self.kv_cache,
-            q_per_kv=self.q_per_kv,
         )
 
     def setup_cache(

--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -280,5 +280,5 @@ class MultiHeadAttention(nn.Module):
             if self.kv_cache is not None:
                 self._sdpa.kv_cache_update(input_pos, k, v)
 
-        output = self._sdpa.sdpa(q, k, v, b, s_x)
+        output = self._sdpa.forward(q, k, v, b, s_x)
         return self.output_proj(output)

--- a/torchtune/modules/sdpa.py
+++ b/torchtune/modules/sdpa.py
@@ -12,9 +12,9 @@ from torch import nn, Tensor
 class SDPA(nn.Module):
     """
     The core of SDPA which can be optimized and can be swapped
-    out for a more efficient implemmentations.
-
-    TODO: word the above docstring better.
+    out for a more efficient implementations. Split into
+    kv cache update and core sdpa (foward) components because
+    they are easier to optimize separately.
     """
 
     def __init__(

--- a/torchtune/modules/sdpa.py
+++ b/torchtune/modules/sdpa.py
@@ -67,8 +67,8 @@ class SDPA(nn.Module):
         # Expand the key and value tensors to have the same shape
         # as the query tensor by copying values across the relevant dim
         if self.num_heads != self.num_kv_heads:
-            k = k.expand(bsz, seq_len, self.num_kv_heads, q_per_kv, self.head_dim)
-            v = v.expand(bsz, seq_len, self.num_kv_heads, q_per_kv, self.head_dim)
+            k = k.expand(bsz, seq_len, self.num_kv_heads, self.q_per_kv, self.head_dim)
+            v = v.expand(bsz, seq_len, self.num_kv_heads, self.q_per_kv, self.head_dim)
 
         # [bsz, s, n_h, h_d]
         k = k.reshape(bsz, seq_len, -1, self.head_dim)

--- a/torchtune/modules/sdpa.py
+++ b/torchtune/modules/sdpa.py
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch import nn, Tensor
+
+
+class SDPA(nn.Module):
+    """
+    The core of SDPA which can be optimized and can be swapped
+    out for a more efficient implemmentations.
+
+    TODO: word the above docstring better.
+    """
+
+    def __init__(
+        self,
+        attention_fn,
+        kv_cache,
+        q_per_kv,
+    ) -> None:
+        super().__init__()
+        self._attention_fn = attention_fn
+        self.kv_cache = kv_cache
+        self.q_per_kv = q_per_kv
+
+    def kv_cache_update(
+        self,
+        input_pos: Tensor,
+        k: Tensor,
+        v: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        k, v = self.kv_cache.update(input_pos, k, v)
+        return k, v
+
+    def sdpa(
+        self,
+        q: Tensor,  # [b, s, n_h, h_d]
+        k: Tensor,  # [b, s, n_kv, h_d]
+        v: Tensor,  # [b, s, n_kv, h_d]
+        bsz: int,
+        seq_len: int,
+        mask: Tensor = None,
+    ) -> Tensor:
+        # View + expand + reshape bring num_kv_heads to num_heads for k and v
+        # to match q.
+
+        # k: [bsz, seq_len, n_kv, 1, h_d]
+        # v: [bsz, seq_len, n_kv, 1, h_d]
+        k = k.view(bsz, seq_len, self.num_kv_heads, 1, self.head_dim)
+        v = v.view(bsz, seq_len, self.num_kv_heads, 1, self.head_dim)
+
+        # Expand the key and value tensors to have the same shape
+        # as the query tensor by copying values across the relevant dim
+        if self.num_heads != self.num_kv_heads:
+            k = k.expand(bsz, seq_len, self.num_kv_heads, q_per_kv, self.head_dim)
+            v = v.expand(bsz, seq_len, self.num_kv_heads, q_per_kv, self.head_dim)
+
+        # [bsz, s, n_h, h_d]
+        k = k.reshape(bsz, seq_len, -1, self.head_dim)
+        v = v.reshape(bsz, seq_len, -1, self.head_dim)
+
+        # [bsz, n_h, s, h_d]
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+        output = self._attention_fn(
+            q,
+            k,
+            v,
+            mask=mask,
+            dropout_p=self.attn_dropout,
+            is_causal=self.kv_cache is None and mask is None and self.is_causal,
+        )
+        # Reshape the output to be the same shape as the input
+        return output.transpose(1, 2).contiguous().view(b, s_x, -1)

--- a/torchtune/modules/sdpa.py
+++ b/torchtune/modules/sdpa.py
@@ -47,7 +47,7 @@ class SDPA(nn.Module):
         k, v = self._kv_cache.update(input_pos, k, v)
         return k, v
 
-    def sdpa(
+    def forward(
         self,
         q: Tensor,  # [b, s, n_h, h_d]
         k: Tensor,  # [b, s, n_kv, h_d]


### PR DESCRIPTION
#### Context
This PR factors out the optimizable portions of SDPA (namely the kv cache update, the transpose, the expand, and the actual sdpa). This allows a module containing optimized implementations of the above functionalities to easily be swapped in with the new module via source transformation.

Atm, ET has an optimized SDPA op that does all of the above (kv cache update, transpose, expand, sdpa) that we are hoping to swap in pre-export. cc @kimishpatel.

#### Proof of correctness
### Before change
```
$ tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device max_steps_per_epoch=25  epochs=1 metric_logger=torchtune.training.metric_logging.WandBLogger log_peak_memory_stats=True
.
.
.
1|25|Loss: 1.487076759338379: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [11:27<00:00, 27.49s/it]
wandb:                                                                                
wandb: 
wandb: Run history:
wandb:               global_step ▁▁▂▂▂▂▃▃▃▄▄▄▅▅▅▅▆▆▆▇▇▇▇██
wandb:                      loss ▆▆▇▆▆▆▇▇▅▇▅▅█▅▆▆▅▅▄▃▃▃▂▂▁
wandb:                        lr ▁▁▂▂▂▂▃▃▃▄▄▄▄▅▅▅▆▆▆▇▇▇▇██
wandb:        peak_memory_active ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:         peak_memory_alloc ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:      peak_memory_reserved ▁▁▂██████████████████████
wandb: tokens_per_second_per_gpu ▃▄▃▃▄▃▂▂▆▄▅█▁▅▂▂▂▄▄▃▃▄▃▂▃
wandb: 
wandb: Run summary:
wandb:               global_step 25
wandb:                      loss 1.48708
wandb:                        lr 7e-05
wandb:        peak_memory_active 16.20987
wandb:         peak_memory_alloc 16.20987
wandb:      peak_memory_reserved 18.77148
wandb: tokens_per_second_per_gpu 1313.99555
wandb: 
wandb: 🚀 View run flowing-lion-18 at: https://wandb.ai/dvorjackz-meta/torchtune/runs/imx4iros
wandb: ⭐️ View project at: https://wandb.ai/dvorjackz-meta/torchtune
wandb: Synced 5 W&B file(s), 0 media file(s), 2 artifact file(s) and 1 other file(s)
wandb: Find logs at: /tmp/wandb/run-20240920_154125-imx4iros/logs
```

### After change
We see essentially the exact same loss (slight difference since only trained for one epoch). Interestingly, we also squeeze out ~9% more tokens per gpu after this refactor.
```
# tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device max_steps_per_epoch=25  epochs=1 metric_logger=torchtune.training.metric_logging.WandBLogger log_peak_memory_stats=True
.
.
.
1|25|Loss: 1.480817198753357: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [11:25<00:00, 27.41s/it]
wandb:                                                                                
wandb: 
wandb: Run history:
wandb:               global_step ▁▁▂▂▂▂▃▃▃▄▄▄▅▅▅▅▆▆▆▇▇▇▇██
wandb:                      loss ▆▆▇▇▆▆▇▇▅▇▅▅█▅▆▆▅▅▄▃▃▂▂▂▁
wandb:                        lr ▁▁▂▂▂▂▃▃▃▄▄▄▄▅▅▅▆▆▆▇▇▇▇██
wandb:        peak_memory_active ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:         peak_memory_alloc ▅▆▇█▆█▇▆▄██▆▅▆▁▆▆▇█▄▇▇▃▅▇
wandb:      peak_memory_reserved ▁▁▂██████████████████████
wandb: tokens_per_second_per_gpu ▄▆▆▇▇▃▃▁▆▂▅█▂▄▃▅▃▃▃▃▄▄▃▃▆
wandb: 
wandb: Run summary:
wandb:               global_step 25
wandb:                      loss 1.48082
wandb:                        lr 7e-05
wandb:        peak_memory_active 16.20987
wandb:         peak_memory_alloc 16.20987
wandb:      peak_memory_reserved 18.77148
wandb: tokens_per_second_per_gpu 1434.81084
wandb: 
wandb: 🚀 View run fresh-puddle-17 at: https://wandb.ai/dvorjackz-meta/torchtune/runs/ehh7osgb
wandb: ⭐️ View project at: https://wandb.ai/dvorjackz-meta/torchtune
wandb: Synced 5 W&B file(s), 0 media file(s), 2 artifact file(s) and 1 other file(s)
wandb: Find logs at: /tmp/wandb/run-20240920_152752-ehh7osgb/logs
```

#### Changelog
Factor out inference-optimizable portions of SDPA

#### Test plan
[Pending] Went through a quick export process as sanity check, will do more extensive correctness checking
- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
No public API changes
