### PR TITLE
Support load_dataset kwargs in other dataset builders

### DIFF
--- a/torchtune/datasets/_grammar.py
+++ b/torchtune/datasets/_grammar.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from torchtune.data import InputOutputToMessages
 from torchtune.datasets._packed import PackedDataset

--- a/torchtune/datasets/_grammar.py
+++ b/torchtune/datasets/_grammar.py
@@ -22,6 +22,7 @@ def grammar_dataset(
     new_system_prompt: Optional[str] = None,
     packed: bool = False,
     split: str = "train",
+    **load_dataset_kwargs: Dict[str, Any],
 ) -> Union[SFTDataset, PackedDataset]:
     """
     Support for grammar correction datasets and their variants from Hugging Face Datasets.
@@ -54,6 +55,7 @@ def grammar_dataset(
         packed (bool): Whether or not to pack the dataset to tokenizer's ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Returns:
         Union[SFTDataset, PackedDataset]: dataset configured with source data and template
@@ -78,6 +80,7 @@ def grammar_dataset(
         message_transform=message_transform,
         model_transform=tokenizer,
         split=split,
+        **load_dataset_kwargs,
     )
     if packed:
         if tokenizer.max_seq_len is None:

--- a/torchtune/datasets/_hh_rlhf_helpful.py
+++ b/torchtune/datasets/_hh_rlhf_helpful.py
@@ -19,6 +19,7 @@ def hh_rlhf_helpful_dataset(
     train_on_input: bool = False,
     new_system_prompt: Optional[str] = None,
     split: str = "train",
+    **load_dataset_kwargs: Dict[str, Any],
 ) -> PreferenceDataset:
     """
     Constructs preference datasets similar to `Anthropic's helpful/harmless RLHF
@@ -43,6 +44,7 @@ def hh_rlhf_helpful_dataset(
             any system messages already present in the dataset. Default is None.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Returns:
         PreferenceDataset: The preference dataset built from source paired data.
@@ -59,4 +61,5 @@ def hh_rlhf_helpful_dataset(
         message_transform=message_transform,
         tokenizer=tokenizer,
         split=split,
+        **load_dataset_kwargs,
     )

--- a/torchtune/datasets/_hh_rlhf_helpful.py
+++ b/torchtune/datasets/_hh_rlhf_helpful.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from torchtune.data import ChosenRejectedToMessages
 from torchtune.datasets._preference import PreferenceDataset

--- a/torchtune/datasets/_samsum.py
+++ b/torchtune/datasets/_samsum.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from torchtune.data import InputOutputToMessages
 from torchtune.datasets._packed import PackedDataset

--- a/torchtune/datasets/_samsum.py
+++ b/torchtune/datasets/_samsum.py
@@ -22,6 +22,7 @@ def samsum_dataset(
     new_system_prompt: Optional[str] = None,
     packed: bool = False,
     split: str = "train",
+    **load_dataset_kwargs: Dict[str, Any],
 ) -> Union[SFTDataset, PackedDataset]:
     """
     Support for summarization datasets and their variants from Hugging Face Datasets.
@@ -54,6 +55,7 @@ def samsum_dataset(
         packed (bool): Whether or not to pack the dataset to tokenizer's ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Returns:
         Union[SFTDataset, PackedDataset]: dataset configured with source data and template
@@ -79,6 +81,7 @@ def samsum_dataset(
         message_transform=message_transform,
         model_transform=tokenizer,
         split=split,
+        **load_dataset_kwargs,
     )
     if packed:
         if tokenizer.max_seq_len is None:

--- a/torchtune/datasets/_slimorca.py
+++ b/torchtune/datasets/_slimorca.py
@@ -22,6 +22,7 @@ def slimorca_dataset(
     new_system_prompt: Optional[str] = None,
     packed: bool = False,
     split: str = "train",
+    **load_dataset_kwargs: Dict[str, Any],
 ) -> Union[SFTDataset, PackedDataset]:
     """
     Support for `SlimOrca-style <https://huggingface.co/datasets/Open-Orca/SlimOrca-Dedup>`_
@@ -51,6 +52,7 @@ def slimorca_dataset(
         packed (bool): Whether or not to pack the dataset to tokenizer's ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Returns:
         Union[SFTDataset, PackedDataset]: dataset configured with SlimOrca source data
@@ -78,6 +80,7 @@ def slimorca_dataset(
         message_transform=message_transform,
         model_transform=tokenizer,
         split=split,
+        **load_dataset_kwargs,
     )
     if packed:
         if tokenizer.max_seq_len is None:

--- a/torchtune/datasets/_slimorca.py
+++ b/torchtune/datasets/_slimorca.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from torchtune.data import ShareGPTToMessages
 from torchtune.datasets._packed import PackedDataset

--- a/torchtune/datasets/_stack_exchange_paired.py
+++ b/torchtune/datasets/_stack_exchange_paired.py
@@ -79,6 +79,7 @@ def stack_exchange_paired_dataset(
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
     split: str = "train",
+    **load_dataset_kwargs: Dict[str, Any],
 ) -> PreferenceDataset:
     """
     Family of preference datasets similar to the `Stack Exchange Paired dataset
@@ -101,6 +102,7 @@ def stack_exchange_paired_dataset(
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
     Returns:
         PreferenceDataset: The preference dataset built from source paired data.
@@ -122,4 +124,5 @@ def stack_exchange_paired_dataset(
         tokenizer=tokenizer,
         split=split,
         data_dir="data/rl",
+        **load_dataset_kwargs,
     )


### PR DESCRIPTION
Some of our dataset classes (e.g. `grammar_dataset` require passing `trust_remote_code=True` to HF's `load_dataset` function. We have `**load_dataset_kwargs` in our different dataset classes for this, but don't actually expose it in all of our builders. This PR bubbles it up to Grammar, HH-RLHF-Helpful, SAMsum, SlimOrca, and Stack Exchange Paired builders