### PR TITLE
Update QAT recipe docs for v0.3.0

### DIFF
--- a/docs/source/recipes/qat_distributed.rst
+++ b/docs/source/recipes/qat_distributed.rst
@@ -8,20 +8,11 @@ QAT allows for taking advantage of memory-saving optimizations from quantization
 degrading model performance. In torchtune, we use `torchao <https://github.com/pytorch/ao>`_ to implement QAT.
 This works by :ref:`simulating quantization numerics during fine-tuning <what_is_qat_label>`. While this may introduce memory and
 compute overheads during training, our tests found that QAT significantly reduced performance degradation in evaluations of
-quantized model, without compromising on model size reduction gains.
-
-.. note::
-
-  The `PyTorch blogpost <https://pytorch.org/blog/quantization-aware-training/>`_ on QAT provides further insight into how QAT works.
-
+quantized model, without compromising on model size reduction gains. Please see the `PyTorch blogpost <https://pytorch.org/blog/quantization-aware-training/>`_
+on QAT for a deeper dive on how the technique works.
 
 We provide pre-tested out-of-the-box configs which you can get up and running with the latest `Llama models <https://llama.meta.com/>`_
 in just two steps:
-
-.. note::
-
-    You may need to be granted access to the Llama model you're interested in. See
-    :ref:`here <download_llama_label>` for details on accessing gated repositories.
 
 .. code-block:: bash
 
@@ -34,8 +25,9 @@ in just two steps:
     --config llama3/8B_qat_full
 
 .. note::
-  This workload requires at least 6 GPUs, each with VRAM of at least 80GB.
-
+  You may need to be granted access to the Llama model you're interested in. See
+  :ref:`here <download_llama_label>` for details on accessing gated repositories.
+  Also, this workload requires at least 6 GPUs, each with VRAM of at least 80GB e.g. A100s or H100s.
 
 Currently, the main lever you can pull for QAT is by using *delayed fake quantization*.
 Delayed fake quantization allows for control over the step after which fake quantization occurs.


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
* Update QAT recipe docs for v0.3.0*

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
