### PR TITLE
Fixes for MM Masking and Collation

### DIFF
--- a/torchtune/data/_collate.py
+++ b/torchtune/data/_collate.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -223,6 +223,7 @@ def padded_collate_tiled_images_and_mask(
     padding_idx: int = 0,
     ignore_idx: int = CROSS_ENTROPY_IGNORE_IDX,
     pad_direction: str = "right",
+    pad_max_images: Optional[int] = None,
 ) -> Dict[str, torch.Tensor]:
     """Pad a batch of text sequences, tiled image tensors, aspect ratios,
     and cross attention masks. This can be used for both training and inference.
@@ -254,6 +255,8 @@ def padded_collate_tiled_images_and_mask(
             :func:`torch.nn.utils.rnn.pad_sequence`, otherwise if ``pad_direction="left"``,
             we use :func:`torchtune.data.left_pad_sequence`. For training, we typically want to pad from the right.
             For inference, we typically want to pad from the left. Defaults to "right".
+        pad_max_images (Optional[int]): Maximum number of images to pad to. If None, will pad to the largest number of images
+            in the batch. Defaults to None.
 
     Returns:
         Dict[str, Tensor]: Collated tokens, labels, images, encoder_mask, aspect_ratio tensors.
@@ -365,14 +368,28 @@ def padded_collate_tiled_images_and_mask(
             text_seq_len, image_seq_len = mask.shape
             tokens_per_tile = image_seq_len // n_tiles
             padding_tiles = max_num_tiles - n_tiles
-            padding_text = max_seq_len - text_seq_len
+            right_padding_text = (
+                max_seq_len - text_seq_len if pad_direction == "right" else 0
+            )
+            left_padding_text = (
+                max_seq_len - text_seq_len if pad_direction == "left" else 0
+            )
+
             # Image should now have shape (max_num_tiles, c, h, w)
             padded_image = F.pad(image, (0, 0, 0, 0, 0, 0, 0, padding_tiles), value=0)
             # Mask should now have shape (max_seq_len, max_image_seq_len), where
             # max_image_seq_len = max_num_tiles * tokens_per_tile
             padded_mask = F.pad(
-                mask, (0, padding_tiles * tokens_per_tile, 0, padding_text), value=0
+                mask,
+                (
+                    0,
+                    padding_tiles * tokens_per_tile,
+                    left_padding_text,
+                    right_padding_text,
+                ),
+                value=0,
             )
+
             sample_images.append(padded_image)
             sample_masks.append(padded_mask)
         # Stack multiple images and masks per sample in num_images dimension
@@ -391,6 +408,11 @@ def padded_collate_tiled_images_and_mask(
 
     # Concatenate masks for multiple images across image_seq_len dimension
     concat_masks = collated_masks.view(bsz, max_seq_len, -1)
+    if pad_max_images is not None:
+        _, _, img_seq = concat_masks.shape
+        concat_masks = F.pad(
+            concat_masks, (0, pad_max_images * image_seq_len - img_seq)
+        )
 
     batch_dict = {
         "tokens": collated_text["tokens"],

--- a/torchtune/models/flamingo/_transform.py
+++ b/torchtune/models/flamingo/_transform.py
@@ -40,7 +40,6 @@ class FlamingoTransform(ModelTokenizer, Transform):
             Llama3 special tokens.
         max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
             after which the input will be truncated. Default is None.
-        encoder_max_seq_len (Optional[int]): maximum sequence length for the encoder input. Default is None.
         image_mean (Optional[Tuple[float, float, float]]): Mean values of each channel, used for normalization.
         image_std (Optional[Tuple[float, float, float]]): Standard deviations for each channel, used for normalization.
         prompt_template (Optional[PromptTemplate]): template used to format the messages based on their role. This is used
@@ -71,7 +70,6 @@ class FlamingoTransform(ModelTokenizer, Transform):
         max_num_tiles: int = 4,
         special_tokens: Optional[Dict[str, int]] = None,
         max_seq_len: Optional[int] = None,
-        encoder_max_seq_len: Optional[int] = None,
         image_mean: Optional[Tuple[float, float, float]] = None,
         image_std: Optional[Tuple[float, float, float]] = None,
         prompt_template: Optional[PromptTemplate] = None,
@@ -96,7 +94,7 @@ class FlamingoTransform(ModelTokenizer, Transform):
             tile_size=tile_size,
             patch_size=patch_size,
             image_token_id=self.tokenizer.image_id,
-            encoder_max_seq_len=encoder_max_seq_len,
+            max_num_tiles=max_num_tiles,
         )
 
         self.stop_tokens = self.tokenizer.stop_tokens


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Several bug fixes here:
- left padding needs to pad encoder_mask on the left
- encoder_mask transform max size is based on max_num_tiles not encoder_max_seq_len
- collate needs to support optional pad_max_images for when a kv_cache with a fixed size is set.

#### Changelog
transforms.py and _collate.py along with tests updated

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
