### PR TITLE
Set max cache seq len in generate recipe

### DIFF
--- a/recipes/configs/generation.yaml
+++ b/recipes/configs/generation.yaml
@@ -35,7 +35,7 @@ chat_format: null
 max_new_tokens: 300
 temperature: 0.6 # 0.8 and 0.6 are popular values to try
 top_k: 300
-# It is recommended to set enable_kv_cache=False for long-context models like Llama3.1
+
 enable_kv_cache: True
 
 quantizer: null

--- a/recipes/generate.py
+++ b/recipes/generate.py
@@ -55,9 +55,9 @@ class InferenceRecipe:
         self._model = self._setup_model(
             model_cfg=cfg.model,
             model_state_dict=ckpt_dict[training.MODEL_KEY],
-            enable_kv_cache=cfg.enable_kv_cache,
         )
         self._tokenizer = config.instantiate(cfg.tokenizer)
+        self._enable_kv_cache = cfg.enable_kv_cache
 
     def _setup_model(
         self,
@@ -79,11 +79,6 @@ class InferenceRecipe:
             model.named_parameters(), dtype=self._dtype
         )
         logger.info(f"Model is initialized with precision {self._dtype}.")
-
-        # Ensure the cache is setup on the right device
-        if enable_kv_cache:
-            with self._device:
-                model.setup_caches(batch_size=1, dtype=self._dtype)
 
         return model
 
@@ -142,6 +137,15 @@ class InferenceRecipe:
 
         custom_generate_next_token = None
 
+        # Ensure the cache is setup on the right device, with only as many tokens as we need
+        if cfg.enable_kv_cache:
+            with self._device:
+                self._.setup_caches(
+                    batch_size=1,
+                    dtype=self._dtype,
+                    decoder_max_seq_len=prompt.numel() + cfg.max_new_tokens,
+                )
+
         # since quantized model uses torch.compile to get speedup, it needs a warm up / prefill run
         # to get the accurate performance measurement
         if self._quantization_mode is not None:
@@ -161,6 +165,7 @@ class InferenceRecipe:
             )
             t = time.perf_counter() - t0
             logger.info(f"Warmup run for quantized model takes: {t:.02f} sec")
+            self._model.reset_caches()
 
         t0 = time.perf_counter()
         generated_tokens, _ = generation.generate(

--- a/recipes/generate.py
+++ b/recipes/generate.py
@@ -57,7 +57,6 @@ class InferenceRecipe:
             model_state_dict=ckpt_dict[training.MODEL_KEY],
         )
         self._tokenizer = config.instantiate(cfg.tokenizer)
-        self._enable_kv_cache = cfg.enable_kv_cache
 
     def _setup_model(
         self,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#1581 

#### Changelog

We only need a cache size of `prompt_len + max_generated_tokens` for the generate recipe. This utilizes #1449 to significantly reduce unnecessary memory consumption.


Tested on a 4090 with Llama3.1 8B:
On this branch 
```bash
INFO:torchtune.utils._logging:Time for inference: 4.57 sec total, 25.39 tokens/sec
INFO:torchtune.utils._logging:Bandwidth achieved: 413.58 GB/s
INFO:torchtune.utils._logging:Memory used: 16.43 GB
```
on main:
```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1024.00 MiB. GPU 0 has a total capacity of 23.64 GiB of which 62.81 MiB is free. 
Process 539192 has 23.57 GiB memory in use. Of the allocated memory 23.02 GiB is allocated by PyTorch, and 121.49 MiB is reserved by PyTorch but unallocated. 
If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
```

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.)

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Example of docstring: https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285
Example in our docs: https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models

- [ ] I did not change any public API;
- [ ] I have added an example to docs or docstrings;
