### PR TITLE
Fix tune run not identifying custom components

### DIFF
--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import os
 import runpy
 import sys
 import textwrap
@@ -166,6 +167,11 @@ For a list of all possible recipes, run `tune ls`."""
         # Prepare args
         args.recipe = recipe_path
         args.recipe_args[config_idx] = config_path
+
+        # Make sure user code in current directory is importable
+        # TODO: This is a temporary fix, figure out how to make runpy and torchrun
+        # run from this directory
+        sys.path.append(os.getcwd())
 
         # Execute recipe
         if self._is_distributed_args(args):


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Closes #1540 

#### Test plan
Tested by creating a custom dataset builder and instantiating it in the config:
```
dataset:
  _component_: tune.dataset.custom_dataset
```
Then calling tune run with the fix, it was able to identify the custom component. Only works for single device, still figuring out with distributed doesn't work.