### PR TITLE
Fix kv-cacheing and bsz > 1 in eval recipe

### DIFF
--- a/recipes/configs/eleuther_evaluation.yaml
+++ b/recipes/configs/eleuther_evaluation.yaml
@@ -33,7 +33,6 @@ tasks: ["truthfulqa_mc2"]
 limit: null
 max_seq_length: 4096
 batch_size: 8
-# It is recommended to set enable_kv_cache=False for long-context models like Llama3.1
 enable_kv_cache: True
 
 # Quantization specific args

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -123,6 +123,11 @@ class _EvalWrapper(HFLM):
         self, context: torch.Tensor, **generation_kwargs
     ) -> torch.Tensor:
         curr_batch_size = context.size(0)
+
+        # if we've recieved fewer than self._batch_size samples in the current
+        # batch we need to pad the batch out. here we're padding the end of the
+        # current batch to the correct length. this is because when we use static
+        # KV-caches, the model will expect a fixed batch size for all samples.
         maybe_padded_context = torch.nn.functional.pad(
             context,
             (0, 0, 0, self._batch_size - curr_batch_size),

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -131,7 +131,7 @@ class _EvalWrapper(HFLM):
         maybe_padded_context = torch.nn.functional.pad(
             context,
             (0, 0, 0, self._batch_size - curr_batch_size),
-            value=self._tokenizer.eos_id,
+            value=self._tokenizer.eos_id,  # pad with one of the tokenizer's stop tokens so generation can stop early
         )
 
         temperature = generation_kwargs.get("temperature", 0.0)

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -24,7 +24,7 @@ class TestEleutherEval:
         [
             ("truthfulqa_gen", 0.1, 8),
             ("truthfulqa_gen", 0.1, 1),
-            ("truthfulqa_mc2", 0.3, 8),
+            ("truthfulqa_mc2", 0.4, 8),
         ],
     )
     @pytest.mark.integration_test
@@ -67,18 +67,17 @@ class TestEleutherEval:
         # v0.4.2 format
         # |    Tasks     |Version|Filter|n-shot|Metric|Value |   |Stderr|
         # |--------------|------:|------|-----:|------|-----:|---|-----:|
-        # |truthfulqa_mc2|      2|none  |     0|acc   |0.3469|±  |0.1444|
+        # |truthfulqa_mc2|      2|none  |     0|acc   |0.4497|±  |0.1067|
 
         # v0.4.3 format
         # |    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
         # |--------------|------:|------|-----:|------|---|-----:|---|-----:|
-        # |truthfulqa_mc2|      2|none  |     0|acc   |↑  |0.3469|±  |0.1444|
+        # |truthfulqa_mc2|      2|none  |     0|acc   |↑  |0.4497|±  |0.1067|
 
         # The below RegEx command will pick up both formats
         search_results = re.search(
             r"acc(?:_norm)?\s*\|?\s*(?:\↑\s*\|?)?([\d.]+)", out.strip()
         )
-
         assert search_results is not None
         acc_result = float(search_results.group(1))
         assert math.isclose(acc_result, expected_acc, abs_tol=0.05)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
closes #1600

#### Changelog
What are the changes made in this PR?
* The eval harness will return `batch_size` specified prompts until the last batch, where it will return a smaller number of samples.
* This breaks our static KV-cacheing which is only setup for a single batch size. 
* To address this, we can manually pad out batches, and then remove the padded samples after generation.
* This could be wasteful for large batch sizes, and where the last batch may be mostly empty. We can kind of mitigate this by padding out with `self._tokenizer.eos_id` so we correctly trigger early stopping in generation.
* Expected test values are changed because `limit` has changed.

* Since swapping between KV-cacheing-inference and regular inference isn't supported yet, I've guarded against using generation tasks with non-generation tasks. This will be addressed in a follow up.
* I've also moved setup cache logic outside of `_model_generate` - it only needs to be called once if we're expecting a generation task.

Thanks to @baberabb for the advice here.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
