### PR TITLE
Fix compile error in `get_causal_mask_from_padding_mask`

### DIFF
--- a/torchtune/generation/_generation.py
+++ b/torchtune/generation/_generation.py
@@ -147,7 +147,7 @@ def get_causal_mask_from_padding_mask(
         diagonal=0,
     ).repeat(bsz, 1, 1)
     mask.narrow(2, 0, seq_len).mul_(padding_mask[:, None, :].expand(-1, seq_len, -1))
-    mask.diagonal(dim1=1, dim2=2).copy_(True)
+    mask.diagonal(dim1=1, dim2=2).copy_(torch.Tensor([True]))
     return mask
 
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)


#### Changelog
What are the changes made in this PR?

Fixing a compile bug in `get_causal_mask_from_padding_mask`.

Repro on main
```python
import torch
from torchtune.generation import get_causal_mask_from_padding_mask
get_causal_mask_from_padding_mask = torch.compile(get_causal_mask_from_padding_mask, fullgraph=True, backend="aot_eager")
get_causal_mask_from_padding_mask(torch.ones((10)).unsqueeze(0).bool())
```
```bash
torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
RuntimeError: aten::copy() Expected a value of type 'Tensor' for argument 'src' but instead found type 'bool'.
Position: 1
Value: True
Declaration: aten::copy(Tensor self, Tensor src, bool non_blocking=False) -> Tensor
Cast error details: Unable to cast True to Tensor

While executing %copy_ : [num_users=0] = call_method[target=copy_](args = (%diagonal, True), kwargs = {})
Original traceback:
  File "/Users/salmanmohammadi/projects/torchtune/torchtune/generation/_generation.py", line 150, in get_causal_mask_from_padding_mask
    mask.diagonal(dim1=1, dim2=2).copy_(True)


Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True
```

This error does not occur on this branch.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
