### PR TITLE
Make ``q`` optional in ``sample``

### DIFF
--- a/tests/torchtune/generation/test_generation.py
+++ b/tests/torchtune/generation/test_generation.py
@@ -224,7 +224,7 @@ class TestGenerate:
         q = torch.empty(
             (1, 2000),
         ).exponential_(1)
-        token = sample(logits, q, temperature=1, top_k=1)
+        token = sample(logits, temperature=1, top_k=1, q=q)
         assert token.item() == 100
 
     @pytest.mark.parametrize(

--- a/tests/torchtune/generation/test_generation.py
+++ b/tests/torchtune/generation/test_generation.py
@@ -221,10 +221,7 @@ class TestGenerate:
         # set all probabilities except for token_id=100 to 0
         logits = torch.zeros(2000)
         logits[100] = 1
-        q = torch.empty(
-            (1, 2000),
-        ).exponential_(1)
-        token = sample(logits, temperature=1, top_k=1, q=q)
+        token = sample(logits, top_k=1)
         assert token.item() == 100
 
     @pytest.mark.parametrize(

--- a/torchtune/generation/_generation.py
+++ b/torchtune/generation/_generation.py
@@ -101,7 +101,7 @@ def generate_next_token(
     # we want to take the last token's logits as the input to the next model call
     logits = model(x, input_pos=input_pos, mask=mask)
     return (
-        sample(logits[:, -1].clone(), q, temperature=temperature, top_k=top_k),
+        sample(logits[:, -1].clone(), temperature=temperature, top_k=top_k, q=q),
         logits,
     )
 

--- a/torchtune/generation/_generation.py
+++ b/torchtune/generation/_generation.py
@@ -17,18 +17,20 @@ def multinomial_sample_one(probs: torch.Tensor, q: torch.Tensor) -> torch.Tensor
 
 def sample(
     logits: torch.Tensor,
-    q: torch.Tensor,
     *,
     temperature: float = 1.0,
     top_k: Optional[int] = None,
+    q: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Generic sample from a probability distribution.
+    """Generic sample from a probability distribution. Includes support for Top-K sampling
+    and Temperature.
 
     Args:
         logits (torch.Tensor): logits from which to sample
-        q (torch.Tensor): randomly sampled tensor for softmax sampling trick.
         temperature (float): value to scale the predicted logits by, default 1.0.
         top_k (Optional[int]): If specified, we prune the sampling to only token ids within the top_k probabilities
+        q (Optional[torch.Tensor]): randomly sampled tensor for softmax sampling trick. Default None.
+            If None, we use the default softmax sampling trick.
 
     Returns:
         torch.Tensor: sampled token id
@@ -42,8 +44,14 @@ def sample(
         # set everything smaller than pivot value to inf since these
         # should be pruned
         logits = torch.where(logits < pivot, -float("Inf"), logits)
+
     # change logits into probabilities
     probs = torch.nn.functional.softmax(logits, dim=-1)
+
+    # if q is None, we use the default softmax sampling trick
+    if q is None:
+        q = torch.empty_like(probs).exponential_(1).to(device=probs.device)
+
     return multinomial_sample_one(probs, q)
 
 

--- a/torchtune/generation/_generation.py
+++ b/torchtune/generation/_generation.py
@@ -50,7 +50,7 @@ def sample(
 
     # if q is None, we use the default softmax sampling trick
     if q is None:
-        q = torch.empty_like(probs).exponential_(1).to(device=probs.device)
+        q = torch.empty_like(probs).exponential_(1)
 
     return multinomial_sample_one(probs, q)
 

--- a/torchtune/generation/_generation.py
+++ b/torchtune/generation/_generation.py
@@ -29,8 +29,16 @@ def sample(
         logits (torch.Tensor): logits from which to sample
         temperature (float): value to scale the predicted logits by, default 1.0.
         top_k (Optional[int]): If specified, we prune the sampling to only token ids within the top_k probabilities
-        q (Optional[torch.Tensor]): randomly sampled tensor for softmax sampling trick. Default None.
-            If None, we use the default softmax sampling trick.
+        q (Optional[torch.Tensor]): randomly sampled tensor for softmax sampling trick. If None,
+            we use the default softmax sampling trick. Default None.
+
+    Example:
+        >>> from torchtune.generation import sample
+        >>> logits = torch.empty(3, 3).uniform_(0, 1)
+        >>> sample(logits)
+        tensor([[1],
+                [2],
+                [0]], dtype=torch.int32)
 
     Returns:
         torch.Tensor: sampled token id


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

User should not have to specify ``q`` in order to use the ``sample`` method. Therefore, we can provide the default. 

TODO: Look into whether setting the RNG is actually necessary or if a global Generator works fine, too.

#### Changelog
* Set default for ``q``

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

```
>>> from torchtune.generation import sample
>>> import torch
>>> compiled_sample = torch.compile(sample, fullgraph=True, backend="aot_eager")
>>> logits = torch.empty(3, 3).uniform_(0, 1)
>>> compiled_sample(logits)
tensor([[1],
        [2],
        [0]], dtype=torch.int32)
>>> sample(logits)
tensor([[1],
        [2],
        [0]], dtype=torch.int32)
```

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x] I have added an example to docs or docstrings
