### PR TITLE
add BlockMask to batch_to_device

### DIFF
--- a/torchtune/modules/attention_utils.py
+++ b/torchtune/modules/attention_utils.py
@@ -10,17 +10,10 @@ from typing import Callable, List, Optional, Union
 import torch
 
 from torch import nn
+from torchtune.utils._import_guard import _SUPPORTS_FLEX_ATTENTION
 from torchtune.utils._logging import get_logger, log_once
-from torchtune.utils._version import torch_version_ge
 
 _log: logging.Logger = get_logger()
-
-# We can only use flex attention / BlockMask if torch version >= 2.5.0 and GPU is Turing / SM75 and above
-_SUPPORTS_FLEX_ATTENTION = (
-    torch_version_ge("2.5.0")
-    and torch.cuda.is_available()
-    and torch.cuda.get_device_capability() >= (7, 5)
-)
 
 if _SUPPORTS_FLEX_ATTENTION:
     from torch.nn.attention.flex_attention import (

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -154,5 +154,5 @@ def batch_to_device(batch: dict, device: torch.device) -> None:
         else:
             raise ValueError(
                 f"""To use batch_to_device, all elements in the batch must be a dict or Tensor.
-Got key {k} with value {v} of type {type(v)}"""
+Got key "{k}" with value of type {type(v)}"""
             )

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -9,6 +9,13 @@ from typing import Optional
 
 import torch
 
+from torchtune.utils._import_guard import _SUPPORTS_FLEX_ATTENTION
+
+if _SUPPORTS_FLEX_ATTENTION:
+    from torch.nn.attention.flex_attention import BlockMask
+else:
+    BlockMask = torch.Tensor
+
 
 def _get_local_rank() -> Optional[int]:
     """Function that gets the local rank from the environment.
@@ -142,7 +149,10 @@ def batch_to_device(batch: dict, device: torch.device) -> None:
             batch_to_device(v, device)
         elif isinstance(v, torch.Tensor):
             batch[k] = v.to(device)
+        elif _SUPPORTS_FLEX_ATTENTION and isinstance(v, BlockMask):
+            batch[k] = v.to(device)
         else:
             raise ValueError(
-                "To use batch_to_device, all elements in the batch must be a dict or Tensor"
+                f"""To use batch_to_device, all elements in the batch must be a dict or Tensor.
+Got key {k} with value {v} of type {type(v)}"""
             )

--- a/torchtune/utils/_import_guard.py
+++ b/torchtune/utils/_import_guard.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torchtune.utils._version import torch_version_ge
+
+# We can only use flex attention / BlockMask if torch version >= 2.5.0 and GPU is Turing / SM75 and above
+_SUPPORTS_FLEX_ATTENTION = (
+    torch_version_ge("2.5.0")
+    and torch.cuda.is_available()
+    and torch.cuda.get_device_capability() >= (7, 5)
+)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

batch_to_device only checks dict and tensors. When input is BlockMask (packed=True), it triggers the RaiseError condition.

#### Changelog

- Improve error message
- Add BlockMask as one of the isinstance checks
- Add file _import_guard.py to check for flex attention, since we have two different files checking it, and we should have only one source of truth

#### Test plan

After this PR, the code below runs well
`tune run full_finetune_single_device --config llama3_1/8B_full_single_device dataset.packed=True tokenizer.max_seq_len=4096`

If I remove the check for BlockMask, the error message is improved:
```
ValueError: To use batch_to_device, all elements in the batch must be a dict or Tensor.
Got key "mask" with value of type <class 'torch.nn.attention.flex_attention.BlockMask'>
```
