### PR TITLE
add drop_last to dataloader

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -507,6 +507,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             sampler=sampler,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=partial(
                 collate_fn,
                 padding_idx=self._tokenizer.pad_id,

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -461,6 +461,8 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             sampler=sampler,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=partial(
                 collate_fn,
                 padding_idx=self._tokenizer.pad_id,

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -531,6 +531,8 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             sampler=sampler,
             batch_size=batch_size,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=(
                 partial(
                     padded_collate_sft,

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -474,6 +474,8 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             sampler=sampler,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=partial(
                 padded_collate_dpo,
                 padding_idx=self._tokenizer.pad_id,

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -369,6 +369,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             sampler=sampler,
             batch_size=batch_size,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=partial(
                 padded_collate_dpo,
                 padding_idx=self._tokenizer.pad_id,

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -562,6 +562,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             sampler=sampler,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=partial(
                 padded_collate_sft,
                 padding_idx=self._tokenizer.pad_id,

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -530,6 +530,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             sampler=sampler,
             batch_size=batch_size,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=(
                 partial(
                     padded_collate_sft,

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -579,6 +579,8 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             sampler=sampler,
             batch_size=batch_size,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=partial(
                 padded_collate,
                 pad_direction="left",

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -587,7 +587,6 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 keys_to_pad=["tokens", "labels"],
                 padding_idx=self._tokenizer.pad_id,
             ),
-            drop_last=True,
         )
 
         return sampler, dataloader

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -523,6 +523,8 @@ class QATRecipeDistributed(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             sampler=sampler,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=cfg_dataset.get("drop_last", True),
             collate_fn=partial(
                 padded_collate_sft,
                 padding_idx=self._tokenizer.pad_id,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

flex_attention + compile break if the last batch size has a different shape. This PR adds drop_last, which only drops the last batch IF the batch size is not divisible by number of steps.

#### Test plan
```
tune run --nnodes 1 --nproc_per_node 2 full_finetune_distributed --config qwen2/0.5B_full max_steps_per_epoch=5
```

#### reproducing the bug

error log: https://www.internalfb.com/phabricator/paste/view/P1605485255

tune run --nproc_per_node 2 full_finetune_distributed --config llama3_1/8B_full enable_activation_checkpointing=False fsdp_cpu_offload=False compile=True dataset.packed=True dataset.split=train[:20%] tokenizer.max_seq_len=4096 metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=profiling metric_logger.tags=[my_experiment_name] log_every_n_steps=1 log_peak_memory_stats=True gradient_accumulation_steps=1 max_steps_per_epoch=40 epochs=1 batch_size=4 enable_activation_checkpointing=True

torch                     2.6.0.dev20240922+cu121
torchao                   0.6.0.dev20240922+cu121
torchtune                 0.0.0                    /data/users/felipemello/torchtune
torchvision               0.20.0.dev20240922+cu121

this happens in the very last batch. All other batches have shape:
tokens shape torch.Size([4, 4096])
labels shape torch.Size([4, 4096])
mask (4, 1, 4096, 4096)
input_pos torch.Size([4, 4096])

But the last batch has shape:
tokens shape torch.Size([2, 4096])
labels shape torch.Size([2, 4096])
mask (2, 1, 4096, 4096)
input_pos torch.Size([2, 4096])

adding drop_last=True to the dataloader solves it
