### PR TITLE
Fix llava_instruct_dataset

### DIFF
--- a/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
+++ b/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
@@ -31,12 +31,8 @@ class TestLLaVAInstructDataset:
 
     @patch("torchtune.datasets._sft.load_dataset")
     @patch("torchtune.datasets.multimodal._llava_instruct.load_image")
-    def test_label_no_masking(
-        self, load_image, load_dataset, tokenizer, test_image_pil
-    ):
+    def test_get_item(self, load_image, load_dataset, tokenizer, test_image_pil):
         """
-        Test whether the input and the labels are correctly created when the input is not masked.
-
         WARNING: careful with these mocks, they are applied in bottom up order
         """
         # mock the call to load_image
@@ -68,71 +64,8 @@ class TestLLaVAInstructDataset:
 
         ds = llava_instruct_dataset(
             model_transform=tokenizer,
-            train_on_input=True,
         )
 
-        input, labels, images = ds[0]["tokens"], ds[0]["labels"], ds[0]["images"]
-
-        expected_count = {
-            3: 17,
-            2: 15,
-            4: 11,
-            8: 9,
-            5: 8,
-            7: 8,
-            6: 5,
-            1: 5,
-            9: 2,
-            0: 1,
-            -2: 1,
-            12: 1,
-            10: 1,
-            -1: 1,
-        }
-
-        assert Counter(input) == expected_count
-        assert Counter(labels) == expected_count
-        assert images == [test_image_pil]
-
-    @patch("torchtune.datasets._sft.load_dataset")
-    @patch("torchtune.datasets.multimodal._llava_instruct.load_image")
-    def test_label_masking(self, load_image, load_dataset, tokenizer, test_image_pil):
-        """
-        Test whether the input and the labels are correctly created when the input is masked.
-
-        WARNING: careful with these mocks, they are applied in bottom up order
-        """
-        # mock the call to load_image
-        load_image.return_value = test_image_pil
-
-        # mock the call to HF datasets
-        load_dataset.return_value = Dataset.from_list(
-            [
-                {
-                    "image": "test_image.jpg",
-                    "conversations": [
-                        {
-                            "from": "human",
-                            "value": "<image>\nWhat can you infer about the man's outdoor activity?",
-                        },
-                        {
-                            "from": "gpt",
-                            "value": "From the image, we can infer that the man is engaging in a "
-                            "recreational activity involving a frisbee in a park or grass field. "
-                            "The frisbee is in the air, and the man appears to be either catching "
-                            "or throwing it. This suggests that he might be playing a casual game "
-                            "of catch with a friend or practicing his frisbee skills, enjoying the "
-                            "outdoors and getting some physical activity at the same time.",
-                        },
-                    ],
-                }
-            ]
-        )
-
-        ds = llava_instruct_dataset(
-            model_transform=tokenizer,
-            train_on_input=False,
-        )
         input, labels, images = ds[0]["tokens"], ds[0]["labels"], ds[0]["images"]
 
         expected_count = {

--- a/tests/torchtune/datasets/multimodal/test_the_cauldron_dataset.py
+++ b/tests/torchtune/datasets/multimodal/test_the_cauldron_dataset.py
@@ -25,10 +25,7 @@ class TestTheCauldronDataset:
         return PIL.Image.new(mode="RGB", size=(4, 4))
 
     @patch("torchtune.datasets._sft.load_dataset")
-    def test_label_no_masking(self, load_dataset, tokenizer, test_image_pil):
-        """
-        Test whether the input and the labels are correctly created when the input is not masked.
-        """
+    def test_get_item(self, load_dataset, tokenizer, test_image_pil):
         # mock the call to HF datasets
         load_dataset.return_value = [
             {
@@ -46,65 +43,8 @@ class TestTheCauldronDataset:
         ]
 
         ds = the_cauldron_dataset(
-            model_transform=tokenizer, subset="dummy", train_on_input=True
-        )
-        input, labels, images = (ds[0]["tokens"], ds[0]["labels"], ds[0]["images"])
-
-        assert input == [
-            0,
-            -2,
-            9,
-            4,
-            2,
-            11,
-            3,
-            10,
-            4,
-            3,
-            8,
-            2,
-            6,
-            2,
-            6,
-            7,
-            2,
-            8,
-            2,
-            4,
-            6,
-            4,
-            3,
-            7,
-            7,
-            1,
-            -1,
-        ]
-        assert labels == input
-        assert images == [test_image_pil]
-
-    @patch("torchtune.datasets._sft.load_dataset")
-    def test_label_masking(self, load_dataset, tokenizer, test_image_pil):
-        """
-        Test whether the input and the labels are correctly created when the input is masked.
-        """
-        # mock the call to HF datasets
-        load_dataset.return_value = [
-            {
-                "images": [test_image_pil],
-                "texts": [
-                    {
-                        "user": "Question: What do respiration and combustion give out"
-                        "\nChoices:\nA. Oxygen\nB. Carbon dioxide\nC. Nitrogen\nD. Heat"
-                        "\nAnswer with the letter.",
-                        "assistant": "Answer: B",
-                        "source": "AI2D",
-                    }
-                ],
-            }
-        ]
-
-        ds = the_cauldron_dataset(
-            model_transform=tokenizer, subset="dummy", train_on_input=False
+            model_transform=tokenizer,
+            subset="dummy",
         )
         input, labels, images = (ds[0]["tokens"], ds[0]["labels"], ds[0]["images"])
 

--- a/torchtune/data/_utils.py
+++ b/torchtune/data/_utils.py
@@ -129,7 +129,8 @@ def format_content_with_images(
     num_image_tags_in_content = content.count(image_tag)
     if len(images) != num_image_tags_in_content:
         raise ValueError(
-            f"Number of images ({len(images)}) does not match number of image tags ({num_image_tags_in_content})"
+            f"Number of images ({len(images)}) does not match number of image tags "
+            f"({num_image_tags_in_content}) in content: {content}"
         )
 
     split_content = content.split(image_tag)

--- a/torchtune/datasets/multimodal/_llava_instruct.py
+++ b/torchtune/datasets/multimodal/_llava_instruct.py
@@ -48,7 +48,6 @@ class LlavaInstructToMessages(Transform):
         ]
 
     Args:
-        train_on_input (bool): whether the prompt should remain unmasked. Default: False
         column_map (Optional[Dict[str, str]]): a mapping from the expected columns ("conversations", "image")
             to the new column names in the dataset. Keys should be "conversations" and "image" and values should
             be the new column names. If None, keep the default "conversations" and "image".
@@ -65,12 +64,10 @@ class LlavaInstructToMessages(Transform):
 
     def __init__(
         self,
-        train_on_input: bool = False,
         column_map: Optional[Dict[str, str]] = None,
         new_system_prompt: Optional[str] = None,
         images_dir: Optional[Path] = None,
     ):
-        self.train_on_input = train_on_input
         self.new_system_prompt = new_system_prompt
         if column_map:
             if "image" not in column_map:
@@ -115,7 +112,7 @@ class LlavaInstructToMessages(Transform):
                         images=[pil_image],
                     )
                     image_loaded = True
-            masked = (role != "assistant") and (not self.train_on_input)
+            masked = role != "assistant"
             messages.append(Message(role=role, content=content, masked=masked))
 
         return {"messages": messages}
@@ -129,7 +126,6 @@ def llava_instruct_dataset(
     images_dir: str = "coco/train2017/",
     column_map: Optional[Dict[str, str]] = None,
     new_system_prompt: Optional[str] = None,
-    train_on_input: bool = True,
     packed: bool = False,
     split: str = "train",
     data_files: str = "llava_instruct_150k.json",
@@ -203,7 +199,6 @@ def llava_instruct_dataset(
         new_system_prompt (Optional[str]): if specified, prepend a system message. This can
             serve as instructions to guide the model response. Setting this will OVERRIDE any system
             messages already present in the dataset. Default is None.
-        train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
@@ -228,7 +223,6 @@ def llava_instruct_dataset(
     """
 
     message_transform = LlavaInstructToMessages(
-        train_on_input=train_on_input,
         column_map=column_map,
         new_system_prompt=new_system_prompt,
         images_dir=Path(images_dir),

--- a/torchtune/datasets/multimodal/_the_cauldron.py
+++ b/torchtune/datasets/multimodal/_the_cauldron.py
@@ -56,8 +56,6 @@ class TheCauldronToMessages(Transform):
         ]
 
     Args:
-        train_on_input (bool): Whether the model is trained on the user prompt or not.
-            Default is True.
         column_map (Optional[Dict[str, str]]): a mapping to change the expected "texts"
             column names to the actual column names in the dataset. Default is None,
             keeping the default column names.
@@ -70,11 +68,9 @@ class TheCauldronToMessages(Transform):
 
     def __init__(
         self,
-        train_on_input: bool = True,
         column_map: Optional[Dict[str, str]] = None,
         new_system_prompt: Optional[str] = None,
     ):
-        self.train_on_input = train_on_input
         self.new_system_prompt = new_system_prompt
         if column_map is not None:
             if "images" not in column_map:
@@ -105,7 +101,7 @@ class TheCauldronToMessages(Transform):
                 Message(
                     role="user",
                     content=user_content,
-                    masked=not self.train_on_input,
+                    masked=True,
                 )
             )
             messages.append(
@@ -133,7 +129,6 @@ def the_cauldron_dataset(
     source: str = "HuggingFaceM4/the_cauldron",
     column_map: Optional[Dict[str, str]] = None,
     new_system_prompt: Optional[str] = None,
-    train_on_input: bool = False,
     packed: bool = False,
     split: str = "train",
     **load_dataset_kwargs: Dict[str, Any],
@@ -199,7 +194,6 @@ def the_cauldron_dataset(
         new_system_prompt (Optional[str]): if specified, prepend a system message. This can
             serve as instructions to guide the model response. Setting this will OVERRIDE any system
             messages already present in the dataset. Default is None.
-        train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
         packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False.
         split (str): ``split`` argument for ``datasets.load_dataset``. You can use this argument to load a subset
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
@@ -221,7 +215,6 @@ def the_cauldron_dataset(
     """
 
     message_transform = TheCauldronToMessages(
-        train_on_input=train_on_input,
         column_map=column_map,
         new_system_prompt=new_system_prompt,
     )


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Process multiturn conversations with one image correctly (image only included in first user message)
* Remove train on input from all multimodal datasets since image id is out of vocab

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
