### PR TITLE
Multimodal dataset builder + docs

### DIFF
--- a/docs/source/basics/chat_datasets.rst
+++ b/docs/source/basics/chat_datasets.rst
@@ -199,6 +199,8 @@ that follows this format:
         ...
     ]
 
+.. _sharegpt:
+
 ``"sharegpt"``
 ^^^^^^^^^^^^^^
 The associated message transform is :class:`~torchtune.data.ShareGPTToMessages`. The expected format is:

--- a/docs/source/basics/message_transforms.rst
+++ b/docs/source/basics/message_transforms.rst
@@ -19,6 +19,7 @@ These are exposed in our dataset builders :func:`~torchtune.datasets.instruct_da
 so you don't have to worry about the message transform itself and can configure this directly from the config.
 You can see :ref:`example_instruct` or :ref:`example_chat` for more details.
 
+.. _custom_message_transform:
 
 Custom message transforms
 -------------------------

--- a/docs/source/basics/multimodal_datasets.rst
+++ b/docs/source/basics/multimodal_datasets.rst
@@ -4,7 +4,8 @@
 Multimodal Datasets
 ===================
 
-Multimodal datasets include both text and image data used to train VLMs. torchtune currently supports multimodal chat datasets.
+Multimodal datasets include more than one data modality, e.g. text + image, and can be used to train transformer-based models.
+torchtune currently only supports multimodal text+image chat datasets for Vision-Language Models (VLMs).
 
 The primary entry point for fine-tuning with multimodal datasets in torchtune is the :func:`~torchtune.datasets.multimodal.multimodal_chat_dataset`
 builder. This lets you specify a local or Hugging Face dataset that follows the multimodal chat data format
@@ -15,7 +16,9 @@ directly from the config and train your VLM on it.
 Example multimodal dataset
 --------------------------
 
-Here is an example of a multimodal chat dataset for a visual question-answering task.
+Here is an example of a multimodal chat dataset for a visual question-answering task. Note that there is a placeholder
+in the text, ``"<image>"`` for where to place the image tokens. This will get replaced by the image special token
+``<|image|>`` in the example below.
 
 .. code-block:: python
 
@@ -69,7 +72,7 @@ Here is an example of a multimodal chat dataset for a visual question-answering 
 
 .. code-block:: yaml
 
-    # In config
+    # In config - model_transforms takes the place of the tokenizer
     model_transform:
       _component_: torchtune.models.flamingo
       path: /tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model
@@ -102,6 +105,8 @@ and the user-assistant conversations are in another column.
     |  {"from": "gpt", "value": "A1"}]   |              |
 
 As an example, you can see the schema of the `ShareGPT4V dataset <https://huggingface.co/datasets/Lin-Chen/ShareGPT4V>`_.
+
+Currently, :func:`~torchtune.datasets.multimodal.multimodal_chat_dataset` only supports a single image path per conversation sample.
 
 
 Loading multimodal datasets from Hugging Face

--- a/docs/source/basics/multimodal_datasets.rst
+++ b/docs/source/basics/multimodal_datasets.rst
@@ -1,0 +1,285 @@
+.. _multimodal_dataset_usage_label:
+
+===================
+Multimodal Datasets
+===================
+
+Multimodal datasets include both text and image data used to train VLMs. torchtune currently supports multimodal chat datasets.
+
+The primary entry point for fine-tuning with multimodal datasets in torchtune is the :func:`~torchtune.datasets.multimodal.multimodal_chat_dataset`
+builder. This lets you specify a local or Hugging Face dataset that follows the multimodal chat data format
+directly from the config and train your VLM on it.
+
+.. _example_multimodal:
+
+Example multimodal dataset
+--------------------------
+
+Here is an example of a multimodal chat dataset for a visual question-answering task.
+
+.. code-block:: python
+
+    # data/my_data.json
+    [
+        {
+            "dialogue": [
+                {
+                    "from": "human",
+                    "value": "<image>What time is it on the clock?",
+                },
+                {
+                    "from": "gpt",
+                    "value": "It is 10:00 AM.",
+                },
+            ],
+            "image_path": "images/clock.jpg",
+        },
+        ...,
+    ]
+
+.. code-block:: python
+
+    from torchtune.models.flamingo import FlamingoTransform
+    from torchtune.datasets.multimodal import multimodal_chat_dataset
+
+    transform = FlamingoTransform(
+        path="/tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model",
+        prompt_template="torchtune.data.QuestionAnswerTemplate",
+        max_seq_len=8192,
+        tile_size=224,
+        patch_size=14,
+    )
+    ds = multimodal_chat_dataset(
+        model_transform=model_transform,
+        source="json",
+        data_files="data/my_data.json",
+        column_map={
+            "dialogue": "conversations",
+            "image_path": "image",
+        },
+        image_dir="/home/user/dataset/",  # /home/user/dataset/images/clock.jpg
+        image_tag="<image>",
+        split="train",
+    )
+    tokenized_dict = ds[0]
+    print(transform.decode(tokenized_dict["tokens"], skip_special_tokens=False))
+    # '<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nQuestion:<|image|>What time is it on the clock?Answer:<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nIt is 10:00AM.<|eot_id|>'
+    print(tokenized_dict["encoder_input"]["images"][0].shape)  # (num_tiles, num_channels, tile_height, tile_width)
+    # torch.Size([4, 3, 224, 224])
+
+.. code-block:: yaml
+
+    # In config
+    model_transform:
+      _component_: torchtune.models.flamingo
+      path: /tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model
+      prompt_template: torchtune.data.QuestionAnswerTemplate
+      max_seq_len: 8192
+
+    dataset:
+      _component_: torchtune.datasets.multimodal.multimodal_chat_dataset
+      source: json
+      data_files: data/my_data.json
+      split: train
+      column_map:
+        dialogue: conversations
+        image_path: image
+      image_dir: /home/user/dataset/
+      image_tag: "<image>"
+      split: train
+
+Multimodal dataset format
+-------------------------
+
+Multimodal datasets are currently expected to follow the :ref:`sharegpt` chat format, where the image paths are in one column
+and the user-assistant conversations are in another column.
+
+.. code-block:: text
+
+    |  conversations                     | image        |
+    |------------------------------------|--------------|
+    | [{"from": "human", "value": "Q1"}, | images/1.jpg |
+    |  {"from": "gpt", "value": "A1"}]   |              |
+
+As an example, you can see the schema of the `ShareGPT4V dataset <https://huggingface.co/datasets/Lin-Chen/ShareGPT4V>`_.
+
+
+Loading multimodal datasets from Hugging Face
+---------------------------------------------
+
+You simply need to pass in the dataset repo name to ``source``, which is then passed into Hugging Face's ``load_dataset``.
+For most datasets, you will also need to specify the ``split`` and/or the subset via ``name``.
+
+.. code-block:: python
+
+    # In code
+    from torchtune.models.flamingo import FlamingoTransform
+    from torchtune.datasets.multimodal import multimodal_chat_dataset
+
+    transform = FlamingoTransform(
+        path="/tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model",
+        max_seq_len=8192,
+        tile_size=224,
+        patch_size=14,
+    )
+    ds = multimodal_chat_dataset(
+        model_transform=model_transform,
+        source="Lin-Chen/ShareGPT4V",
+        split="train",
+        name="ShareGPT4V",
+        image_dir="/home/user/dataset/",
+        image_tag="<image>",
+    )
+
+.. code-block:: yaml
+
+    # In config
+    model_transform:
+      _component_: torchtune.models.flamingo.FlamingoTransform
+      path: /tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model
+      max_seq_len: 8192
+      tile_size: 224
+      patch_size: 14
+
+    # Tokenizer is passed into the dataset in the recipe
+    dataset:
+      _component_: torchtune.datasets.multimodal.multimodal_chat_dataset
+      source: Lin-Chen/ShareGPT4V
+      split: train
+      name: ShareGPT4V
+      image_dir: /home/user/dataset/
+      image_tag: "<image>"
+
+This will use the default column names "conversations" and "image". To change the column names, use the ``column_map`` argument (see :ref:`column_map`).
+
+Loading local and remote multimodal datasets
+--------------------------------------------
+
+To load in a local or remote dataset via https that follows the instruct format, you need to specify the ``source``, ``data_files`` and ``split``
+arguments. See Hugging Face's ``load_dataset`` `documentation <https://huggingface.co/docs/datasets/main/en/loading#local-and-remote-files>`_
+for more details on loading local or remote files. See :ref:`example_multimodal` above.
+
+Loading images
+--------------
+In many cases, your dataset will contain paths to the images instead of the raw images themselves. :func:`~torchtune.datasets.multimodal.multimodal_chat_dataset`
+will automatically handle this for you, but if you are writing a custom message transform for a custom multimodal dataset
+(see :ref:`custom_message_transform`), you can use the :func:`~torchtune.data.load_image` utility directly.
+
+.. code-block:: python
+
+    from torchtune.data import load_image
+    from pathlib import Path
+
+    sample = {
+        "conversations": [
+            {
+                "from": "human",
+                "value": "What time is it on the clock?",
+            },
+            {
+                "from": "gpt",
+                "value": "It is 10:00 AM.",
+            },
+        ],
+        "image": "images/clock.jpg",
+    }
+    image_dir = "/home/user/dataset/"
+    pil_image = load_image(Path(image_dir) / Path(sample["image"]))
+    print(pil_image)
+    # <PIL.Image.Image>
+
+Then, you can add the PIL image directly to the content of the related message. Only PIL images are supported as image content
+in :class:`~torchtune.data.Message`, not image paths or urls.
+
+.. code-block:: python
+
+    from torchtune.data import Message
+
+    user_message = None
+    for msg in sample["conversations"]:
+        if msg["from"] == "human":
+            user_message = Message(
+                role="user",
+                content=[
+                    {"type": "image", "content": pil_image},
+                    {"type": "text", "content": msg["value"]},
+                ]
+            )
+    print(user_message.contains_media)
+    # True
+    print(user_message.get_media())
+    # [<PIL.Image.Image>]
+    print(user_message.text_content)
+    # What time is it on the clock?
+
+If the image paths in your dataset are relative paths, you can use the ``image_dir`` parameter in :func:`~torchtune.datasets.multimodal.multimodal_chat_dataset`
+to prepend the full path where your images are downloaded locally.
+
+Interleaving images in text
+---------------------------
+torchtune supports adding multiple images in any locations in the text, as long as your model supports it.
+
+.. code-block:: python
+
+    import PIL
+    from torchtune.data import Message
+
+    image_dog = PIL.Image.new(mode="RGB", size=(4, 4))
+    image_cat = PIL.Image.new(mode="RGB", size=(4, 4))
+    image_bird = PIL.Image.new(mode="RGB", size=(4, 4))
+
+    user_message = Message(
+        role="user",
+        content=[
+            {"type": "image", "content": image_dog},
+            {"type": "text", "content": "This is an image of a dog. "},
+            {"type": "image", "content": image_cat},
+            {"type": "text", "content": "This is an image of a cat. "},
+            {"type": "image", "content": image_bird},
+            {"type": "text", "content": "This is a bird, the best pet of the three."},
+        ]
+    )
+    print(user_message.contains_media)
+    # True
+    print(user_message.get_media())
+    # [<PIL.Image.Image>, <PIL.Image.Image>, <PIL.Image.Image>]
+    print(user_message.text_content)
+    # This is an image of a dog. This is an image of a cat. This is a bird, the best pet of the three.
+
+Your dataset may contain image placeholder tags which indicate where in the text the image should be referenced
+As an example, see `ShareGPT4V <https://huggingface.co/datasets/Lin-Chen/ShareGPT4V>`, which uses ``"<image>"``.
+You can easily create the interleaved message content similar to above with the utility :func:`~torchtune.data.format_content_with_images`,
+which replaces the image placeholder tags with the passed in images.
+
+.. code-block:: python
+
+    import PIL
+    from torchtune.data import Message, format_content_with_images
+
+    image_dog = PIL.Image.new(mode="RGB", size=(4, 4))
+    image_cat = PIL.Image.new(mode="RGB", size=(4, 4))
+    image_bird = PIL.Image.new(mode="RGB", size=(4, 4))
+
+    text = "[img]This is an image of a dog. [img]This is an image of a cat. [img]This is a bird, the best pet of the three."
+    user_message = Message(
+        role="user",
+        content=format_content_with_images(
+            content=text,
+            image_tag="[img]",
+            images=[image_dog, image_cat, image_bird],
+        ),
+    )
+    print(user_message.contains_media)
+    # True
+    print(user_message.get_media())
+    # [<PIL.Image.Image>,<PIL.Image.Image>, <PIL.Image.Image>]
+    print(user_message.text_content)
+    # This is an image of a dog. This is an image of a cat. This is a bird, the best pet of the three.
+
+This is handled automatically for you in :func:`~torchtune.datasets.multimodal.multimodal_chat_dataset` when you pass in
+``image_tag``.
+
+Built-in multimodal datasets
+----------------------------
+- :class:`~torchtune.datasets.multimodal.the_cauldron_dataset`
+- :class:`~torchtune.datasets.multimodal.llava_instruct_dataset`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -120,6 +120,7 @@ torchtune tutorials.
    basics/tokenizers
    basics/prompt_templates
    basics/preference_datasets
+   basics/multimodal_datasets
 
 .. toctree::
    :glob:

--- a/tests/torchtune/data/test_messages.py
+++ b/tests/torchtune/data/test_messages.py
@@ -284,6 +284,26 @@ class TestShareGPTToMessages:
                 column_map={"bananas": "maybe_conversations"},
             )
 
+    @mock.patch("torchtune.data._messages.load_image")
+    def test_image_only_in_first_user_message(self, mock_load_image):
+        mock_load_image.return_value = Image.new(mode="RGB", size=(4, 4))
+        sample = {
+            "conversations": [
+                {"from": "human", "value": "<image>\nFirst message."},
+                {"from": "gpt", "value": "First response."},
+                {"from": "human", "value": "Second message."},
+                {"from": "gpt", "value": "Second response."},
+            ],
+            "image": "test_image.jpg",
+        }
+        transform = ShareGPTToMessages(image_tag="<image>")
+        messages = transform(sample)
+        for idx, message in enumerate(messages["messages"]):
+            if idx == 0:
+                assert message.contains_media
+            else:
+                assert not message.contains_media
+
 
 class TestOpenAIToMessages:
     samples = {

--- a/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
+++ b/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
@@ -28,7 +28,7 @@ class TestLLaVAInstructDataset:
         return PIL.Image.new(mode="RGB", size=(4, 4))
 
     @patch("torchtune.datasets._sft.load_dataset")
-    @patch("torchtune.datasets.multimodal._llava_instruct.load_image")
+    @patch("torchtune.data._messages.load_image")
     def test_get_item(self, load_image, load_dataset, tokenizer, test_image_pil):
         """
         WARNING: careful with these mocks, they are applied in bottom up order

--- a/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
+++ b/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import Counter
-from unittest import mock
 from unittest.mock import patch
 
 import PIL
@@ -17,7 +16,6 @@ from tests.test_utils import DummyTokenizer
 from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
 
 from torchtune.datasets.multimodal import llava_instruct_dataset
-from torchtune.datasets.multimodal._llava_instruct import LlavaInstructToMessages
 
 
 class TestLLaVAInstructDataset:
@@ -88,28 +86,3 @@ class TestLLaVAInstructDataset:
         assert Counter(input) == expected_count
         assert labels.count(CROSS_ENTROPY_IGNORE_IDX) == 11
         assert images == [test_image_pil]
-
-
-class TestLlavaInstructToMessages:
-    @pytest.fixture
-    def transform(self):
-        return LlavaInstructToMessages()
-
-    @mock.patch("torchtune.datasets.multimodal._llava_instruct.load_image")
-    def test_image_only_in_first_user_message(self, mock_load_image, transform):
-        mock_load_image.return_value = PIL.Image.new(mode="RGB", size=(4, 4))
-        sample = {
-            "conversations": [
-                {"from": "human", "value": "<image>\nFirst message."},
-                {"from": "gpt", "value": "First response."},
-                {"from": "human", "value": "Second message."},
-                {"from": "gpt", "value": "Second response."},
-            ],
-            "image": "test_image.jpg",
-        }
-        messages = transform(sample)
-        for idx, message in enumerate(messages["messages"]):
-            if idx == 0:
-                assert message.contains_media
-            else:
-                assert not message.contains_media

--- a/torchtune/data/_messages.py
+++ b/torchtune/data/_messages.py
@@ -417,11 +417,10 @@ class ShareGPTToMessages(Transform):
                     pil_image = load_image(image_path)
                     # If image tag is not specified, prepend by default
                     if self.image_tag is None:
-                        content = format_content_with_images(
-                            "<image>" + content,
-                            image_tag="<image>",
-                            images=[pil_image],
-                        )
+                        content = [
+                            {"type": "image", "content": pil_image},
+                            {"type": "text", "content": content},
+                        ]
                     else:
                         content = format_content_with_images(
                             content,
@@ -431,7 +430,7 @@ class ShareGPTToMessages(Transform):
                     image_loaded = True
 
             masked = (role != "assistant") and (
-                not self.train_on_input and not is_multimodal
+                not self.train_on_input or is_multimodal
             )
             messages.append(Message(role=role, content=content, masked=masked))
 

--- a/torchtune/data/_messages.py
+++ b/torchtune/data/_messages.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Mapping, Optional, Union
 
-from torchtune.data._utils import load_image
+from torchtune.data._utils import format_content_with_images, load_image
 
 from torchtune.modules.transforms import Transform
 
@@ -335,7 +336,8 @@ class ShareGPTToMessages(Transform):
         ]
 
     Args:
-        train_on_input (bool): whether the prompt should remain unmasked. Default: False
+        train_on_input (bool): whether the prompt should remain unmasked. For multimodal datasets, ``train_on_input``
+            is always False and this value is ignored. Default: False
         column_map (Optional[Dict[str, str]]): a mapping from the expected columns ("conversations")
             to the new column names in the dataset. Key should be "conversations" and value should
             be the new column name. If None, keep the default "conversations".
@@ -343,6 +345,13 @@ class ShareGPTToMessages(Transform):
         new_system_prompt (Optional[str]): if specified, prepend a system message. This can
             serve as instructions to guide the model response. Setting this will OVERRIDE any system
             messages already present in the dataset. Default is None.
+        image_dir (Optional[Path]): path to the directory containing the images that is prepended to all image
+            paths in the dataset. If None, assume images are available in current working directory or are located
+            on a remote url. For text-only,leave as None. Default is None.
+        image_tag (Optional[str]): placeholder tags in the text content of each message to be replaced by dictionaries
+            indicating to the tokenizer where to place image tokens. If images are present and this is None,
+            then will prepend image tokens to the first user message in the sample by default. If text-only, leave
+            this as None. Default is None.
 
     Raises:
         ValueError: If ``column_map`` is provided and ``conversations`` not in ``column_map``.
@@ -353,6 +362,8 @@ class ShareGPTToMessages(Transform):
         train_on_input: bool = False,
         column_map: Optional[Dict[str, str]] = None,
         new_system_prompt: Optional[str] = None,
+        image_dir: Optional[Path] = None,
+        image_tag: Optional[str] = None,
     ):
         self.train_on_input = train_on_input
         self.new_system_prompt = new_system_prompt
@@ -363,7 +374,9 @@ class ShareGPTToMessages(Transform):
                 )
             self._column_map = column_map
         else:
-            self._column_map = {"conversations": "conversations"}
+            self._column_map = {"conversations": "conversations", "image": "image"}
+        self.image_dir = image_dir
+        self.image_tag = image_tag
 
     def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
         """
@@ -384,12 +397,42 @@ class ShareGPTToMessages(Transform):
                     role="system", content=self.new_system_prompt, masked=True, eot=True
                 )
             )
+
+        is_multimodal = "image" in sample or (
+            "image" in self._column_map and self._column_map["image"] in sample
+        )
+
+        # Add in image stuffs / load from file
+        image_loaded = False
         for message in sample[self._column_map["conversations"]]:
             role = role_map[message["from"]]
+            content = message["value"]
             if role == "system" and self.new_system_prompt is not None:
                 continue
-            content = message["value"]
-            masked = (role != "assistant") and (not self.train_on_input)
+            if role == "user":
+                if is_multimodal and not image_loaded:
+                    image_path = sample[self._column_map["image"]]
+                    if self.image_dir is not None:
+                        image_path = self.image_dir / image_path
+                    pil_image = load_image(image_path)
+                    # If image tag is not specified, prepend by default
+                    if self.image_tag is None:
+                        content = format_content_with_images(
+                            "<image>" + content,
+                            image_tag="<image>",
+                            images=[pil_image],
+                        )
+                    else:
+                        content = format_content_with_images(
+                            content,
+                            image_tag=self.image_tag,
+                            images=[pil_image],
+                        )
+                    image_loaded = True
+
+            masked = (role != "assistant") and (
+                not self.train_on_input and not is_multimodal
+            )
             messages.append(Message(role=role, content=content, masked=masked))
 
         return {"messages": messages}

--- a/torchtune/datasets/multimodal/__init__.py
+++ b/torchtune/datasets/multimodal/__init__.py
@@ -5,9 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 from ._llava_instruct import llava_instruct_dataset
+from ._multimodal import multimodal_chat_dataset
 from ._the_cauldron import the_cauldron_dataset
 
 __all__ = [
     "the_cauldron_dataset",
     "llava_instruct_dataset",
+    "multimodal_chat_dataset",
 ]

--- a/torchtune/datasets/multimodal/_llava_instruct.py
+++ b/torchtune/datasets/multimodal/_llava_instruct.py
@@ -17,7 +17,7 @@ def llava_instruct_dataset(
     model_transform: Transform,
     *,
     source: str = "liuhaotian/LLaVA-Instruct-150K",
-    images_dir: str = "coco/train2017/",
+    image_dir: str = "coco/train2017/",
     column_map: Optional[Dict[str, str]] = None,
     new_system_prompt: Optional[str] = None,
     packed: bool = False,
@@ -85,7 +85,7 @@ def llava_instruct_dataset(
             define source as the data file type (e.g. "json", "csv", "text") and pass
             in the filepath in ``data_files``. See `Hugging Face's
             <https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path>`_
-        images_dir (str): path to the directory containing the images as you are expected to download the COCO dataset
+        image_dir (str): path to the directory containing the images as you are expected to download the COCO dataset
             before using. Default is "coco/".
         column_map (Optional[Dict[str, str]]): a mapping from the expected columns ("conversations")
             to the new column names in the dataset. If None, assume these are identical.
@@ -120,7 +120,8 @@ def llava_instruct_dataset(
         train_on_input=False,
         column_map=column_map,
         new_system_prompt=new_system_prompt,
-        images_dir=Path(images_dir),
+        image_dir=Path(image_dir),
+        image_tag="<image>",
     )
 
     ds = SFTDataset(

--- a/torchtune/datasets/multimodal/_llava_instruct.py
+++ b/torchtune/datasets/multimodal/_llava_instruct.py
@@ -5,117 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Optional
 
-from torchtune.data._messages import Message
-from torchtune.data._utils import format_content_with_images, load_image
+from torchtune.data._messages import ShareGPTToMessages
 from torchtune.datasets._sft import SFTDataset
 from torchtune.modules.transforms import Transform
-
-
-class LlavaInstructToMessages(Transform):
-    """
-    Construct messages from a sample formatted similarly to
-    `LLaVA-Instruct-150K <https://huggingface.co/datasets/liuhaotian/LLaVA-Instruct-150K>`_.
-
-    Chat samples in the "conversations" column follow the ShareGPT format::
-
-        {
-            "image": "image0001.png",
-            "conversations": [
-                {
-                    "from": "system" | "human" | "gpt",
-                    "value": "<image> This is a sample image.",
-                },
-                ...
-            ]
-        }
-
-    Image locations are indicated by "<image>" placeholder tags in the text content of each message.
-    These are replaced by dictionaries indicating to the tokenizer where to place image tokens.
-    Altogether, the above format is converted to torchtune's Message format::
-
-        [
-            {
-                "role": "system" | "user" | "assistant",
-                "content":
-                    [
-                        {"type": "image", "content": <PIL.Image.Image>},
-                        {"type": "text", "content": "This is a sample image."},
-                    ],
-            },
-            ...
-        ]
-
-    Args:
-        column_map (Optional[Dict[str, str]]): a mapping from the expected columns ("conversations", "image")
-            to the new column names in the dataset. Keys should be "conversations" and "image" and values should
-            be the new column names. If None, keep the default "conversations" and "image".
-            Default is None.
-        new_system_prompt (Optional[str]): if specified, prepend a system message. This can
-            serve as instructions to guide the model response. Setting this will OVERRIDE any system
-            messages already present in the dataset. Default is None.
-        images_dir (Optional[Path]): path to the directory containing the images. User is expected to download the COCO dataset.
-            If None, assume images are available in current working directory. Default is None.
-
-    Raises:
-        ValueError: If ``column_map`` is provided and ``conversations`` not in ``column_map``.
-    """
-
-    def __init__(
-        self,
-        column_map: Optional[Dict[str, str]] = None,
-        new_system_prompt: Optional[str] = None,
-        images_dir: Optional[Path] = None,
-    ):
-        self.new_system_prompt = new_system_prompt
-        if column_map:
-            if "image" not in column_map:
-                raise ValueError(
-                    f"Expected a key of 'image' in column_map but found {column_map.keys()}."
-                )
-            if "conversations" not in column_map:
-                raise ValueError(
-                    f"Expected a key of 'conversations' in column_map but found {column_map.keys()}."
-                )
-            self._column_map = column_map
-        else:
-            self._column_map = {"conversations": "conversations", "image": "image"}
-        self.images_dir = images_dir
-
-    def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
-        role_map = {"system": "system", "human": "user", "gpt": "assistant"}
-        messages = []
-        if self.new_system_prompt is not None:
-            messages.append(
-                Message(
-                    role="system", content=self.new_system_prompt, masked=True, eot=True
-                )
-            )
-
-        # Add in image stuffs / load from file
-        image_loaded = False
-        for message in sample[self._column_map["conversations"]]:
-            role = role_map[message["from"]]
-            content = message["value"]
-            if role == "system" and self.new_system_prompt is not None:
-                continue
-            if role == "user":
-                if not image_loaded:
-                    image_path = sample[self._column_map["image"]]
-                    if self.images_dir is not None:
-                        image_path = self.images_dir / image_path
-                    pil_image = load_image(image_path)
-                    content = format_content_with_images(
-                        content,
-                        image_tag="<image>",
-                        images=[pil_image],
-                    )
-                    image_loaded = True
-            masked = role != "assistant"
-            messages.append(Message(role=role, content=content, masked=masked))
-
-        return {"messages": messages}
 
 
 # TODO: point to Flamingo model transform as an example
@@ -222,7 +116,8 @@ def llava_instruct_dataset(
         >>> Batch size: 8
     """
 
-    message_transform = LlavaInstructToMessages(
+    message_transform = ShareGPTToMessages(
+        train_on_input=False,
         column_map=column_map,
         new_system_prompt=new_system_prompt,
         images_dir=Path(images_dir),

--- a/torchtune/datasets/multimodal/_multimodal.py
+++ b/torchtune/datasets/multimodal/_multimodal.py
@@ -52,7 +52,8 @@ def multimodal_chat_dataset(
             Message(role="assistant", content="A1"),
         ]
 
-    This list of messages is then tokenized for model training.
+    This list of messages is then tokenized for model training. Currently, only a single image per conversation sample
+    is supported, and it is always added to the first user message.
 
     If your dataset is not in the ShareGPT format, we recommend creating a custom message transform and
     using it in a custom dataset builder function similar to :class:`~torchtune.datasets.multimodal_chat_dataset`.

--- a/torchtune/datasets/multimodal/_multimodal.py
+++ b/torchtune/datasets/multimodal/_multimodal.py
@@ -1,0 +1,172 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from torchtune.data._messages import ShareGPTToMessages
+from torchtune.datasets._sft import SFTDataset
+from torchtune.modules.transforms import Transform
+
+
+def multimodal_chat_dataset(
+    model_transform: Transform,
+    *,
+    source: str,
+    column_map: Optional[Dict[str, str]] = None,
+    new_system_prompt: Optional[str] = None,
+    image_tag: Optional[str] = None,
+    image_dir: Optional[str] = None,
+    **load_dataset_kwargs: Dict[str, Any],
+) -> SFTDataset:
+    """
+    Configure a text+image dataset with conversations between user and model assistant.
+
+    This builder function can be used to configure a custom multimodal dataset directly from the yaml config
+    as an alternative to :class:`~torchtune.datasets.SFTDataset`, as it is made to be config friendly.
+
+    The dataset is expected to follow the ShareGPT format:
+
+    .. code-block:: text
+
+        |  conversations                     | image        |
+        |------------------------------------|--------------|
+        | [{"from": "human", "value": "Q1"}, | images/1.jpg |
+        |  {"from": "gpt", "value": "A1"}]   |              |
+
+    This will be converted to:
+
+    .. code-block:: python
+
+        messages = [
+            Message(
+                role="user",
+                content=[
+                    {"type": "image", "content": [<PIL.Image.Image>]},
+                    {"type": "text", "content": "Q1"},
+                ],
+            ),
+            Message(role="assistant", content="A1"),
+        ]
+
+    This list of messages is then tokenized for model training.
+
+    If your dataset is not in the ShareGPT format, we recommend creating a custom message transform and
+    using it in a custom dataset builder function similar to :class:`~torchtune.datasets.multimodal_chat_dataset`.
+
+    If your column names are different, use the ``column_map`` parameter to point
+    towards the columns with the conversations and images.
+
+    Args:
+        model_transform (Transform): callable that applies model-specific pre-processing to the sample.
+            This includes tokenization and any modality-specific transforms. It is expected to return at
+            minimum ``"tokens"`` and ``"mask"`` keys.
+        source (str): path to dataset repository on Hugging Face. For local datasets,
+            define source as the data file type (e.g. "json", "csv", "text"), pass
+            in the filepath in ``data_files``, and set ``split="train"``. See `Hugging Face's
+            <https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset.path>`_
+            ``load_dataset`` for more details.
+        column_map (Optional[Dict[str, str]]): a mapping from the expected columns ("conversations", "image")
+            to the new column names in the dataset. Keys should be "conversations", "image" and values should
+            be the new column names. If None, keep the default "conversations", "image".
+            Default is None.
+        new_system_prompt (Optional[str]): if specified, prepend a system message. This can
+            serve as instructions to guide the model response. Setting this will OVERRIDE any system
+            messages already present in the dataset. Default is None.
+        image_tag (Optional[str]): placeholder tags in the text content of each message to be replaced by dictionaries
+            indicating to the tokenizer where to place image tokens. If images are present and this is None,
+            then will prepend image tokens to the first user message in the sample by default. If text-only, leave
+            this as None. Default is None.
+        image_dir (Optional[str]): path to the directory containing the images that is prepended to all image
+            paths in the dataset. If None, assume images are available in current working directory or are located
+            on a remote url. For text-only,leave as None. Default is None.
+        **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``,
+            such as ``data_files`` or ``split``.
+
+    Examples:
+
+    ::
+
+        my_dataset.json
+        [
+            {
+                "dialogue": [
+                    {
+                        "from": "human",
+                        "value": "<image>What time is it on the clock?",
+                    },
+                    {
+                        "from": "gpt",
+                        "value": "It is 10:00 AM.",
+                    },
+                ],
+                "image_path": "images/clock.jpg",
+            },
+            ...,
+        ]
+
+    ::
+
+        >>> from torchtune.datasets.multimodal import multimodal_chat_dataset
+        >>> from torchtune.models.flamingo import FlamingoTransform
+        >>> model_transform = FlamingoTransform(
+        ...     path="/tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model",
+        ...     tile_size=224,
+        ...     patch_size=14,
+        ... )
+        >>> dataset = multimodal_chat_dataset(
+        ...     model_transform=model_transform,
+        ...     source="json",
+        ...     data_files="my_dataset.json",
+        ...     column_map={
+        ...         "dialogue": "conversations",
+        ...         "image_path": "image",
+        ...     },
+        ...     image_dir="/home/user/dataset/",  # /home/user/dataset/images/clock.jpg
+        ...     image_tag="<image>",
+        ...     split="train",
+        ... )
+        >>> tokens = dataset[0]["tokens"]
+        >>> model_transform.decode(tokens, skip_special_tokens=True)
+        "What time is it on the clock?It is 10:00 AM."
+        >>> print(dataset[0]["encoder_input"]["images"][0].shape)  # (num_tiles, num_channels, tile_height, tile_width)
+        torch.Size([4, 3, 224, 224])
+
+
+    This can also be accomplished via the yaml config:
+
+    .. code-block:: yaml
+
+        dataset:
+          _component_: torchtune.datasets.multimodal.multimodal_chat_dataset
+          source: json
+          data_files: my_dataset.json
+          column_map:
+            dialogue: conversations
+            image_path: image
+          image_dir: /home/user/dataset/
+          image_tag: "<image>"
+          split: train
+
+    Returns:
+        SFTDataset: the configured :class:`~torchtune.datasets.SFTDataset`
+    """
+    message_transform = ShareGPTToMessages(
+        train_on_input=False,
+        column_map=column_map,
+        new_system_prompt=new_system_prompt,
+        image_dir=Path(image_dir),
+        image_tag=image_tag,
+    )
+
+    ds = SFTDataset(
+        source=source,
+        message_transform=message_transform,
+        model_transform=model_transform,
+        **load_dataset_kwargs,
+    )
+
+    return ds


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

There is currently no way to load a custom multimodal dataset. The current workflow is users will write their own transform and builder - which is already a big lift - but on top of that our custom component imports don't even work (#1540). So basically, it's impossible to use anything other than llava instruct and cauldron. This sucks.

I added a quick `multimodal_chat_dataset` builder. It assumes conversational data with images, much like llava instruct and ShareGPT4V. To keep changes minimal, I only support ShareGPT format. We can expand to other chat formats or to instruct data later.

This unfortunately required me to generalize the LlavaInstructToMessages (cc @joecummings, I agree we shouldn't generalize too early but in this case I think it's warranted). Again, to keep changes minimal, I simply merged LlavaInstructToMessages with ShareGPTToMessages. There were identical in handling text, the only difference was the image loading logic.

With this builder, now I finally have something to point to and discuss in the multimodal dataset docs, and users have some avenue to finetune multimodal on their own data. A bit of extra work, but worthwhile imo.

#### Changelog
What are the changes made in this PR?
* Merge ShareGPTToMessages and LlavaInstructToMessages
* Merge any relevant tests
* Add `multimodal_chat_dataset` builder
* Add doc page on multimodal datasets

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
