### PR TITLE
Initial multimodal compile support

### DIFF
--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -40,11 +40,12 @@ def compile_model(
 
     """
     backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
-    model_to_compile = model if isinstance(model, TransformerDecoder) else model.decoder
+    if isinstance(model, DeepFusionModel):
+        model = model.decoder
     if torch_version_ge("2.5.0"):
         if verbose:
             log.info("Compiling model layers with torch.compile...")
-        for m in reversed(list(model_to_compile.modules())):
+        for m in reversed(list(model.modules())):
             if isinstance(m, TransformerSelfAttentionLayer) or isinstance(
                 m, TransformerCrossAttentionLayer
             ):
@@ -57,7 +58,7 @@ def compile_model(
                 For faster compile times via per-layer compile, please run on PyTorch nightlies.
                 """
             )
-        model_to_compile.compile(backend=backend)
+        model.compile(backend=backend)
 
 
 def compile_loss(loss: nn.Module, verbose: bool = True) -> None:

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -11,12 +11,12 @@ import torch
 from torch import nn
 
 from torchtune.modules import (
-    DeepFusionModel,
     TransformerCrossAttentionLayer,
     TransformerDecoder,
     TransformerSelfAttentionLayer,
 )
 from torchtune.modules.loss import CEWithChunkedOutputLoss
+from torchtune.modules.model_fusion import DeepFusionModel
 from torchtune.utils import get_logger, torch_version_ge
 
 log = get_logger("INFO")

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -5,11 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+from typing import Union
 
 import torch
 from torch import nn
 
-from torchtune.modules import TransformerDecoder, TransformerSelfAttentionLayer
+from torchtune.modules import (
+    DeepFusionModel,
+    TransformerCrossAttentionLayer,
+    TransformerDecoder,
+    TransformerSelfAttentionLayer,
+)
 from torchtune.modules.loss import CEWithChunkedOutputLoss
 from torchtune.utils import get_logger, torch_version_ge
 
@@ -17,7 +23,7 @@ log = get_logger("INFO")
 
 
 def compile_model(
-    model: TransformerDecoder,
+    model: Union[TransformerDecoder, DeepFusionModel],
     verbose: bool = True,
 ) -> None:
     """
@@ -25,18 +31,23 @@ def compile_model(
     to reduce compile times. Otherwise we compile the full model, which takes longer.
 
     Args:
-        model (TransformerDecoder): A transformer model to compile.
+        model (Union[TransformerDecoder, DeepFusionModel]): A model to compile.
+            Can be a TransformerDecoder or DeepFusionModel; in the latter case only
+            the model's decoder will be compiled.
         verbose (bool): Whether to log compile info. Default: True
     Returns:
         None
 
     """
     backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
+    model_to_compile = model if isinstance(model, TransformerDecoder) else model.decoder
     if torch_version_ge("2.5.0"):
         if verbose:
             log.info("Compiling model layers with torch.compile...")
-        for m in reversed(list(model.modules())):
-            if isinstance(m, TransformerSelfAttentionLayer):
+        for m in reversed(list(model_to_compile.modules())):
+            if isinstance(m, TransformerSelfAttentionLayer) or isinstance(
+                m, TransformerCrossAttentionLayer
+            ):
                 m.compile(backend=backend)
     else:
         if verbose:
@@ -46,7 +57,7 @@ def compile_model(
                 For faster compile times via per-layer compile, please run on PyTorch nightlies.
                 """
             )
-        model.compile(backend=backend)
+        model_to_compile.compile(backend=backend)
 
 
 def compile_loss(loss: nn.Module, verbose: bool = True) -> None:


### PR DESCRIPTION
For multimodal models we are currently unable to compile both the encoder and the decoder due to some shape inference from the encoder bleeding into the decoder (specifically the seq len in the RoPE embeddings). This is a short-term fix to at least enable compiling the decoder. Additionally, it adds support for compiling cross-attention layers.

Test plan:

Run

```
tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=compile-test metric_logger.name=compile-off gradient_accumulation_steps=1
```

and 

```
tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=compile-test metric_logger.name=compile-on compile=True gradient_accumulation_steps=1
```

to confirm we still get compile speedups. Results:

<img width="1628" alt="Screenshot 2024-09-24 at 8 16 35 PM" src="https://github.com/user-attachments/assets/1e1ecbcd-c3dd-46de-a99e-d296816ffd0a">
