### PR TITLE
Add Pillow >= 9.4 requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "omegaconf",
     "psutil",
 
+    # Multimodal
+    "Pillow>=9.4.0",
+
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
torchvision nightlies come with PIL == 9.3 (at least in my env), but unless we have PIL >= 9.4 we will run into errors on our multimodal datasets around the usage of ExIfTags ([ref](https://github.com/huggingface/datasets/pull/6883)). Ideally we can  change this in torchvision, but until then gonna pin to a minimum version of PIL just to be safe.

Test plan:

```
conda create -n test-pillow python=3.11 -y
conda activate test-pillow
pip install --pre torch torchvision torchao --index-url https://download.pytorch.org/whl/nightly/cu121
pip list
...
Pillow                   9.3.0
...

# From torchtune directory
pip install -e .
pip list
...
pillow                   10.4.0
...
```

Before:

```
  File "/home/ebs/.conda/envs/nightly-testing-09-25/lib/python3.11/site-packages/PIL/Image.py", line 76, in __getattr__
    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
AttributeError: module 'PIL.Image' has no attribute 'ExifTags'
```

After:

```
1|1|Loss: 0.2959183156490326:   0%|▍                                                                                                                           | 1/304 [00:27<2:20:33, 27.83s/it]
```