### PR TITLE
convert rgba to rgb

### DIFF
--- a/torchtune/models/clip/_transform.py
+++ b/torchtune/models/clip/_transform.py
@@ -163,6 +163,8 @@ class CLIPImageTransform:
         assert isinstance(image, Image.Image), "Input image must be a PIL image."
 
         # Make image torch.tensor((3, H, W), dtype=dtype), 0<=values<=1
+        if hasattr(image, "mode") and image.mode == "RGBA":
+            image = image.convert("RGB")
         image = F.to_image(image)
         image = F.grayscale_to_rgb_image(image)
         image = F.to_dtype(image, dtype=self.dtype, scale=True)


### PR DESCRIPTION
For datasets with RGBA samples we will error out with shape mismatch since we assume 3 channels elsewhere. This change will convert them to RGB up front