### PR TITLE
Llama3.2 knowledge distillation config

### DIFF
--- a/recipes/configs/llama3_2/knowledge_distillation_single_device.yaml
+++ b/recipes/configs/llama3_2/knowledge_distillation_single_device.yaml
@@ -1,0 +1,129 @@
+# Config for single device knowledge distillation in kd_single_device.py
+# using a LLAMA3 teacher and student model
+#
+# This config assumes that you've ran the following commands before launching KD:
+# First download the student and teacher models
+#   tune download meta-llama/Llama-3.2-1B-Instruct --output-dir /tmp/Llama-3.2-1B-Instruct --ignore-patterns "original/consolidated.00.pth"
+#   tune download meta-llama/Meta-Llama-3-8B-Instruct --output-dir /tmp/Meta-Llama-3-8B-Instruct
+#
+# You get better results using KD if the teacher model has already been fine-tuned on the target dataset:
+#   tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device
+#
+# To launch on a single device, run the following command from root:
+#   tune run knowledge_distillation_single_device --config llama3_2/knowledge_distillation_single_device
+#
+# This config works only for training on single device.
+
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_2.lora_llama3_2_1b
+  lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 64
+  lora_alpha: 128
+  lora_dropout: 0.0
+
+teacher_model:
+  _component_: torchtune.models.llama3_1.llama3_1_8b
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Llama-3.2-1B-Instruct/original/tokenizer.model
+  max_seq_len: null
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Llama-3.2-1B-Instruct/
+  checkpoint_files: [
+    model.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/Llama-3.2-1B-Instruct/
+  model_type: LLAMA3
+resume_from_checkpoint: False
+save_adapter_weights_only: False
+
+# Teacher checkpoint
+teacher_checkpointer:
+  _component_: torchtune.training.FullModelMetaCheckpointer
+  checkpoint_dir: /home/lindawang/llama/Meta-Llama-3.1-8B-Instruct/lora_finetuned_single_device_epoch_1
+  checkpoint_files: [
+    meta_model_0.pt
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  model_type: LLAMA3
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+seed: null
+shuffle: True
+batch_size: 4
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.modules.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
+
+kd_loss:
+  _component_: torchtune.modules.loss.ForwardKLWithChunkedOutputLoss
+kd_ratio: 0.5
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 4
+compile: False
+
+# Logging
+output_dir: /tmp/kd_output
+metric_logger:
+  _component_: torchtune.training.metric_logging.WandBLogger
+  project: torchtune-kd
+log_every_n_steps: 1
+log_peak_memory_stats: False
+
+# Environment
+device: cuda
+dtype: bf16
+
+# Activations Memory
+enable_activation_checkpointing: False
+enable_activation_offloading: False
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 5
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/llama3_2/knowledge_distillation_single_device.yaml
+++ b/recipes/configs/llama3_2/knowledge_distillation_single_device.yaml
@@ -1,4 +1,4 @@
-# Config for single device knowledge distillation in kd_single_device.py
+# Config for single device knowledge distillation (KD) in knowledge_distillation_single_device.py
 # using a LLAMA3 teacher and student model
 #
 # This config assumes that you've ran the following commands before launching KD:

--- a/recipes/configs/llama3_2/knowledge_distillation_single_device.yaml
+++ b/recipes/configs/llama3_2/knowledge_distillation_single_device.yaml
@@ -4,7 +4,7 @@
 # This config assumes that you've ran the following commands before launching KD:
 # First download the student and teacher models
 #   tune download meta-llama/Llama-3.2-1B-Instruct --output-dir /tmp/Llama-3.2-1B-Instruct --ignore-patterns "original/consolidated.00.pth"
-#   tune download meta-llama/Meta-Llama-3-8B-Instruct --output-dir /tmp/Meta-Llama-3-8B-Instruct
+#   tune download meta-llama/Meta-Llama-3.1-8B-Instruct --output-dir /tmp/Meta-Llama-3.1-8B-Instruct --ignore-patterns "original/consolidated.00.pth"
 #
 # You get better results using KD if the teacher model has already been fine-tuned on the target dataset:
 #   tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device
@@ -48,10 +48,13 @@ save_adapter_weights_only: False
 
 # Teacher checkpoint
 teacher_checkpointer:
-  _component_: torchtune.training.FullModelMetaCheckpointer
-  checkpoint_dir: /home/lindawang/llama/Meta-Llama-3.1-8B-Instruct/lora_finetuned_single_device_epoch_1
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
   checkpoint_files: [
-    meta_model_0.pt
+    hf_model_0001_0.pt,
+    hf_model_0002_0.pt,
+    hf_model_0003_0.pt,
+    hf_model_0004_0.pt
   ]
   recipe_checkpoint: null
   output_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
@@ -84,14 +87,14 @@ kd_ratio: 0.5
 # Training
 epochs: 1
 max_steps_per_epoch: null
-gradient_accumulation_steps: 4
+gradient_accumulation_steps: 32
 compile: False
 
 # Logging
 output_dir: /tmp/kd_output
 metric_logger:
-  _component_: torchtune.training.metric_logging.WandBLogger
-  project: torchtune-kd
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}
 log_every_n_steps: 1
 log_peak_memory_stats: False
 

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -352,6 +352,10 @@ _ALL_RECIPES = [
                 name="qwen2/knowledge_distillation_single_device",
                 file_path="qwen2/knowledge_distillation_single_device.yaml",
             ),
+            Config(
+                name="llama3_2/knowledge_distillation_single_device",
+                file_path="llama3_2/knowledge_distillation_single_device.yaml",
+            ),
         ],
         supports_distributed=False,
     ),


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
What are the changes made in this PR?
* Knowledge distillation config to distill LLAMA3 models, specifically Llama 3.1 8B into Llama 3.2 1B

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
```
tune run knowledge_distillation_single_device --config llama3_2/knowledge_distillation_single_device
```
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/841952ab-b7bb-4795-bed6-341cd3349c4f">
<img width="410" alt="image" src="https://github.com/user-attachments/assets/1a993e19-427b-4e8e-a45d-9f6fd219dbcf"><img width="409" alt="image" src="https://github.com/user-attachments/assets/b07994de-fd57-4760-af93-6da43feecbe5">

Eval results show that using KD yields slightly better results than just standard fine-tuning.
<img width="758" alt="image" src="https://github.com/user-attachments/assets/bbf28776-af21-46c5-8ecd-5b8572a163c0">

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x] I have added an example to docs or docstrings
