### PR TITLE
added a text generation yaml for Llama3_1 model for multi-GPU inferencing.

### DIFF
--- a/recipes/configs/llama3_1/generation_config_multiGPU.yaml
+++ b/recipes/configs/llama3_1/generation_config_multiGPU.yaml
@@ -1,0 +1,41 @@
+# Config for running the InferenceRecipe in generate.py to generate output from an LLM
+#
+# To launch, run the following command from root torchtune directory:
+# cp torchtune/recipes/configs/llama3_1/generation_config_multiGPU.yaml .
+# tune run generate --config generation_config_multiGPU.yaml prompt="Hello, my name is"
+# Model arguments
+model:
+  _component_: torchtune.models.llama3.llama3_8b
+
+
+checkpointer:
+  _component_: torchtune.training.FullModelMetaCheckpointer
+  checkpoint_dir: /tmp/Meta-Llama-3-8B-Instruct/
+  checkpoint_files: [
+    consolidated.00.pth
+  ]
+  output_dir: /tmp/Meta-Llama-3-8B-Instruct/
+  model_type: LLAMA3
+
+device: cuda
+dtype: bf16
+
+seed: 1234
+
+# Tokenizer arguments
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  max_seq_len: null
+
+# Generation arguments; defaults taken from gpt-fast
+prompt: "Tell me a joke?"
+instruct_template: null
+chat_format: null
+max_new_tokens: 300
+temperature: 0.6 # 0.8 and 0.6 are popular values to try
+top_k: 300
+# It is recommended to set enable_kv_cache=False for long-context models like Llama3.1
+enable_kv_cache: True
+
+quantizer: null


### PR DESCRIPTION
added a text generation yaml for Llama3_1 model for multi-GPU inferencing. with instructions in commit to use.

#### Context
Purpose of this PR Is it to
- [ ] update tests and/or documentation
- [ ] Made instructions clear for using LLama3_1 for text generation

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
added a new file for generation which was missing in this LLama3_1 directory named: `generation_config_multiGPU.yaml`
#### Test plan
To test below command can be used:
`cp torchtune/recipes/configs/llama3_1/generation_config_multiGPU.yaml` \\
`tune run generate --config generation_config_multiGPU.yaml prompt="Hello, my name is"`


- [ ] I have added an example to docs or docstrings
- [x] I did not change any public API
