### PR TITLE
Fix PackedDataset bug for seq_len > 2 * max_seq_len setting.

### DIFF
--- a/tests/torchtune/datasets/test_packed_dataset.py
+++ b/tests/torchtune/datasets/test_packed_dataset.py
@@ -151,9 +151,7 @@ class TestPackedDataset:
     @pytest.mark.parametrize("sample_size", [27, 40])
     @pytest.mark.parametrize("max_packs", [5, 200, 3000])
     @pytest.mark.parametrize("split_across_pack", [True])
-    def test_chuncked_case(
-        self, max_seq_len, sample_size, max_packs, split_across_pack
-    ):
+    def test_chunked_case(self, max_seq_len, sample_size, max_packs, split_across_pack):
         dataset = DummyDataset(sample_size)
         packed = PackedDataset(
             dataset,

--- a/tests/torchtune/datasets/test_packed_dataset.py
+++ b/tests/torchtune/datasets/test_packed_dataset.py
@@ -167,6 +167,11 @@ class TestPackedDataset:
             len(dataset), max_seq_len, sample_size, split_across_pack, max_packs
         )
         assert len(packed) == correct_num_packs
+        assert (
+            len(packed[-1]["tokens"])
+            == len(packed[-1]["labels"])
+            == len(packed[-1]["input_pos"])
+        )
 
     def test_packed_dataset_real_data(self):
         expected_tokenized_prompts = [

--- a/tests/torchtune/datasets/test_packed_dataset.py
+++ b/tests/torchtune/datasets/test_packed_dataset.py
@@ -147,6 +147,27 @@ class TestPackedDataset:
         torch.testing.assert_close(packed[0]["seq_lens"], expected_seq_lens)
         torch.testing.assert_close(packed[0]["input_pos"], expected_input_pos)
 
+    @pytest.mark.parametrize("max_seq_len", [13])
+    @pytest.mark.parametrize("sample_size", [27, 40])
+    @pytest.mark.parametrize("max_packs", [5, 200, 3000])
+    @pytest.mark.parametrize("split_across_pack", [True])
+    def test_chuncked_case(
+        self, max_seq_len, sample_size, max_packs, split_across_pack
+    ):
+        dataset = DummyDataset(sample_size)
+        packed = PackedDataset(
+            dataset,
+            max_seq_len=max_seq_len,
+            max_packs=max_packs,
+            split_across_pack=split_across_pack,
+        )
+
+        # Check we get right number of packs
+        correct_num_packs = self._calculate_num_packs(
+            len(dataset), max_seq_len, sample_size, split_across_pack, max_packs
+        )
+        assert len(packed) == correct_num_packs
+
     def test_packed_dataset_real_data(self):
         expected_tokenized_prompts = [
             torch.tensor([0, 4, 2, 1, 7, 4, -1, 0, 1, 9]),

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -136,7 +136,7 @@ class PackedDataset(Dataset):
             # Update the current pack
             current_pack["tokens"] += tokens
             current_pack["labels"] += labels
-            current_pack["input_pos"] += list(range(seq_len))
+            current_pack["input_pos"] += [x % self.max_seq_len for x in range(seq_len)]
             current_pack["seq_lens"] += [seq_len]
 
             # If the current pack is over the max_seq_len, add it to self.packs and

--- a/torchtune/datasets/_packed.py
+++ b/torchtune/datasets/_packed.py
@@ -141,7 +141,10 @@ class PackedDataset(Dataset):
 
             # If the current pack is over the max_seq_len, add it to self.packs and
             # retain any truncated or bumped samples for next pack
-            if len(current_pack["tokens"]) > self.max_seq_len:
+            while (
+                len(current_pack["tokens"]) > self.max_seq_len
+                and not self._should_stop_packing()
+            ):
                 current_pack = self._split_and_add_pack(current_pack)
 
             if rank == 0:
@@ -150,8 +153,7 @@ class PackedDataset(Dataset):
             # Keep track of previous sample boundary
             self.previous_sample_boundary = len(current_pack["tokens"])
 
-            # If max packs is set, stop packing when we reach that number
-            if self.max_packs is not None and len(self.packs) == self.max_packs:
+            if self._should_stop_packing():
                 break
 
         # Handle the last pack if there's leftover and we haven't filled up the max packs
@@ -160,6 +162,13 @@ class PackedDataset(Dataset):
         ):
             # No need to handle splitting at this point so we can just add the current pack
             self._add_pack(current_pack)
+
+    def _should_stop_packing(self) -> bool:
+        """If max packs is set, stop packing when we reach that number."""
+
+        if self.max_packs is not None and len(self.packs) == self.max_packs:
+            return True
+        return False
 
     def _split_and_add_pack(self, current_pack: PACK_TYPE) -> PACK_TYPE:
         """Splits the current pack at the boundary, processes it, adds it to ``self.packs`` and


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Fixes #1689 - the case where PackedDataset with `max_seq_len * 2 < seq_len` would throw a runtime error when trying to pad `input_pos`.

I've set the PR as a draft and only added 1 test to first get some feedback on this setting. In this case the PackedDataset acts more as a chunking utility. Note that since `seq_len > max_seq_len`, to avoid out of bounds errors I've changed `input_pos` to be generated by:

`current_pack["input_pos"] += [x % self.max_seq_len for x in range(seq_len)]`

This might be unexpected for some users (?).
Also, some of the testing utilities in PackedDataset I assume where not written with this case in mind (e.g. `_get_expected_seq_lens_and_input_pos`), so before I make further changes I'd like to know this direction is fine.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
