### PR TITLE
[WIP] Deprecate `_register_reparametrize_state_dict_hooks`

### DIFF
--- a/torchtune/models/gemma/_component_builders.py
+++ b/torchtune/models/gemma/_component_builders.py
@@ -6,7 +6,8 @@
 
 from torch import nn
 from typing import List
-from torchtune.modules.common_utils import _register_reparametrize_state_dict_hooks
+from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
+from functools import partial
 
 from torchtune.modules import (
     MultiHeadAttention,
@@ -241,11 +242,11 @@ def lora_gemma(
     )
 
     if quantize_base:
-        # For QLoRA, we reparametrize 4-bit tensors to higher precision, and offload to CPU on the fly
+        # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
         # so as to not increase peak memory
-        # TODO this is clowny, figure out a better way to get what precision the rest
-        # of the model is in
-        _register_reparametrize_state_dict_hooks(model, dtype=tok_embeddings.weight.dtype)
+        model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+        )
 
     return model
 

--- a/torchtune/models/llama3/_component_builders.py
+++ b/torchtune/models/llama3/_component_builders.py
@@ -21,7 +21,8 @@ from torchtune.modules import (
     TransformerSelfAttentionLayer,
 )
 
-from torchtune.modules.common_utils import _register_reparametrize_state_dict_hooks
+from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
+from functools import partial
 
 from torchtune.modules.peft import DoRALinear, LORA_ATTN_MODULES, LoRALinear
 
@@ -255,8 +256,9 @@ def lora_llama3(
     if quantize_base:
         # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
         # so as to not increase peak memory
-        _register_reparametrize_state_dict_hooks(model)
-
+        model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+        )
     return model
 
 

--- a/torchtune/models/llama3_1/_component_builders.py
+++ b/torchtune/models/llama3_1/_component_builders.py
@@ -19,7 +19,8 @@ from torchtune.modules import (
     TransformerSelfAttentionLayer,
 )
 
-from torchtune.modules.common_utils import _register_reparametrize_state_dict_hooks
+from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
+from functools import partial
 
 from torchtune.modules.peft import DoRALinear, LORA_ATTN_MODULES, LoRALinear
 
@@ -267,8 +268,9 @@ def lora_llama3_1(
     if quantize_base:
         # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
         # so as to not increase peak memory
-        _register_reparametrize_state_dict_hooks(model)
-
+        model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+        )
     return model
 
 

--- a/torchtune/models/mistral/_component_builders.py
+++ b/torchtune/models/mistral/_component_builders.py
@@ -17,7 +17,8 @@ from torchtune.modules import (
     TransformerDecoder,
     TransformerSelfAttentionLayer,
 )
-from torchtune.modules.common_utils import _register_reparametrize_state_dict_hooks
+from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
+from functools import partial
 
 from torchtune.modules.peft import DoRALinear, LORA_ATTN_MODULES, LoRALinear
 
@@ -260,12 +261,11 @@ def lora_mistral(
     )
 
     if quantize_base:
-        # For QLoRA, we reparametrize 4-bit tensors to higher precision, and offload to CPU on the fly
+        # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
         # so as to not increase peak memory
-        # TODO this is clowny, figure out a better way to get what precision the rest
-        # of the model is in
-        _register_reparametrize_state_dict_hooks(model, dtype=tok_embeddings.weight.dtype)
-
+        model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+        )
     return model
 
 
@@ -663,10 +663,9 @@ def lora_mistral_classifier(
     )
 
     if quantize_base:
-        # For QLoRA, we reparametrize 4-bit tensors to higher precision, and offload to CPU on the fly
+        # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
         # so as to not increase peak memory
-        # TODO this is clowny, figure out a better way to get what precision the rest
-        # of the model is in
-        _register_reparametrize_state_dict_hooks(model, dtype=tok_embeddings.weight.dtype)
-
+        model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+        )
     return model

--- a/torchtune/models/phi3/_component_builders.py
+++ b/torchtune/models/phi3/_component_builders.py
@@ -18,7 +18,8 @@ from torchtune.modules import (
     TransformerSelfAttentionLayer,
 )
 
-from torchtune.modules.common_utils import _register_reparametrize_state_dict_hooks
+from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
+from functools import partial
 
 from torchtune.modules.peft import DoRALinear, LORA_ATTN_MODULES, LoRALinear
 
@@ -242,8 +243,9 @@ def lora_phi3(
     if quantize_base:
         # For QLoRA, we reparametrize 4-bit tensors to bf16, and offload to CPU on the fly
         # so as to not increase peak memory
-        _register_reparametrize_state_dict_hooks(model, dtype=tok_embeddings.weight.dtype)
-
+        model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+        )
     return model
 
 

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorConverter, FakeTensorMode
 from torchao.dtypes.nf4tensor import NF4Tensor
+from torchtune.utils._logging import deprecated
 
 _use_low_cpu_ram: bool = False
 
@@ -127,6 +128,16 @@ def _low_ram_reparametrize_as_dtype_state_dict_post_hook(
         state_dict[k] = dest_state_dict[k]
 
 
+@deprecated(
+    msg="""Please use
+    ```
+    model._register_state_dict_hook(
+            partial(reparametrize_as_dtype_state_dict_post_hook, offload_to_cpu=True)
+        )
+    ```
+    To register a hook on `model.state_dict` instead.
+"""
+)
 def _register_reparametrize_state_dict_hooks(
     module: nn.Module,
     dtype: torch.dtype = torch.bfloat16,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)



#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
