### PR TITLE
Add error propagation to distributed run.

### DIFF
--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 import torchtune
 
+from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.run import get_args_parser as get_torchrun_args_parser, run
 from torchtune._cli.subcommand import Subcommand
 from torchtune._recipe_registry import Config, get_all_recipes, Recipe
@@ -78,6 +79,7 @@ For a list of all possible recipes, run `tune ls`."""
                 continue
             self._parser._add_action(action)
 
+    @record
     def _run_distributed(self, args: argparse.Namespace):
         """Run a recipe with torchrun."""
         # TODO (rohan-varma): Add check that nproc_per_node <= cuda device count. Currently,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Currently the torchtune CLI acts as a wrapper around the torch.distributed/torchrun launcher when running distributed recipes. However because [run](https://github.com/pytorch/pytorch/blob/main/torch/distributed/run.py#L916) is called directly users might have trouble tracing multiprocessing errors. This PR adds the `record` decorator (see https://pytorch.org/docs/stable/elastic/errors.html) to the entry point of a distributed run (another location where this could be added is the recipe entrypoint, however the current choice allows the recipe writer to not have to worry about it).

Since we are wrapping torchrun I haven't added an explicit test. One should be able to validate this works for example by running any distributed recipe and just killing it before it completes (keyboard interrupt, etc), e.g. assuming files are already downloaded:

```py
TORCH_ELASTIC_ERROR_FILE=./error_log.txt
tune run --nnodes 1 --nproc_per_node 2 lora_finetune_distributed --config llama2/7B_lora
``` 
Now `error_log.txt` should show something like (truncated for brevity):

```json
{"message": {"message": "SignalException: Process 20453 got signal: 2", "extraInfo": {"pycallstack": "Traceback (most recent call last):\n  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/elastic/multiprocessing/errors/__init.py", line 348, in wrapper\n    return f(args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^\n  File "/root/torchtune/torchtune/_cli/run.py", line 91, in rundistributed\n    run(args)\n  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/run.py", line 892, in run\n    elastic_launch(\n  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/launcher/api.py", line 133, in __call\n    return launch_agent(self._config, self._entrypoint, list(args))\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/launcher/api.py", line 255, in launch_agent\n    result = agent.run()\n             ^^^^^^^^^^^\n  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/elastic/metrics/api.py", line 124, in wrapper\n    result = f(args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^\n  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/elastic/agent/server/api.py", line 680, in run\n    result = self._invoke_run(role)\n             ^^^^^^^^^^^^^^^^^^^^^^\n  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/elastic/agent/server/api.py", line 835, in _invoke_run
```

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
