### PR TITLE
Update fusion layer counting logic for Llama 3.2 weight conversion

### DIFF
--- a/torchtune/models/llama3_2_vision/_convert_weights.py
+++ b/torchtune/models/llama3_2_vision/_convert_weights.py
@@ -148,8 +148,8 @@ def llama3_vision_tune_to_meta(
 
     # Calculate fusion_interval: layer interval where cross attention layers are fused
     num_layers = max(_layer_num(k) for k in state_dict if "layers" in k) + 1
-    num_fusion_layers = (
-        max(_layer_num(k) for k in state_dict if "cross_attention_layers" in k) + 1
+    num_fusion_layers = len(
+        set([k.split(".")[2] for k in state_dict if "fusion_layer" in k])
     )
     assert (
         num_layers % num_fusion_layers == 0

--- a/torchtune/models/llama3_2_vision/_convert_weights.py
+++ b/torchtune/models/llama3_2_vision/_convert_weights.py
@@ -106,10 +106,8 @@ def llama3_vision_meta_to_tune(
 
     # Calculate fusion_interval: layer interval where cross attention layers are fused
     num_layers = max(_layer_num(k) for k in state_dict if "layers" in k) + 1
-    # Get the number of unique fusion layers.
-    # Keys have the form decoder.fusion_layer.i. ... where i is the layer number
-    num_fusion_layers = len(
-        set([k.split(".")[2] for k in state_dict if "fusion_layer" in k])
+    num_fusion_layers = (
+        max(_layer_num(k) for k in state_dict if "cross_attention_layers" in k) + 1
     )
     assert (
         num_layers % num_fusion_layers == 0
@@ -150,6 +148,8 @@ def llama3_vision_tune_to_meta(
 
     # Calculate fusion_interval: layer interval where cross attention layers are fused
     num_layers = max(_layer_num(k) for k in state_dict if "layers" in k) + 1
+    # Get the number of unique fusion layers.
+    # Keys have the form decoder.fusion_layer.i. ... where i is the layer number
     num_fusion_layers = len(
         set([k.split(".")[2] for k in state_dict if "fusion_layer" in k])
     )

--- a/torchtune/models/llama3_2_vision/_convert_weights.py
+++ b/torchtune/models/llama3_2_vision/_convert_weights.py
@@ -106,8 +106,10 @@ def llama3_vision_meta_to_tune(
 
     # Calculate fusion_interval: layer interval where cross attention layers are fused
     num_layers = max(_layer_num(k) for k in state_dict if "layers" in k) + 1
-    num_fusion_layers = (
-        max(_layer_num(k) for k in state_dict if "cross_attention_layers" in k) + 1
+    # Get the number of unique fusion layers.
+    # Keys have the form decoder.fusion_layer.i. ... where i is the layer number
+    num_fusion_layers = len(
+        set([k.split(".")[2] for k in state_dict if "fusion_layer" in k])
     )
     assert (
         num_layers % num_fusion_layers == 0


### PR DESCRIPTION
Checkpoint save errors without this change

Test plan:

```
tune run lora_finetune_single_device --config llama3_2_vision/11B_lora_single_device max_steps_per_epoch=1
```


Before: https://gist.github.com/ebsmothers/c9ad0175cedeb5ad2719aec4d266090d

After: 

```
INFO:torchtune.utils._logging:Saving final epoch checkpoint.
INFO:torchtune.utils._logging:The full model checkpoint, including all weights and configurations, has been saved successfully.You can now use this checkpoint for further training or inference.
INFO:torchtune.utils._logging:Checkpoint saved in 46.25 seconds.
```
