### PR TITLE
Fix custom imports for both distributed and single device

### DIFF
--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -88,6 +88,9 @@ For a list of all possible recipes, run `tune ls`."""
         # Have to reset the argv so that the recipe can be run with the correct arguments
         args.training_script = args.recipe
         args.training_script_args = args.recipe_args
+        # torchtune built-in recipes are specified with an absolute posix path, but
+        # custom recipes are specified as a relative module dot path and need to be
+        # run with python -m
         args.module = not is_builtin
         run(args)
 

--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import os
 import runpy
 import sys
 import textwrap
@@ -79,7 +80,7 @@ For a list of all possible recipes, run `tune ls`."""
             self._parser._add_action(action)
 
     @record
-    def _run_distributed(self, args: argparse.Namespace):
+    def _run_distributed(self, args: argparse.Namespace, is_builtin: bool):
         """Run a recipe with torchrun."""
         # TODO (rohan-varma): Add check that nproc_per_node <= cuda device count. Currently,
         # we don't do this since we test on CPUs for distributed. Will update once multi GPU CI is supported.
@@ -87,12 +88,18 @@ For a list of all possible recipes, run `tune ls`."""
         # Have to reset the argv so that the recipe can be run with the correct arguments
         args.training_script = args.recipe
         args.training_script_args = args.recipe_args
+        args.module = not is_builtin
         run(args)
 
-    def _run_single_device(self, args: argparse.Namespace):
+    def _run_single_device(self, args: argparse.Namespace, is_builtin: bool):
         """Run a recipe on a single device."""
         sys.argv = [str(args.recipe)] + args.recipe_args
-        runpy.run_path(str(args.recipe), run_name="__main__")
+        if is_builtin:
+            # torchtune built-in recipes are specified with an absolute posix path
+            runpy.run_path(str(args.recipe), run_name="__main__")
+        else:
+            # custom recipes are specified as a relative module dot path
+            runpy.run_module(str(args.recipe), run_name="__main__")
 
     def _is_distributed_args(self, args: argparse.Namespace):
         """Check if the user is trying to run a distributed recipe."""
@@ -154,9 +161,11 @@ For a list of all possible recipes, run `tune ls`."""
         recipe = self._get_recipe(args.recipe)
         if recipe is None:
             recipe_path = args.recipe
+            is_builtin = False
         else:
             recipe_path = str(ROOT / "recipes" / recipe.file_path)
             supports_distributed = recipe.supports_distributed
+            is_builtin = True
 
         # Get config path
         config = self._get_config(config_str, recipe)
@@ -169,6 +178,9 @@ For a list of all possible recipes, run `tune ls`."""
         args.recipe = recipe_path
         args.recipe_args[config_idx] = config_path
 
+        # Make sure user code in current directory is importable
+        sys.path.append(os.getcwd())
+
         # Execute recipe
         if self._is_distributed_args(args):
             if not supports_distributed:
@@ -176,6 +188,6 @@ For a list of all possible recipes, run `tune ls`."""
                     f"Recipe {recipe.name} does not support distributed training."
                     "Please run without torchrun commands."
                 )
-            self._run_distributed(args)
+            self._run_distributed(args, is_builtin=is_builtin)
         else:
-            self._run_single_device(args)
+            self._run_single_device(args, is_builtin=is_builtin)

--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
-import os
 import runpy
 import sys
 import textwrap
@@ -169,11 +168,6 @@ For a list of all possible recipes, run `tune ls`."""
         # Prepare args
         args.recipe = recipe_path
         args.recipe_args[config_idx] = config_path
-
-        # Make sure user code in current directory is importable
-        # TODO: This is a temporary fix, figure out how to make runpy and torchrun
-        # run from this directory
-        sys.path.append(os.getcwd())
 
         # Execute recipe
         if self._is_distributed_args(args):

--- a/torchtune/config/_instantiate.py
+++ b/torchtune/config/_instantiate.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import os
+import sys
 from typing import Any, Callable, Dict, Tuple
 
 from omegaconf import DictConfig, OmegaConf
@@ -88,6 +90,10 @@ def instantiate(
         return None
     if not OmegaConf.is_dict(config):
         raise ValueError(f"instantiate only supports DictConfigs, got {type(config)}")
+
+    # Ensure local imports are able to be instantiated
+    if os.getcwd() not in sys.path:
+        sys.path.append(os.getcwd())
 
     config_copy = copy.deepcopy(config)
     config_copy._set_flag(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Closes #1540. To run custom recipes, you now need to specify via dotpath as if it were a module. this enables running with `python -m` under the hood of `torch.distributed.run` which will automatically prepend the current directory to sys.path.

In `instantiate`, we append the current working directory to the sys.path so it is recognized by `import_module` in `_get_component_from_path` in the Python path. This applies to both single device and distributed runs - previously we appended to sys.path BEFORE `torch.distributed.run` (#1617) which discards it for some reason. Now, we do it within instantiate itself.

#### Test plan
Log before the fix, the CWD is not present in sys.path right before `import_module`:
```
2024-10-01:12:14:30,820 INFO     [_utils.py:75] pythonpath: ['/data/users/rafiayub/torchtune-rafiayub/recipes', '/home/rafiayub/.conda/envs/torchtune/lib/python310.zip', '/home/rafiayub/.conda/envs/torchtune/lib/python3.10', '/home/rafiayub/.conda/envs/torchtune/lib/python3.10/lib-dynload', '/home/rafiayub/.conda/envs/torchtune/lib/python3.10/site-packages', '__editable__.torchtune-0.0.0.finder.__path_hook__', '/data/users/rafiayub/torchtune-rafiayub/docs/src/pytorch-sphinx-theme', '/tmp/tmpgqp_rg5o']
2024-10-01:12:14:30,820 INFO     [_utils.py:76] cwd: /data/users/rafiayub
2024-10-01:12:14:30,820 INFO     [_utils.py:77] import path ['data', 'dataset', 'custom_dataset']
```

Log after the fix, you can see the CWD at the end of sys.path:
```
2024-10-01:12:16:57,555 INFO     [_utils.py:77] pythonpath: ['/data/users/rafiayub/torchtune-rafiayub/recipes', '/home/rafiayub/.conda/envs/torchtune/lib/python310.zip', '/home/rafiayub/.conda/envs/torchtune/lib/python3.10', '/home/rafiayub/.conda/envs/torchtune/lib/python3.10/lib-dynload', '/home/rafiayub/.conda/envs/torchtune/lib/python3.10/site-packages', '__editable__.torchtune-0.0.0.finder.__path_hook__', '/data/users/rafiayub/torchtune-rafiayub/docs/src/pytorch-sphinx-theme', '/tmp/tmp695bcof_', '/data/users/rafiayub']
2024-10-01:12:16:57,555 INFO     [_utils.py:78] cwd: /data/users/rafiayub
2024-10-01:12:16:57,555 INFO     [_utils.py:79] import path ['data', 'dataset', 'custom_dataset']
```

Tested both distributed and single device runs by using `tune cp` and modifying config to point to a local custom dataset builder at `data.dataset.custom_dataset`:
```
def custom_dataset(tokenizer):
	return alpaca_dataset(tokenizer)
```

Also tested the four combinations:
- built-in single device recipe + custom component: `tune run full_finetune_single_device --config config/my_config_single_device.yaml`
- custom single device recipe + custom imports + custom component: `tune run recipe.tune_single --config config/my_config_single_device.yaml`
- built-in distributed recipe + custom component: `tune run --nproc_per_node 4 full_finetune_distributed --config config/my_config.yaml`
- custom distributedrecipe + custom imports + custom component: `tune run --nproc_per_node 4 recipe.tune_dist --config config/my_config.yaml`