### PR TITLE
Fix CLIP pos embedding interpolation to work on DTensors

### DIFF
--- a/torchtune/models/clip/_position_embeddings.py
+++ b/torchtune/models/clip/_position_embeddings.py
@@ -139,7 +139,7 @@ class TiledTokenPositionalEmbedding(nn.Module):
             prefix + "local_token_positional_embedding"
         )
         local_device = inpt_local_pos_embed.device
-        if isinstance(self.local_token_positional_embedding, DTensor):
+        if isinstance(inpt_local_pos_embed, DTensor):
             inpt_local_pos_embed = inpt_local_pos_embed.full_tensor()
 
         if inpt_local_pos_embed is not None:
@@ -189,7 +189,7 @@ class TiledTokenPositionalEmbedding(nn.Module):
             prefix + "global_token_positional_embedding"
         )
         global_device = inpt_global_pos_embed.device
-        if isinstance(self.global_token_positional_embedding, DTensor):
+        if isinstance(inpt_global_pos_embed, DTensor):
             inpt_global_pos_embed = inpt_global_pos_embed.full_tensor()
 
         if inpt_global_pos_embed is not None:
@@ -521,7 +521,7 @@ class TilePositionalEmbedding(nn.Module):
 
         embedding = state_dict.get(prefix + "embedding")
         device = embedding.device
-        if isinstance(self.embedding, DTensor):
+        if isinstance(embedding, DTensor):
             embedding = embedding.full_tensor()
         if embedding is not None:
 

--- a/torchtune/models/clip/_position_embeddings.py
+++ b/torchtune/models/clip/_position_embeddings.py
@@ -140,7 +140,10 @@ class TiledTokenPositionalEmbedding(nn.Module):
         )
         local_device = inpt_local_pos_embed.device
         if isinstance(inpt_local_pos_embed, DTensor):
+            local_embed_is_sharded = True
             inpt_local_pos_embed = inpt_local_pos_embed.full_tensor()
+        else:
+            local_embed_is_sharded = False
 
         if inpt_local_pos_embed is not None:
 
@@ -164,7 +167,7 @@ class TiledTokenPositionalEmbedding(nn.Module):
                 tgt_patch_grid_size=int(math.sqrt(tgt_n_tokens_per_tile - 1)),
             )
 
-            if isinstance(inpt_local_pos_embed, DTensor):
+            if local_embed_is_sharded:
                 inpt_local_pos_embed = distribute_tensor(
                     inpt_local_pos_embed,
                     device_mesh=self.local_token_positional_embedding.device_mesh,
@@ -190,7 +193,10 @@ class TiledTokenPositionalEmbedding(nn.Module):
         )
         global_device = inpt_global_pos_embed.device
         if isinstance(inpt_global_pos_embed, DTensor):
+            global_embed_is_sharded = True
             inpt_global_pos_embed = inpt_global_pos_embed.full_tensor()
+        else:
+            global_embed_is_sharded = False
 
         if inpt_global_pos_embed is not None:
 
@@ -218,7 +224,7 @@ class TiledTokenPositionalEmbedding(nn.Module):
                 tgt_patch_grid_size=int(math.sqrt(tgt_n_tokens_per_tile - 1)),
             )
 
-            if isinstance(inpt_global_pos_embed, DTensor):
+            if global_embed_is_sharded:
                 inpt_global_pos_embed = distribute_tensor(
                     inpt_global_pos_embed,
                     device_mesh=self.global_token_positional_embedding.device_mesh,
@@ -522,7 +528,11 @@ class TilePositionalEmbedding(nn.Module):
         embedding = state_dict.get(prefix + "embedding")
         device = embedding.device
         if isinstance(embedding, DTensor):
+            embedding_is_sharded = True
             embedding = embedding.full_tensor()
+        else:
+            embedding_is_sharded = False
+
         if embedding is not None:
 
             # ckpt pos emb
@@ -559,7 +569,7 @@ class TilePositionalEmbedding(nn.Module):
                 embedding, tgt_max_num_tiles=tgt_max_num_tiles_x
             )
 
-            if isinstance(embedding_new, DTensor):
+            if embedding_is_sharded:
                 embedding_new = distribute_tensor(
                     embedding_new,
                     device_mesh=self.embedding.device_mesh,

--- a/torchtune/models/clip/_position_embeddings.py
+++ b/torchtune/models/clip/_position_embeddings.py
@@ -141,6 +141,8 @@ class TiledTokenPositionalEmbedding(nn.Module):
         local_device = inpt_local_pos_embed.device
         if isinstance(inpt_local_pos_embed, DTensor):
             local_embed_is_sharded = True
+            local_embed_device_mesh = inpt_local_pos_embed.device_mesh
+            local_embed_placements = inpt_local_pos_embed.placements
             inpt_local_pos_embed = inpt_local_pos_embed.full_tensor()
         else:
             local_embed_is_sharded = False
@@ -170,8 +172,8 @@ class TiledTokenPositionalEmbedding(nn.Module):
             if local_embed_is_sharded:
                 inpt_local_pos_embed = distribute_tensor(
                     inpt_local_pos_embed,
-                    device_mesh=self.local_token_positional_embedding.device_mesh,
-                    placements=self.local_token_positional_embedding.placements,
+                    device_mesh=local_embed_device_mesh,
+                    placements=local_embed_placements,
                 )
 
             # update state dict
@@ -194,6 +196,8 @@ class TiledTokenPositionalEmbedding(nn.Module):
         global_device = inpt_global_pos_embed.device
         if isinstance(inpt_global_pos_embed, DTensor):
             global_embed_is_sharded = True
+            global_embed_device_mesh = inpt_global_pos_embed.device_mesh
+            global_embed_placements = inpt_global_pos_embed.placements
             inpt_global_pos_embed = inpt_global_pos_embed.full_tensor()
         else:
             global_embed_is_sharded = False
@@ -227,8 +231,8 @@ class TiledTokenPositionalEmbedding(nn.Module):
             if global_embed_is_sharded:
                 inpt_global_pos_embed = distribute_tensor(
                     inpt_global_pos_embed,
-                    device_mesh=self.global_token_positional_embedding.device_mesh,
-                    placements=self.global_token_positional_embedding.placements,
+                    device_mesh=global_embed_device_mesh,
+                    placements=global_embed_placements,
                 )
 
             # update state dict
@@ -529,6 +533,8 @@ class TilePositionalEmbedding(nn.Module):
         device = embedding.device
         if isinstance(embedding, DTensor):
             embedding_is_sharded = True
+            device_mesh = embedding.device_mesh
+            placements = embedding.placements
             embedding = embedding.full_tensor()
         else:
             embedding_is_sharded = False
@@ -572,8 +578,8 @@ class TilePositionalEmbedding(nn.Module):
             if embedding_is_sharded:
                 embedding_new = distribute_tensor(
                     embedding_new,
-                    device_mesh=self.embedding.device_mesh,
-                    placements=self.embedding.placements,
+                    device_mesh=device_mesh,
+                    placements=placements,
                 )
 
             # update state dict

--- a/torchtune/models/clip/_position_embeddings.py
+++ b/torchtune/models/clip/_position_embeddings.py
@@ -164,17 +164,17 @@ class TiledTokenPositionalEmbedding(nn.Module):
                 tgt_patch_grid_size=int(math.sqrt(tgt_n_tokens_per_tile - 1)),
             )
 
-            # update state dict
-            embedding_new_local = distribute_tensor(
-                inpt_local_pos_embed,
-                device_mesh=self.local_token_positional_embedding.device_mesh,
-                placements=self.local_token_positional_embedding.placements,
-            )
+            if isinstance(inpt_local_pos_embed, DTensor):
+                inpt_local_pos_embed = distribute_tensor(
+                    inpt_local_pos_embed,
+                    device_mesh=self.local_token_positional_embedding.device_mesh,
+                    placements=self.local_token_positional_embedding.placements,
+                )
 
             # update state dict
             state_dict[
                 prefix + "local_token_positional_embedding"
-            ] = embedding_new_local
+            ] = inpt_local_pos_embed
             if (
                 inpt_local_pos_embed.shape
                 != self.local_token_positional_embedding.shape
@@ -218,17 +218,17 @@ class TiledTokenPositionalEmbedding(nn.Module):
                 tgt_patch_grid_size=int(math.sqrt(tgt_n_tokens_per_tile - 1)),
             )
 
-            # update state dict
-            embedding_new_global = distribute_tensor(
-                inpt_global_pos_embed,
-                device_mesh=self.global_token_positional_embedding.device_mesh,
-                placements=self.global_token_positional_embedding.placements,
-            )
+            if isinstance(inpt_global_pos_embed, DTensor):
+                inpt_global_pos_embed = distribute_tensor(
+                    inpt_global_pos_embed,
+                    device_mesh=self.global_token_positional_embedding.device_mesh,
+                    placements=self.global_token_positional_embedding.placements,
+                )
 
             # update state dict
             state_dict[
                 prefix + "global_token_positional_embedding"
-            ] = embedding_new_global
+            ] = inpt_global_pos_embed
             if (
                 inpt_global_pos_embed.shape
                 != self.global_token_positional_embedding.shape
@@ -559,13 +559,14 @@ class TilePositionalEmbedding(nn.Module):
                 embedding, tgt_max_num_tiles=tgt_max_num_tiles_x
             )
 
-            # update state dict
-            embedding_new = distribute_tensor(
-                embedding_new,
-                device_mesh=self.embedding.device_mesh,
-                placements=self.embedding.placements,
-            )
+            if isinstance(embedding_new, DTensor):
+                embedding_new = distribute_tensor(
+                    embedding_new,
+                    device_mesh=self.embedding.device_mesh,
+                    placements=self.embedding.placements,
+                )
 
+            # update state dict
             state_dict[prefix + "embedding"] = embedding_new
             if embedding_new.shape != self.embedding.shape:
                 raise ValueError(

--- a/torchtune/models/clip/_position_embeddings.py
+++ b/torchtune/models/clip/_position_embeddings.py
@@ -138,16 +138,19 @@ class TiledTokenPositionalEmbedding(nn.Module):
         inpt_local_pos_embed = state_dict.get(
             prefix + "local_token_positional_embedding"
         )
-        local_device = inpt_local_pos_embed.device
-        if isinstance(inpt_local_pos_embed, DTensor):
-            local_embed_is_sharded = True
-            local_embed_device_mesh = inpt_local_pos_embed.device_mesh
-            local_embed_placements = inpt_local_pos_embed.placements
-            inpt_local_pos_embed = inpt_local_pos_embed.full_tensor()
-        else:
-            local_embed_is_sharded = False
 
         if inpt_local_pos_embed is not None:
+
+            # We can only apply F.interpolate to vanilla tensors, not DTensors
+            # If pos embeds are a DTensor, we gather the full tensor, apply
+            # interpolate, and then reshard after
+            if isinstance(inpt_local_pos_embed, DTensor):
+                local_embed_is_sharded = True
+                local_embed_device_mesh = inpt_local_pos_embed.device_mesh
+                local_embed_placements = inpt_local_pos_embed.placements
+                inpt_local_pos_embed = inpt_local_pos_embed.full_tensor()
+            else:
+                local_embed_is_sharded = False
 
             # sanity check
             inpt_n_tokens_per_tile, inpt_embed_dim = inpt_local_pos_embed.shape
@@ -193,16 +196,19 @@ class TiledTokenPositionalEmbedding(nn.Module):
         inpt_global_pos_embed = state_dict.get(
             prefix + "global_token_positional_embedding"
         )
-        global_device = inpt_global_pos_embed.device
-        if isinstance(inpt_global_pos_embed, DTensor):
-            global_embed_is_sharded = True
-            global_embed_device_mesh = inpt_global_pos_embed.device_mesh
-            global_embed_placements = inpt_global_pos_embed.placements
-            inpt_global_pos_embed = inpt_global_pos_embed.full_tensor()
-        else:
-            global_embed_is_sharded = False
 
         if inpt_global_pos_embed is not None:
+
+            # We can only apply F.interpolate to vanilla tensors, not DTensors
+            # If pos embeds are a DTensor, we gather the full tensor, apply
+            # interpolate, and then reshard after
+            if isinstance(inpt_global_pos_embed, DTensor):
+                global_embed_is_sharded = True
+                global_embed_device_mesh = inpt_global_pos_embed.device_mesh
+                global_embed_placements = inpt_global_pos_embed.placements
+                inpt_global_pos_embed = inpt_global_pos_embed.full_tensor()
+            else:
+                global_embed_is_sharded = False
 
             _, _, inpt_n_tokens_per_tile, _ = inpt_global_pos_embed.shape
 
@@ -530,16 +536,19 @@ class TilePositionalEmbedding(nn.Module):
         """
 
         embedding = state_dict.get(prefix + "embedding")
-        device = embedding.device
-        if isinstance(embedding, DTensor):
-            embedding_is_sharded = True
-            device_mesh = embedding.device_mesh
-            placements = embedding.placements
-            embedding = embedding.full_tensor()
-        else:
-            embedding_is_sharded = False
 
         if embedding is not None:
+
+            # We can only apply F.interpolate to vanilla tensors, not DTensors
+            # If pos embeds are a DTensor, we gather the full tensor, apply
+            # interpolate, and then reshard after
+            if isinstance(embedding, DTensor):
+                embedding_is_sharded = True
+                device_mesh = embedding.device_mesh
+                placements = embedding.placements
+                embedding = embedding.full_tensor()
+            else:
+                embedding_is_sharded = False
 
             # ckpt pos emb
             (

--- a/torchtune/models/clip/_position_embeddings.py
+++ b/torchtune/models/clip/_position_embeddings.py
@@ -139,9 +139,8 @@ class TiledTokenPositionalEmbedding(nn.Module):
             prefix + "local_token_positional_embedding"
         )
         local_device = inpt_local_pos_embed.device
-        self.to_empty(device=local_device)
         if isinstance(self.local_token_positional_embedding, DTensor):
-            inpt_local_pos_embed = self.local_token_positional_embedding.full_tensor()
+            inpt_local_pos_embed = inpt_local_pos_embed.full_tensor()
 
         if inpt_local_pos_embed is not None:
 
@@ -191,7 +190,7 @@ class TiledTokenPositionalEmbedding(nn.Module):
         )
         global_device = inpt_global_pos_embed.device
         if isinstance(self.global_token_positional_embedding, DTensor):
-            inpt_global_pos_embed = self.global_token_positional_embedding.full_tensor()
+            inpt_global_pos_embed = inpt_global_pos_embed.full_tensor()
 
         if inpt_global_pos_embed is not None:
 
@@ -522,9 +521,8 @@ class TilePositionalEmbedding(nn.Module):
 
         embedding = state_dict.get(prefix + "embedding")
         device = embedding.device
-        self.to_empty(device=device)
         if isinstance(self.embedding, DTensor):
-            embedding = self.embedding.full_tensor()
+            embedding = embedding.full_tensor()
         if embedding is not None:
 
             # ckpt pos emb


### PR DESCRIPTION
Currently our state dict hooks to resize CLIP positional embeddings do not work with FSDP2. This is because some of the ops used by interpolate (e.g. `aten.upsample_bilinear2d.default`) are not natively defined on `DTensor`, and as can be seen [here](https://github.com/pytorch/torchtune/blob/fc0249d6c88e0988dcce2ce9bbaf26b828794cd6/torchtune/training/_distributed.py#L337-L346), we shard the state dict tensors into DTensors before calling `load_state_dict` (where the interpolation hook is triggered).

Until these ops are defined on DTensors, we need to do something like this. This PR adds logic to the CLIP positional embedding state dict hooks to handle the case that tensors in the state dict are already sharded. For each relevant tensor, we:

1) Check if the state dict tensor is a DTensor
2) If it is, we gather via `.full_tensor()`. If it isn't, we don't do anything.
3) Call interpolate (along with various reshapes) on the vanilla Tensor from (2)
4) If the original state dict tensor was a DTensor, we call `distribute_tensor` using the original mesh and placements. Otherwise we don't do anything.

Test plan:

```
pytest tests/torchtune/models/clip/test_pos_embedding_interpolation.py
...
========== 15 passed in 0.66s ============
```

Compare loss curves on recipe before and after fix on base model. First, update 11B_lora_single_device.yaml to match [this](https://gist.github.com/ebsmothers/b9ab22658e8cd7ed27d8d550b2c4cd5f)

Before fix (on main):


```
tune run lora_finetune_single_device --config llama3_2_vision/11B_lora_single_device max_steps_per_epoch=100 \
metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=test-1739 \
metric_logger.name=pre-fix
```

After fix (this PR)

```
tune run lora_finetune_single_device --config llama3_2_vision/11B_lora_single_device max_steps_per_epoch=100 \
metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=test-1739 \
metric_logger.name=post-fix
```

<img width="1204" alt="Screenshot 2024-10-02 at 10 15 15 AM" src="https://github.com/user-attachments/assets/cc4afe36-eab2-4d37-93c6-0ae8c7a75ac7">


Test that distributed recipe now runs: change 11B_lora config to use base model: [here](https://gist.github.com/ebsmothers/f96bbc7ee80c0b195db4892db608c094). Then run:

```
tune run --nproc_per_node 2 lora_finetune_distributed --config llama3_2_vision/11B_lora
...
1|2|Loss: 1.3108230829238892:   0%|                                                                                                                         | 2/10359 [00:57<82:38:19, 28.72s/it]
```