### PR TITLE
Move urllib pin to Github workflow

### DIFF
--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -43,7 +43,7 @@ jobs:
           python -m pip install torch torchvision torchao
           python -m pip install -e ".[dev]"
           python -m pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git@fb963f0f0a5b28b69763590bb59676072cf43a01
-          python -m pip install urllib3<2.0.0
+          python -m pip install "urllib3<2.0.0"
       - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -43,6 +43,7 @@ jobs:
           python -m pip install torch torchvision torchao
           python -m pip install -e ".[dev]"
           python -m pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git@fb963f0f0a5b28b69763590bb59676072cf43a01
+          python -m pip install urllib3<2.0.0
       - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,6 @@ dev = [
     "pytest-mock",
     "pytest-integration",
     "tensorboard",
-    # Pin urllib3 to avoid transient error from https://github.com/psf/requests/issues/6443
-    "urllib3<2.0.0",
     "wandb",
     "expecttest",
 ]


### PR DESCRIPTION
Pin urllib for recipe test in the Github workflow script instead of in dev dependencies. 

**Why?**: Follows the pattern we use for lm-eval. If we want to pin in dev dependencies, then we should move the eleuther download to the dev dependencies, as well. 