### PR TITLE
Adds __repr__ to Message

### DIFF
--- a/tests/torchtune/data/test_messages.py
+++ b/tests/torchtune/data/test_messages.py
@@ -86,6 +86,17 @@ class TestMessage:
         assert text_message.text_content == "hello world"
         assert image_message.text_content == "hello world"
 
+    def test_repr_text(self, text_message):
+        expected_repr = "Message(role='user', content=['hello world'])"
+        assert str(text_message) == expected_repr
+        assert repr(text_message) == expected_repr
+
+    def test_repr_image(self, image_message, test_image):
+        img_repr = str(test_image)
+        expected_repr = f"Message(role='user', content=['hello', {img_repr}, ' world'])"
+        assert str(image_message) == expected_repr
+        assert repr(image_message) == expected_repr
+
 
 class TestInputOutputToMessages:
     @pytest.fixture

--- a/torchtune/data/_messages.py
+++ b/torchtune/data/_messages.py
@@ -138,7 +138,7 @@ class Message:
 
     def __repr__(self) -> str:
         content_only = [content["content"] for content in self.content]
-        return f"Message(role={self.role!r}, content={content_only!r})"
+        return f"Message(role='{self.role}', content={content_only!r})"
 
 
 class InputOutputToMessages(Transform):

--- a/torchtune/data/_messages.py
+++ b/torchtune/data/_messages.py
@@ -136,6 +136,10 @@ class Message:
                 f"Only assistant messages can be tool calls. Found role {self.role} in message: {self.text_content}"
             )
 
+    def __repr__(self) -> str:
+        content_only = [content["content"] for content in self.content]
+        return f"Message(role={self.role!r}, content={content_only!r})"
+
 
 class InputOutputToMessages(Transform):
     """


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Fixes https://github.com/pytorch/torchtune/issues/1639

Updating `__repr__` configures the output for `__str__` as well. This PR diffs a little from the initial proposal by printing out the list of items. The content type is not printed out, since it can be inferred from the `__repr__` itself. i.e. strings are printed directly and `Image` uses the `__repr__` from PIL.

#### Changelog
* Adds `__repr__` to `Message`.

#### Test plan

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
