### PR TITLE
Custom recipes use slash path

### DIFF
--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -123,6 +123,18 @@ For a list of all possible recipes, run `tune ls`."""
             if recipe.name == recipe_str:
                 return recipe
 
+    def _convert_to_dotpath(self, recipe_path: str) -> str:
+        """Convert a custom recipe path to a dot path that can be run as a module.
+
+        Args:
+            recipe_path (str): The path of the recipe.
+
+        Returns:
+            The dot path of the recipe.
+        """
+        filepath, _ = os.path.splitext(recipe_path)
+        return filepath.replace("/", ".")
+
     def _get_config(
         self, config_str: str, specific_recipe: Optional[Recipe]
     ) -> Optional[Config]:
@@ -163,7 +175,7 @@ For a list of all possible recipes, run `tune ls`."""
         # Get recipe path
         recipe = self._get_recipe(args.recipe)
         if recipe is None:
-            recipe_path = args.recipe
+            recipe_path = self._convert_to_dotpath(args.recipe)
             is_builtin = False
         else:
             recipe_path = str(ROOT / "recipes" / recipe.file_path)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Custom imports/recipes were fixed by running as modules, but this required users to specify custom recipes as dotpaths, i.e., `tune run path.to.my.recipe` which isn't consistent (as discussed in #1759). We do the conversion under the hood for them here so they can still specify standard file paths with slashes.

#### Test plan
both of these now run, and they rely on custom dataset builders located outside of torchtune repo:
`tune run --nproc_per_node 8 recipe/sft --config config/sft_llama3_2_1B.yaml`
`tune run --nproc_per_node 8 recipe/sft.py --config config/sft_llama3_2_1B.yaml`