### PR TITLE
Fix save adapter weights only

### DIFF
--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -401,19 +401,13 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                 }
             )
 
-        adapter_key_filter = lambda x: x in self.adapter_params
+        adapter_state_dict = {k: v.cpu() for k, v in self.adapter_params.items()}
+        ckpt_dict.update({training.ADAPTER_KEY: adapter_state_dict})
         if not self._save_adapter_weights_only:
             # Construct the full state dict with LoRA weights merged into base LLM weights
 
             # Move to CPU to avoid a copy on GPU
             state_dict = {k: v.cpu() for k, v in self._model.state_dict().items()}
-
-            # Construct the adapter weights
-            # Do this using the state_dict to avoid running upcast and H2D in state_dict post hook twice
-            # Must be before get_merged_lora_ckpt because get_merged_lora_ckpt will remove lora keys
-            adapter_state_dict = {
-                k: v for k, v in state_dict.items() if adapter_key_filter(k)
-            }
 
             merged_state_dict = get_merged_lora_ckpt(
                 state_dict,
@@ -422,13 +416,6 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             )
 
             ckpt_dict.update({training.MODEL_KEY: merged_state_dict})
-        else:
-            # No need to merge state dict if we're only saving adapter weights
-            adapter_state_dict = {
-                k: v.cpu() for k, v in get_adapter_params(self._model).items()
-            }
-
-        ckpt_dict.update({training.ADAPTER_KEY: adapter_state_dict})
 
         self._checkpointer.save_checkpoint(
             ckpt_dict,

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -577,19 +577,14 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 }
             )
 
+        adapter_state_dict = {k: v.cpu() for k, v in self.adapter_params.items()}
+        ckpt_dict.update({training.ADAPTER_KEY: adapter_state_dict})
+
         if not self._save_adapter_weights_only:
             # Construct the full state dict with LoRA weights merged into base LLM weights
 
             # Move to CPU to avoid a copy on GPU
             state_dict = {k: v.cpu() for k, v in self._model.state_dict().items()}
-
-            # Construct the adapter weights
-            # Do this using the state_dict to avoid running upcast and H2D in state_dict post hook twice
-            # Must be before get_merged_lora_ckpt because get_merged_lora_ckpt will remove lora keys
-            adapter_key_filter = lambda x: x in self.adapter_params
-            adapter_state_dict = {
-                k: v for k, v in state_dict.items() if adapter_key_filter(k)
-            }
 
             merged_state_dict = get_merged_lora_ckpt(
                 state_dict,
@@ -598,13 +593,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             )
 
             ckpt_dict.update({training.MODEL_KEY: merged_state_dict})
-        else:
-            # No need to merge state dict if we're only saving adapter weights
-            adapter_state_dict = {
-                k: v.cpu() for k, v in get_adapter_params(self._model).items()
-            }
 
-        ckpt_dict.update({training.ADAPTER_KEY: adapter_state_dict})
         adapter_config = {
             "r": self._lora_rank,
             "lora_alpha": self._lora_alpha,

--- a/tests/recipes/test_lora_dpo_single_device.py
+++ b/tests/recipes/test_lora_dpo_single_device.py
@@ -32,7 +32,6 @@ class TestLoRADPOSingleDeviceRecipe:
             "batch_size=8",
             "device=cpu",
             f"dtype={dtype_str}",
-            "enable_activation_checkpointing=False",
             "dataset.train_on_input=False",
             "seed=9",
             f"epochs={epochs}",
@@ -83,6 +82,7 @@ class TestLoRADPOSingleDeviceRecipe:
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
             metric_logger.filename={log_file} \
+            enable_activation_checkpointing=True \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama2_lora"]
@@ -112,6 +112,7 @@ class TestLoRADPOSingleDeviceRecipe:
             metric_logger.filename={resumed_log_file} \
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
+            enable_activation_checkpointing=True \
         """.split()
         cmd_2 = cmd_2 + self._get_test_config_overrides(epochs=3) + model_config
         monkeypatch.setattr(sys, "argv", cmd_2)
@@ -142,6 +143,7 @@ class TestLoRADPOSingleDeviceRecipe:
             checkpointer.model_type=LLAMA2 \
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
+            enable_activation_checkpointing=False \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama2_lora"]

--- a/tests/recipes/test_lora_finetune_distributed.py
+++ b/tests/recipes/test_lora_finetune_distributed.py
@@ -33,7 +33,6 @@ class TestLoRAFinetuneDistributedRecipe:
     def _get_test_config_overrides(self):
         return [
             "batch_size=4",
-            "enable_activation_checkpointing=False",
             "dataset.train_on_input=False",
             "seed=9",
             "epochs=2",
@@ -81,6 +80,7 @@ class TestLoRAFinetuneDistributedRecipe:
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
             reshard_after_forward={reshard_after_forward} \
+            enable_activation_checkpointing=False \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama2_lora"]
@@ -147,6 +147,7 @@ class TestLoRAFinetuneDistributedRecipe:
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
+            enable_activation_checkpointing=True \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS[model_type + "_lora"]
@@ -171,6 +172,7 @@ class TestLoRAFinetuneDistributedRecipe:
             tokenizer.prompt_template=null \
             resume_from_checkpoint=True \
             metric_logger.filename={log_file} \
+            enable_activation_checkpointing=True \
         """.split()
 
         cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config
@@ -213,6 +215,7 @@ class TestLoRAFinetuneDistributedRecipe:
             checkpointer.model_type={model_type.upper()} \
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
+            enable_activation_checkpointing=True \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS[model_type + "_lora"]

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -35,7 +35,6 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             "batch_size=8",
             "device=cpu",
             f"dtype={dtype_str}",
-            "enable_activation_checkpointing=False",
             "dataset.train_on_input=False",
             "seed=9",
             f"epochs={epochs}",
@@ -133,6 +132,7 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
             compile={compile} \
+            enable_activation_checkpointing=False \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama2_qlora"]
@@ -188,6 +188,7 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
+            enable_activation_checkpointing=True \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama2_lora"]
@@ -213,6 +214,7 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             metric_logger.filename={log_file} \
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
+            enable_activation_checkpointing=True \
         """.split()
         cmd_2 = cmd_2 + self._get_test_config_overrides(epochs=3) + model_config
         monkeypatch.setattr(sys, "argv", cmd_2)
@@ -244,6 +246,7 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             checkpointer.model_type=LLAMA2 \
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
+            enable_activation_checkpointing=True \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama2_lora"]


### PR DESCRIPTION
Fixes #1713 

### Summary

We should not be using `get_adapter_params` on models with activation checkpointing enabled. This is because `get_adapter_params` iterates over `named_modules`, not `state_dict`. This is a good thing from a memory perspective, but it also means that the state dict hooks that are usually triggered to unwrap activation checkpointing wrapper modules (or previously FSDP wrapper modules) do not get triggered. We can consider adding an option to `get_adapter_params` to do this in that utility cause this is a bit tricky. At the same time, that also feels hacky. 

Actually this is really only an issue in our single-device recipe when `save_adapter_weights_only=True` -- otherwise we filter the state dict on the keys of `self.adapter_params` (this is correct because (a) `self.adapter_params` is defined before any AC wrapping and (b) we are using the state dict so the relevant hooks have fired). 

But actually, we don't need to use `get_adapter_params` here at all: we already have references to all the adapter weights and the correct (non-AC-wrapped) keys in `self.adapter_params` as defined [here](https://github.com/pytorch/torchtune/blob/a8a64ec6a99a6ea2be4fdaf0cd5797b03a2567cf/recipes/lora_finetune_single_device.py#L407). So we can just use that, and we can do it regardless of the value of `save_adapter_weights_only` (which makes the code a bit cleaner).

### Test plan

Why didn't we catch this before? Well actually all of our existing recipes tests set `enable_activation_checkpointing=False` so we missed it. For that reason I've updated the `test_recipe_state_on_resume` tests to have `enable_activation_checkpointing=True`. Running those tests on main with the new values for `enable_activation_checkpointing`:

```
pytest tests/recipes/test_lora_finetune_single_device.py -m integration_test -k 'test_training_state_on_resume'
...
===== 1 failed, 1 passed, 9 deselected, 1 warning in 7.29s ======


pytest tests/recipes/test_lora_dpo_single_device.py -m integration_test -k 'test_training_st
ate_on_resume'
...
==== 1 failed, 1 passed, 1 deselected, 1 warning in 28.37s =======
```

If we instead run with the changes on this PR:

```
pytest tests/recipes/test_lora_finetune_distributed.py -m integration_test
...
========== 7 passed in 127.43s (0:02:07) ==========

pytest tests/recipes/test_lora_dpo_single_device.py -m integration_test
...
========== 3 passed, 2 warnings in 52.46s =======

pytest tests/recipes/test_lora_finetune_single_device.py -m integration_test
...
========== 11 passed, 2 warnings in 271.11s (0:04:31) ===========
```


Also, the command from #1713 that was failing before now passes:

```
tune run lora_finetune_single_device --config llama3_2/3B_lora_single_device max_steps_per_epoch=10 \
gradient_accumulation_steps=1 epochs=1 save_adapter_weights_only=True
```

