### PR TITLE
Make AlpacaToMessage public.

### DIFF
--- a/docs/source/api_ref_data.rst
+++ b/docs/source/api_ref_data.rst
@@ -64,6 +64,7 @@ Converts data from common schema and conversation JSON formats into a list of to
     ShareGPTToMessages
     OpenAIToMessages
     ChosenRejectedToMessages
+    AlpacaToMessages
 
 Collaters
 ---------

--- a/torchtune/data/__init__.py
+++ b/torchtune/data/__init__.py
@@ -23,6 +23,7 @@ from torchtune.data._messages import (
     OpenAIToMessages,
     Role,
     ShareGPTToMessages,
+    AlpacaToMessages,
     validate_messages,
 )
 from torchtune.data._prompt_templates import (
@@ -43,6 +44,7 @@ __all__ = [
     "SummarizeTemplate",
     "OpenAIToMessages",
     "ShareGPTToMessages",
+    "AlpacaToMessages",
     "truncate",
     "Message",
     "validate_messages",

--- a/torchtune/data/__init__.py
+++ b/torchtune/data/__init__.py
@@ -17,13 +17,13 @@ from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
 from torchtune.data._converters import get_openai_messages, get_sharegpt_messages
 from torchtune.data._instruct_templates import InstructTemplate
 from torchtune.data._messages import (
+    AlpacaToMessages,
     ChosenRejectedToMessages,
     InputOutputToMessages,
     Message,
     OpenAIToMessages,
     Role,
     ShareGPTToMessages,
-    AlpacaToMessages,
     validate_messages,
 )
 from torchtune.data._prompt_templates import (

--- a/torchtune/data/_messages.py
+++ b/torchtune/data/_messages.py
@@ -621,3 +621,70 @@ def validate_messages(
                 f"System message at index {i} in messages, but system messages must come first"
             )
         last_turn = message.role
+
+
+class AlpacaToMessages(Transform):
+    """
+    Message transform class for Alpaca-style datasets with "instruction", "input", and "output"
+    (or equivalent fields specified in column_map) columns. User messages are formed from the
+    instruction + input columns and assistant messages are formed from the output column. Prompt
+    templating is conditional on the presence of the "input" column, and thus is handled directly
+    in this transform class instead of a dedicated :class:`~torchtune.data.PromptTemplate` class
+    due to this custom logic.
+
+    Args:
+        train_on_input (bool): Whether the model is trained on the user prompt or not.
+            Default is True.
+        column_map (Optional[Dict[str, str]]): a mapping to change the expected "instruction", "input",
+            and "output" column names to the actual column names in the dataset. Default is None,
+            keeping the default column names.
+    """
+
+    def __init__(
+        self, train_on_input: bool = True, column_map: Optional[Dict[str, str]] = None
+    ):
+        self.train_on_input = train_on_input
+        self.column_map = column_map
+        self.template = {
+            "prompt_input": (
+                "Below is an instruction that describes a task, paired with an input that provides further context. "
+                "Write a response that appropriately completes the request.\n\n"
+                "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:\n"
+            ),
+            "prompt_no_input": (
+                "Below is an instruction that describes a task. "
+                "Write a response that appropriately completes the request.\n\n"
+                "### Instruction:\n{instruction}\n\n### Response:\n"
+            ),
+        }
+
+    def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
+        column_map = self.column_map or {}
+        key_input = column_map.get("input", "input")
+        key_instruction = column_map.get("instruction", "instruction")
+        key_output = column_map.get("output", "output")
+
+        if key_input in sample and sample[key_input]:
+            prompt = self.template["prompt_input"].format(
+                instruction=sample[key_instruction], input=sample[key_input]
+            )
+        else:
+            prompt = self.template["prompt_no_input"].format(
+                instruction=sample[key_instruction]
+            )
+
+        messages = [
+            Message(
+                role="user",
+                content=prompt,
+                masked=not self.train_on_input,
+                eot=True,
+            ),
+            Message(
+                role="assistant",
+                content=sample[key_output],
+                masked=False,
+                eot=True,
+            ),
+        ]
+        return {"messages": messages}

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtune.datasets import multimodal
-from torchtune.datasets._alpaca import alpaca_cleaned_dataset, alpaca_dataset
+from torchtune.datasets._alpaca import alpaca_cleaned_dataset, alpaca_dataset, AlpacaToMessages
 from torchtune.datasets._chat import chat_dataset
 from torchtune.datasets._cnn_dailymail import cnn_dailymail_articles_dataset
 from torchtune.datasets._concat import ConcatDataset
@@ -44,4 +44,5 @@ __all__ = [
     "SFTDataset",
     "hh_rlhf_helpful_dataset",
     "multimodal",
+    "AlpacaToMessages",
 ]

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -5,7 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtune.datasets import multimodal
-from torchtune.datasets._alpaca import alpaca_cleaned_dataset, alpaca_dataset, AlpacaToMessages
+from torchtune.datasets._alpaca import (
+    alpaca_cleaned_dataset,
+    alpaca_dataset
+)
 from torchtune.datasets._chat import chat_dataset
 from torchtune.datasets._cnn_dailymail import cnn_dailymail_articles_dataset
 from torchtune.datasets._concat import ConcatDataset
@@ -44,5 +47,4 @@ __all__ = [
     "SFTDataset",
     "hh_rlhf_helpful_dataset",
     "multimodal",
-    "AlpacaToMessages",
 ]

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -5,10 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtune.datasets import multimodal
-from torchtune.datasets._alpaca import (
-    alpaca_cleaned_dataset,
-    alpaca_dataset
-)
+from torchtune.datasets._alpaca import alpaca_cleaned_dataset, alpaca_dataset
 from torchtune.datasets._chat import chat_dataset
 from torchtune.datasets._cnn_dailymail import cnn_dailymail_articles_dataset
 from torchtune.datasets._concat import ConcatDataset

--- a/torchtune/datasets/_alpaca.py
+++ b/torchtune/datasets/_alpaca.py
@@ -8,10 +8,12 @@ from functools import partial
 
 from typing import Any, Dict, Optional, Union
 
+from torchtune.data._messages import AlpacaToMessages
+
 from torchtune.datasets._packed import PackedDataset
 from torchtune.datasets._sft import SFTDataset
 from torchtune.modules.tokenizers import ModelTokenizer
-from torchtune.data._messages import AlpacaToMessages
+
 
 def alpaca_dataset(
     tokenizer: ModelTokenizer,

--- a/torchtune/datasets/_alpaca.py
+++ b/torchtune/datasets/_alpaca.py
@@ -6,81 +6,12 @@
 
 from functools import partial
 
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Dict, Optional, Union
 
-from torchtune.data._messages import Message
 from torchtune.datasets._packed import PackedDataset
 from torchtune.datasets._sft import SFTDataset
 from torchtune.modules.tokenizers import ModelTokenizer
-from torchtune.modules.transforms import Transform
-
-
-class AlpacaToMessages(Transform):
-    """
-    Message transform class for Alpaca-style datasets with "instruction", "input", and "output"
-    (or equivalent fields specified in column_map) columns. User messages are formed from the
-    instruction + input columns and assistant messages are formed from the output column. Prompt
-    templating is conditional on the presence of the "input" column, and thus is handled directly
-    in this transform class instead of a dedicated :class:`~torchtune.data.PromptTemplate` class
-    due to this custom logic.
-
-    Args:
-        train_on_input (bool): Whether the model is trained on the user prompt or not.
-            Default is True.
-        column_map (Optional[Dict[str, str]]): a mapping to change the expected "instruction", "input",
-            and "output" column names to the actual column names in the dataset. Default is None,
-            keeping the default column names.
-    """
-
-    def __init__(
-        self, train_on_input: bool = True, column_map: Optional[Dict[str, str]] = None
-    ):
-        self.train_on_input = train_on_input
-        self.column_map = column_map
-        self.template = {
-            "prompt_input": (
-                "Below is an instruction that describes a task, paired with an input that provides further context. "
-                "Write a response that appropriately completes the request.\n\n"
-                "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:\n"
-            ),
-            "prompt_no_input": (
-                "Below is an instruction that describes a task. "
-                "Write a response that appropriately completes the request.\n\n"
-                "### Instruction:\n{instruction}\n\n### Response:\n"
-            ),
-        }
-
-    def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
-        column_map = self.column_map or {}
-        key_input = column_map.get("input", "input")
-        key_instruction = column_map.get("instruction", "instruction")
-        key_output = column_map.get("output", "output")
-
-        if key_input in sample and sample[key_input]:
-            prompt = self.template["prompt_input"].format(
-                instruction=sample[key_instruction], input=sample[key_input]
-            )
-        else:
-            prompt = self.template["prompt_no_input"].format(
-                instruction=sample[key_instruction]
-            )
-
-        messages = [
-            Message(
-                role="user",
-                content=prompt,
-                masked=not self.train_on_input,
-                eot=True,
-            ),
-            Message(
-                role="assistant",
-                content=sample[key_output],
-                masked=False,
-                eot=True,
-            ),
-        ]
-        return {"messages": messages}
-
+from torchtune.data._messages import AlpacaToMessages
 
 def alpaca_dataset(
     tokenizer: ModelTokenizer,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [X] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Make AlpacaToMessage public.
#1769 

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [X] I have added an example to docs or docstrings

Really minor fix. This code is now working:

```
from torchtune.datasets import AlpacaToMessages

message_transform = AlpacaToMessages(
    train_on_input=True, column_map=None
)
```

