### PR TITLE
Fix typo in multimodal_datasets.rst

### DIFF
--- a/docs/source/basics/multimodal_datasets.rst
+++ b/docs/source/basics/multimodal_datasets.rst
@@ -64,7 +64,7 @@ in the text, ``"<image>"`` for where to place the image tokens. This will get re
         split="train",
     )
     tokenized_dict = ds[0]
-    print(transform.decode(tokenized_dict["tokens"], skip_special_tokens=False))
+    print(model_transform.decode(tokenized_dict["tokens"], skip_special_tokens=False))
     # '<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nQuestion:<|image|>What time is it on the clock?Answer:<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nIt is 10:00AM.<|eot_id|>'
     print(tokenized_dict["encoder_input"]["images"][0].shape)  # (num_tiles, num_channels, tile_height, tile_width)
     # torch.Size([4, 3, 224, 224])

--- a/docs/source/basics/multimodal_datasets.rst
+++ b/docs/source/basics/multimodal_datasets.rst
@@ -45,7 +45,7 @@ in the text, ``"<image>"`` for where to place the image tokens. This will get re
     from torchtune.models.llama3_2_vision import llama3_2_vision_transform
     from torchtune.datasets.multimodal import multimodal_chat_dataset
 
-    transform = Llama3VisionTransform(
+    model_transform = Llama3VisionTransform(
         path="/tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model",
         prompt_template="torchtune.data.QuestionAnswerTemplate",
         max_seq_len=8192,
@@ -120,7 +120,7 @@ For most datasets, you will also need to specify the ``split`` and/or the subset
     from torchtune.models.llama3_2_vision import llama3_2_vision_transform
     from torchtune.datasets.multimodal import multimodal_chat_dataset
 
-    transform = llama3_2_vision_transform(
+    model_transform = llama3_2_vision_transform(
         path="/tmp/Meta-Llama-3-8B-Instruct/original/tokenizer.model",
         max_seq_len=8192,
         image_size=560,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
#1786

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
