### PR TITLE
Add check that there is no PackedDataset while building ConcatDataset

### DIFF
--- a/torchtune/datasets/_concat.py
+++ b/torchtune/datasets/_concat.py
@@ -4,92 +4,89 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Tuple
-
-from torch.utils.data import Dataset
-
-from torchtune import utils
-
+import pytest
+from datasets import Dataset
+from torch.utils.data import Dataset as TorchDataset
+from torchtune.datasets._concat import ConcatDataset
 from torchtune.datasets._packed import PackedDataset
 
-log = utils.get_logger("DEBUG")
+
+class DummyDataset(TorchDataset):
+    def __init__(self, sample_size):
+        self.sample_size = sample_size
+
+    def __getitem__(self, index):
+        if index >= 1000:
+            raise IndexError()
+        return {
+            "tokens": [index] * self.sample_size,
+            "labels": [index] * self.sample_size,
+        }
+
+    def __len__(self):
+        return 1000
 
 
-class ConcatDataset(Dataset):
-    """
-    A dataset class for concatenating multiple sub-datasets into a single dataset. This class enables the
-    unified handling of different datasets as if they were a single dataset, simplifying tasks such as
-    training models on multiple sources of data simultaneously.
+class TestConcatDataset:
+    @pytest.fixture
+    def datasets(self):
+        ds1 = Dataset.from_list([{"data": f"ds1_{i}"} for i in range(4)])
+        ds2 = Dataset.from_list([{"data": f"ds2_{i}"} for i in range(8)])
+        ds3 = Dataset.from_list([{"data": f"ds3_{i}"} for i in range(15)])
+        ds4 = Dataset.from_list([{"data": f"ds4_{i}"} for i in range(16)])
+        ds5 = Dataset.from_list([{"data": f"ds5_{i}"} for i in range(23)])
+        ds6 = Dataset.from_list([{"data": f"ds6_{i}"} for i in range(42)])
+        return [ds1, ds2, ds3, ds4, ds5, ds6]
 
-    The class internally manages the aggregation of different datasets and allows transparent indexing across them.
-    However, it requires all constituent datasets to be fully loaded into memory, which might not be optimal for
-    very large datasets.
+    @pytest.fixture
+    def torch_datasets(self):
+        ds1 = DummyDataset(4)
+        ds2 = DummyDataset(8)
+        ds3 = DummyDataset(15)
+        ds4 = DummyDataset(16)
+        ds5 = DummyDataset(23)
+        ds6 = DummyDataset(42)
+        return [ds1, ds2, ds3, ds4, ds5, ds6]
 
-    Upon initialization, this class computes the cumulative length of all datasets and maintains an internal mapping
-    of indices to the respective datasets. This approach allows the :class:`~torchtune.datasets.ConcatDataset`
-    to delegate data retrieval to the appropriate sub-dataset transparently when a particular index is accessed.
+    def test_length(self, datasets):
+        """Test the correct computation of total length"""
+        multi_dataset = ConcatDataset(datasets)
 
-    Note:
-        Using this class with very large datasets can lead to high memory consumption, as it requires all datasets to
-        be loaded into memory. For large-scale scenarios, consider other strategies that might stream data on demand.
+        # sum of individual datasets lengths
+        expected_length = 4 + 8 + 15 + 16 + 23 + 42  # 108
+        assert len(multi_dataset) == expected_length
 
-    Args:
-        datasets (List[Dataset]): A list of datasets to concatenate. Each dataset must be an instance of a class
-            derived from :class:`~torch.utils.data.Dataset`.
-    Raises:
-        ValueError: if instanse of `PackedDataset` is in `datasets`
-        
-    Examples:
-        >>> dataset1 = MyCustomDataset(params1)
-        >>> dataset2 = MyCustomDataset(params2)
-        >>> concat_dataset = ConcatDataset([dataset1, dataset2])
-        >>> print(len(concat_dataset))  # Total length of both datasets
-        >>> data_point = concat_dataset[1500]  # Accesses an element from the appropriate dataset
+    def test_getitem(self, datasets):
+        """Test item retrieval across dataset boundaries"""
+        multi_dataset = ConcatDataset(datasets)
 
-    This can also be accomplished by passing in a list of datasets to the YAML config::
+        # Testing indices across different datasets
+        assert multi_dataset[-1] is None  # Index out of range
+        assert multi_dataset[0] == {"data": "ds1_0"}
+        assert multi_dataset[3] == {"data": "ds1_3"}
+        assert multi_dataset[4] == {"data": "ds2_0"}
+        assert multi_dataset[10] == {"data": "ds2_6"}
+        assert multi_dataset[20] == {"data": "ds3_8"}
+        assert multi_dataset[35] == {"data": "ds4_8"}
+        assert multi_dataset[50] == {"data": "ds5_7"}
+        assert multi_dataset[70] == {"data": "ds6_4"}
+        assert multi_dataset[90] == {"data": "ds6_24"}
+        assert multi_dataset[108] is None  # Index out of range
 
-        dataset:
-          - _component_: torchtune.datasets.instruct_dataset
-            source: vicgalle/alpaca-gpt4
-            template: torchtune.data.AlpacaInstructTemplate
-            split: train
-            train_on_input: True
-          - _component_: torchtune.datasets.instruct_dataset
-            source: samsum
-            template: torchtune.data.SummarizeTemplate
-            column_map: {"output": "summary"}
-            output: summary
-            split: train
-            train_on_input: False
+    def test_invalid_index_type(self, datasets):
+        """Test handling of invalid index types"""
+        multi_dataset = ConcatDataset(datasets)
 
-    This class primarily focuses on providing a unified interface to access elements from multiple datasets,
-    enhancing the flexibility in handling diverse data sources for training machine learning models.
-    """
+        with pytest.raises(TypeError):
+            multi_dataset["invalid_type"]  # Non-integer index
 
-    def __init__(self, datasets: List[Dataset]):
-        self._datasets: List[Dataset] = datasets
+    def test_packed_dataset(self, torch_datasets):
+        torch_datasets[0] = PackedDataset(
+            torch_datasets[0],
+            max_seq_len=25,
+            max_packs=5,
+            split_across_pack=True,
+        )
 
-        for dataset in self._datasets:
-            if isinstance(dataset, PackedDataset):
-                raise ValueError(
-                    "ConcatDataset can't proceed instances of PackedDataset."
-                )
-
-        self._len: int = sum(len(dataset) for dataset in datasets)
-        self._indexes: List[Tuple[int, int, int]] = []
-
-        # Calculate distribution of indexes in all datasets
-        cumulative_index = 0
-        for idx, dataset in enumerate(datasets):
-            next_cumulative_index = cumulative_index + len(dataset)
-            self._indexes.append((cumulative_index, next_cumulative_index, idx))
-            cumulative_index = next_cumulative_index
-
-    def __getitem__(self, index: int) -> Tuple[List[int], List[int]]:
-        for start, stop, dataset_index in self._indexes:
-            if start <= index < stop:
-                dataset = self._datasets[dataset_index]
-                return dataset[index - start]
-
-    def __len__(self) -> int:
-        return self._len
+        with pytest.raises(ValueError):
+            concated_dataset = ConcatDataset(torch_datasets)

--- a/torchtune/datasets/_concat.py
+++ b/torchtune/datasets/_concat.py
@@ -10,6 +10,8 @@ from torch.utils.data import Dataset
 
 from torchtune import utils
 
+from torchtune.datasets._packed import PackedDataset
+
 log = utils.get_logger("DEBUG")
 
 
@@ -34,7 +36,9 @@ class ConcatDataset(Dataset):
     Args:
         datasets (List[Dataset]): A list of datasets to concatenate. Each dataset must be an instance of a class
             derived from :class:`~torch.utils.data.Dataset`.
-
+    Raises:
+        ValueError: if instanse of `PackedDataset` is in `datasets`
+        
     Examples:
         >>> dataset1 = MyCustomDataset(params1)
         >>> dataset2 = MyCustomDataset(params2)
@@ -64,6 +68,13 @@ class ConcatDataset(Dataset):
 
     def __init__(self, datasets: List[Dataset]):
         self._datasets: List[Dataset] = datasets
+
+        for dataset in self._datasets:
+            if isinstance(dataset, PackedDataset):
+                raise ValueError(
+                    "ConcatDataset can't proceed instances of PackedDataset."
+                )
+
         self._len: int = sum(len(dataset) for dataset in datasets)
         self._indexes: List[Tuple[int, int, int]] = []
 

--- a/torchtune/datasets/_concat.py
+++ b/torchtune/datasets/_concat.py
@@ -36,8 +36,10 @@ class ConcatDataset(Dataset):
     Args:
         datasets (List[Dataset]): A list of datasets to concatenate. Each dataset must be an instance of a class
             derived from :class:`~torch.utils.data.Dataset`.
+    
     Raises:
         ValueError: if instanse of `PackedDataset` is in `datasets`
+    
     Examples:
         >>> dataset1 = MyCustomDataset(params1)
         >>> dataset2 = MyCustomDataset(params2)

--- a/torchtune/datasets/_concat.py
+++ b/torchtune/datasets/_concat.py
@@ -36,10 +36,10 @@ class ConcatDataset(Dataset):
     Args:
         datasets (List[Dataset]): A list of datasets to concatenate. Each dataset must be an instance of a class
             derived from :class:`~torch.utils.data.Dataset`.
-    
+
     Raises:
         ValueError: if instanse of `PackedDataset` is in `datasets`
-    
+
     Examples:
         >>> dataset1 = MyCustomDataset(params1)
         >>> dataset2 = MyCustomDataset(params2)

--- a/torchtune/datasets/_concat.py
+++ b/torchtune/datasets/_concat.py
@@ -38,7 +38,6 @@ class ConcatDataset(Dataset):
             derived from :class:`~torch.utils.data.Dataset`.
     Raises:
         ValueError: if instanse of `PackedDataset` is in `datasets`
-        
     Examples:
         >>> dataset1 = MyCustomDataset(params1)
         >>> dataset2 = MyCustomDataset(params2)
@@ -72,7 +71,7 @@ class ConcatDataset(Dataset):
         for dataset in self._datasets:
             if isinstance(dataset, PackedDataset):
                 raise ValueError(
-                    "ConcatDataset can't proceed instances of PackedDataset."
+                    "ConcatDataset can't process instances of PackedDataset."
                 )
 
         self._len: int = sum(len(dataset) for dataset in datasets)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [X] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Add check that there is no PackedDataset while building ConcatDataset #1708

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [X] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [X] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [X] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [X] I have added an example to docs or docstrings
