### PR TITLE
Update EleutherAI Eval Harness to v0.4.5

### DIFF
--- a/.github/workflows/gpu_test.yaml
+++ b/.github/workflows/gpu_test.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install remaining dependencies
         run: |
           python -m pip install -e ".[dev]"
-          python -m pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git@fb963f0f0a5b28b69763590bb59676072cf43a01
+          python -m pip install lm-eval==0.4.5
       - name: Run recipe and unit tests with coverage
         run: pytest tests --with-integration --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/.github/workflows/recipe_test.yaml
+++ b/.github/workflows/recipe_test.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install torch torchvision torchao
           python -m pip install -e ".[dev]"
-          python -m pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git@fb963f0f0a5b28b69763590bb59676072cf43a01
+          python -m pip install lm-eval==0.4.5
       - name: Run recipe tests with coverage
         run: pytest tests -m integration_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install remaining dependencies
         run: |
           python -m pip install -e ".[dev]"
-          python -m pip install lm-eval==0.4.*
+          python -m pip install lm-eval==0.4.5
       - name: Run regression tests with coverage
         run: pytest tests -m slow_integration_test --silence-s3-logs --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload Coverage to Codecov

--- a/recipes/configs/llama3_2_vision/evaluation.yaml
+++ b/recipes/configs/llama3_2_vision/evaluation.yaml
@@ -3,8 +3,8 @@
 # This config assumes that you've run the following command before launching:
 #   tune download meta-llama/Llama-3.2-11B-Vision-Instruct --output-dir /tmp/Llama-3.2-11B-Vision-Instruct
 #
-# It also assumes that you've downloaded the EleutherAI Eval Harness:
-#   pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git@fb963f0f0a5b28b69763590bb59676072cf43a01
+# It also assumes that you've downloaded the EleutherAI Eval Harness (v0.4.5):
+#   pip install lm_eval==0.4.5
 #
 # To launch, run the following command from root torchtune directory:
 #    tune run eleuther_eval --config llama3_2_vision/evaluation

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -440,6 +440,16 @@ class EleutherEvalRecipe(EvalRecipeInterface):
     """
 
     def __init__(self, cfg: DictConfig) -> None:
+        # Double check we have the right Eval Harness version
+        from importlib.metadata import version
+
+        if version("lm-eval") != "0.4.5":
+            raise RuntimeError(
+                "This recipe requires EleutherAI Eval Harness v0.4.5. "
+                "Please install with `pip install lm-eval==0.4.5`"
+            )
+
+        # General variable initialization
         self.device = utils.get_device(device=cfg.device)
         self.dtype = training.get_dtype(dtype=cfg.dtype, device=self.device)
         self.logger = utils.get_logger(cfg.get("log_level", "info"))

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import importlib.metadata
 import sys
 import time
 
@@ -13,6 +12,11 @@ from typing import Dict, List, Tuple, Union
 import PIL
 
 import torch
+
+from lm_eval.evaluator import evaluate, get_task_list
+from lm_eval.models.hf_vlms import HFMultimodalLM
+from lm_eval.models.huggingface import HFLM
+from lm_eval.tasks import get_task_dict, TaskManager
 from omegaconf import DictConfig
 
 from torchtune import config, training, utils
@@ -29,40 +33,6 @@ from torchtune.modules.tokenizers import ModelTokenizer
 from torchtune.modules.transforms import Transform
 from torchtune.recipe_interfaces import EvalRecipeInterface
 from torchtune.training import FullModelTorchTuneCheckpointer
-
-try:
-    import lm_eval
-except ImportError:
-    print(
-        "You must install the EleutherAI Eval Harness to run this recipe. "
-        "Please install with `pip install lm_eval>=0.4.2`"
-    )
-    sys.exit(1)
-
-lm_eval_version = importlib.metadata.version("lm_eval")
-if not lm_eval_version >= "0.4.2":
-    print(
-        "You must install the EleutherAI Eval Harness >= v0.4.2 to run this recipe. "
-        "Please install with `pip install lm_eval>=0.4.2`"
-    )
-    sys.exit(1)
-
-from lm_eval.evaluator import evaluate, get_task_list
-
-# User doesn't have to have nightlies installed, they just won't be able
-# to use the multimodal model
-try:
-    from lm_eval.models.hf_vlms import HFMultimodalLM
-except ImportError as e:
-    # Create a dummy class to avoid having to import the HF models
-    # TODO (@joecummings): Remove this once v0.4.5 patch is released
-    class HFMultimodalLM:
-        def __init__(self, *args, **kwargs):
-            pass
-
-
-from lm_eval.models.huggingface import HFLM
-from lm_eval.tasks import get_task_dict, TaskManager
 
 
 class _VLMEvalWrapper(HFMultimodalLM):

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -17,6 +17,7 @@ from lm_eval.evaluator import evaluate, get_task_list
 from lm_eval.models.hf_vlms import HFMultimodalLM
 from lm_eval.models.huggingface import HFLM
 from lm_eval.tasks import get_task_dict, TaskManager
+from lm_eval.utils import make_table
 from omegaconf import DictConfig
 
 from torchtune import config, training, utils
@@ -548,7 +549,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
         self.logger.info(
             f"Max memory allocated: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB"
         )
-        formatted_output = lm_eval.utils.make_table(output)
+        formatted_output = make_table(output)
         self.logger.info(f"\n\n{formatted_output}\n")
 
 

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -81,7 +81,7 @@ class TestEleutherEval:
         import_orig = importlib.metadata.version
 
         def mocked_import(name, *args, **kwargs):
-            if name == "lm_eval":
+            if name == "lm-eval":
                 return "0.4.4"  # Hardcode wrong version number
             return import_orig(name, *args, **kwargs)
 

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -88,7 +88,7 @@ class TestEleutherEval:
 
         def mocked_import(name, *args, **kwargs):
             if name == "lm_eval":
-                raise ImportError()
+                raise ModuleNotFoundError("No module named 'lm_eval'")
             return import_orig(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", mocked_import)
@@ -117,11 +117,8 @@ class TestEleutherEval:
         """.split()
 
         monkeypatch.setattr(sys, "argv", cmd)
-        with pytest.raises(SystemExit, match="1"):
+        with pytest.raises(ModuleNotFoundError, match="No module named 'lm_eval'"):
             runpy.run_path(TUNE_PATH, run_name="__main__")
-
-        printed_err = capsys.readouterr().out
-        assert "ModuleNotFoundError: No module named 'lm_eval'" in printed_err
 
     @pytest.mark.integration_test
     def test_eval_recipe_errors_with_quantization_hf_checkpointer(

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import builtins
 import math
 import re
 import runpy
@@ -64,17 +63,10 @@ class TestEleutherEval:
 
         out = caplog.text
 
-        # v0.4.2 format
-        # |    Tasks     |Version|Filter|n-shot|Metric|Value |   |Stderr|
-        # |--------------|------:|------|-----:|------|-----:|---|-----:|
-        # |truthfulqa_mc2|      2|none  |     0|acc   |0.4497|±  |0.1067|
-
-        # v0.4.3 format
+        # Format of output is:
         # |    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
         # |--------------|------:|------|-----:|------|---|-----:|---|-----:|
         # |truthfulqa_mc2|      2|none  |     0|acc   |↑  |0.4497|±  |0.1067|
-
-        # The below RegEx command will pick up both formats
         search_results = re.search(
             r"acc(?:_norm)?\s*\|?\s*(?:\↑\s*\|?)?([\d.]+)", out.strip()
         )
@@ -83,18 +75,20 @@ class TestEleutherEval:
         assert math.isclose(acc_result, expected_acc, abs_tol=0.05)
 
     @pytest.fixture
-    def hide_available_pkg(self, monkeypatch):
-        import_orig = builtins.__import__
+    def hide_correct_version_number(self, monkeypatch):
+        import importlib.metadata
+
+        import_orig = importlib.metadata.version
 
         def mocked_import(name, *args, **kwargs):
             if name == "lm_eval":
-                raise ModuleNotFoundError("No module named 'lm_eval'")
+                return "0.4.4"  # Hardcode wrong version number
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
+        monkeypatch.setattr(importlib.metadata, "version", mocked_import)
 
     @pytest.mark.integration_test
-    @pytest.mark.usefixtures("hide_available_pkg")
+    @pytest.mark.usefixtures("hide_correct_version_number")
     def test_eval_recipe_errors_without_lm_eval(self, capsys, monkeypatch, tmpdir):
         ckpt = "llama2_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
@@ -117,7 +111,11 @@ class TestEleutherEval:
         """.split()
 
         monkeypatch.setattr(sys, "argv", cmd)
-        with pytest.raises(ModuleNotFoundError, match="No module named 'lm_eval'"):
+        with pytest.raises(
+            RuntimeError,
+            match="This recipe requires EleutherAI Eval Harness v0.4.5. "
+            "Please install with `pip install lm-eval==0.4.5`",
+        ):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
     @pytest.mark.integration_test

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -110,6 +110,9 @@ class TestEleutherEval:
             device=cpu \
         """.split()
 
+        model_config = llama2_test_config()
+        cmd = cmd + model_config
+
         monkeypatch.setattr(sys, "argv", cmd)
         with pytest.raises(
             RuntimeError,

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -121,10 +121,7 @@ class TestEleutherEval:
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
         printed_err = capsys.readouterr().out
-        assert (
-            "You must install the EleutherAI Eval Harness to run this recipe"
-            in printed_err
-        )
+        assert "ModuleNotFoundError: No module named 'lm_eval'" in printed_err
 
     @pytest.mark.integration_test
     def test_eval_recipe_errors_with_quantization_hf_checkpointer(


### PR DESCRIPTION
**Context**:

In v0.4.5, EleutherAI [officially added multimodal support](https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/v0.4.5) to their Eval Harness. We had some hacky code to make sure the user was doing this on their main Github code before this release was public. Now that it is, we should just force people to upgrade their Harness version so that our multimodal code works. 

In addition, I changed the way we gate external packages in our recipes. If they don't have lm-eval installed AT ALL, it will throw the usual `ModuleNotFound` error. This should be sufficient for them to understand that they need this to run the recipe. In addition, b/c we actually want them to use the latest version, we now have another check in the setup part of the workflow to make sure that they are installing v0.4.5 specifically. This happens before any heavy lifting starts. 

**Changelog**:
* Removed hacky code
* Updated workers to download `lm-eval==0.4.5`
* Added gating logic on version in the setup portion of the recipe
* Updated the test to return the "wrong" version of lm-eval in order to ensure we hit the right test

**Testing**:
Recipe tests: `python -m pytest tests/recipes/test_eleuther_eval.py --with-integration`
Output from text run:
```
batch_size: 8
checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Llama-2-7b-hf
  checkpoint_files:
  - pytorch_model-00001-of-00002.bin
  - pytorch_model-00002-of-00002.bin
  model_type: LLAMA2
  output_dir: /tmp/Llama-2-7b-hf
device: cuda
dtype: bf16
enable_kv_cache: true
limit: null
max_seq_length: 4096
model:
  _component_: torchtune.models.llama2.llama2_7b
quantizer: null
seed: 1234
tasks:
- truthfulqa_mc2
tokenizer:
  _component_: torchtune.models.llama2.llama2_tokenizer
  max_seq_len: null
  path: /tmp/Llama-2-7b-hf/tokenizer.model

Model is initialized with precision torch.bfloat16.
2024-10-14:08:58:59,426 INFO     [eleuther_eval.py:505] Model is initialized with precision torch.bfloat16.
2024-10-14:08:58:59,488 INFO     [huggingface.py:129] Using device 'cuda:0'
2024-10-14:08:58:59,607 INFO     [huggingface.py:481] Using model type 'default'
2024-10-14:08:58:59,843 INFO     [huggingface.py:365] Model parallel was set to False, max memory was not set, and device map was set to {'': 'cuda:0'}
Running evaluation on the following tasks: ['truthfulqa_mc2']
2024-10-14:08:59:12,366 INFO     [eleuther_eval.py:549] Running evaluation on the following tasks: ['truthfulqa_mc2']
2024-10-14:08:59:12,367 INFO     [task.py:415] Building contexts for truthfulqa_mc2 on rank 0...
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 817/817 [00:01<00:00, 700.97it/s]
2024-10-14:08:59:13,605 INFO     [evaluator.py:489] Running loglikelihood requests
Running loglikelihood requests: 100%|██████████████████████████████████████████████████████████████| 5882/5882 [01:52<00:00, 52.11it/s]
Eval completed in 119.48 seconds.
2024-10-14:09:01:11,843 INFO     [eleuther_eval.py:558] Eval completed in 119.48 seconds.
Max memory allocated: 39.48 GB
2024-10-14:09:01:11,843 INFO     [eleuther_eval.py:559] Max memory allocated: 39.48 GB


|    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|--------------|------:|------|-----:|------|---|-----:|---|-----:|
|truthfulqa_mc2|      2|none  |     0|acc   |↑  |0.3895|±  |0.0136|


2024-10-14:09:01:11,926 INFO     [eleuther_eval.py:563]

|    Tasks     |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|--------------|------:|------|-----:|------|---|-----:|---|-----:|
|truthfulqa_mc2|      2|none  |     0|acc   |↑  |0.3895|±  |0.0136|


```
Output from multimodal run:
```
2024-10-14:09:05:40,454 INFO     [_logging.py:101] Running EleutherEvalRecipe with resolved config:

batch_size: 1
checkpointer:
  _component_: torchtune.training.FullModelMetaCheckpointer
  checkpoint_dir: /tmp/Llama-3.2-11B-Vision-Instruct/original
  checkpoint_files:
  - consolidated.pth
  model_type: LLAMA3_VISION
  output_dir: ./
device: cuda
dtype: bf16
enable_kv_cache: true
limit: 3
log_level: INFO
max_seq_length: 8192
model:
  _component_: torchtune.models.llama3_2_vision.llama3_2_vision_11b
quantizer: null
seed: 1234
tasks:
- mmmu_val_biology
tokenizer:
  _component_: torchtune.models.llama3_2_vision.llama3_2_vision_transform
  max_seq_len: 8192
  path: /tmp/Llama-3.2-11B-Vision-Instruct/original/tokenizer.model

Model is initialized with precision torch.bfloat16.
2024-10-14:09:05:49,232 INFO     [eleuther_eval.py:505] Model is initialized with precision torch.bfloat16.
Running evaluation on the following tasks: ['mmmu_val_biology']
2024-10-14:09:06:01,712 INFO     [eleuther_eval.py:549] Running evaluation on the following tasks: ['mmmu_val_biology']
2024-10-14:09:06:01,714 INFO     [task.py:415] Building contexts for mmmu_val_biology on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 5706.54it/s]
2024-10-14:09:06:01,766 INFO     [evaluator.py:489] Running generate_until requests
Running generate_until requests with text+image input: 100%|█████████████████████████████████████████████| 3/3 [00:34<00:00, 11.61s/it]
Eval completed in 34.93 seconds.
2024-10-14:09:06:36,641 INFO     [eleuther_eval.py:558] Eval completed in 34.93 seconds.
Max memory allocated: 32.01 GB
2024-10-14:09:06:36,642 INFO     [eleuther_eval.py:559] Max memory allocated: 32.01 GB


| Tasks |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|-------|------:|------|------|------|---|-----:|---|-----:|
|Biology|      0|none  |None  |acc   |↑  |0.3333|±  |0.3333|


2024-10-14:09:06:36,723 INFO     [eleuther_eval.py:563]

| Tasks |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|-------|------:|------|------|------|---|-----:|---|-----:|
|Biology|      0|none  |None  |acc   |↑  |0.3333|±  |0.3333|

```