### PR TITLE
Set dropout in SDPA to 0.0 when not in training mode

### DIFF
--- a/torchtune/modules/attention.py
+++ b/torchtune/modules/attention.py
@@ -70,7 +70,7 @@ class MultiHeadAttention(nn.Module):
             This is needed to compute the RoPE Cache. Default: 4096.
         is_causal (bool): sets the default mask to causal when no mask is provided
         attn_dropout (float): dropout value passed onto the scaled_dot_product_attention function.
-            Default value is 0.0.
+            This argument is ignored if self.training is False. Default value is 0.0.
 
     Raises:
         ValueError: If ``num_heads % num_kv_heads != 0``
@@ -298,7 +298,7 @@ class MultiHeadAttention(nn.Module):
             k,
             v,
             mask=mask,
-            dropout_p=self.attn_dropout,
+            dropout_p=self.attn_dropout if self.training else 0.0,
             is_causal=self.kv_cache is None and mask is None and self.is_causal,
         )
 

--- a/torchtune/modules/attention_utils.py
+++ b/torchtune/modules/attention_utils.py
@@ -196,6 +196,12 @@ def _sdpa_or_flex_attention() -> Callable:
                     "Using flex attention for attention computation since a BlockMask was passed in.",
                     level=logging.DEBUG,
                 )
+                if dropout_p > 0.0:
+                    log_once(
+                        _log,
+                        "Dropout is not supported with flex attention.",
+                        level=logging.WARNING,
+                    )
                 return compile_friendly_flex_attention(
                     q,
                     k,

--- a/torchtune/modules/attention_utils.py
+++ b/torchtune/modules/attention_utils.py
@@ -197,10 +197,8 @@ def _sdpa_or_flex_attention() -> Callable:
                     level=logging.DEBUG,
                 )
                 if dropout_p > 0.0:
-                    log_once(
-                        _log,
-                        "Dropout is not supported with flex attention.",
-                        level=logging.WARNING,
+                    raise ValueError(
+                        "Flex attention does not support dropout. Please set dropout to 0.0."
                     )
                 return compile_friendly_flex_attention(
                     q,


### PR DESCRIPTION
As pointed out by @zjost in #1791, we probably should just manually force dropout to be 0 outside of training. This is actually what we did originally, but along the way we switched to just always using the value from `attn_dropout` directly, which will not be correct at inference time if someone passes a nonzero value. So this PR changes back to coercing dropout to 0.0 outside of training mode. I checked with the author of the PR who first dropped the if/else dropout logic and it was not done by design. 

I also make two other changes: (1) reverting the doc update I made last night, and (2) raising an error in case someone tries to use FlexAttention with nonzero dropout (it's not currently supported).

