### PR TITLE
Remove unused bsz variable

### DIFF
--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -578,7 +578,7 @@ class TransformerDecoder(nn.Module):
             - m_s: max seq len
         """
         # input tensor of shape [b, s]
-        bsz, seq_len = tokens.shape
+        seq_len = tokens.shape[1]
 
         self._validate_inputs(
             seq_len,


### PR DESCRIPTION
Summary: remove unused variables. This could unblock our usecase where the the input is directly the embedding, i.e., b x seq_len x dim.

Differential Revision:
D64089998

Privacy Context Container: L1268898


