### PR TITLE
Deprecating `TiedEmbeddingTransformerDecoder`

### DIFF
--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 from torch import nn
 from torchtune.modules import MultiHeadAttention
 from torchtune.modules.attention_utils import _MaskType
+from torchtune.utils._logging import deprecated
 
 
 class TransformerSelfAttentionLayer(nn.Module):
@@ -619,6 +620,11 @@ class TransformerDecoder(nn.Module):
         return output
 
 
+@deprecated(
+    msg="Please use torchtune.modules.TransformerDecoder instead. \
+If you need an example, see torchtune.models.qwen2._component_builders.py \
+and how to implement torch.modules.TiedLinear for the output projection."
+)
 class TiedEmbeddingTransformerDecoder(nn.Module):
     """
     Transformer Decoder with tied embedding weight. A key difference between


### PR DESCRIPTION
Just adding a deprecation warning like we do for `GemmaTransformerDecoder`