### PR TITLE
Consistent type checks for prepend and append tags.

### DIFF
--- a/torchtune/data/_prompt_templates.py
+++ b/torchtune/data/_prompt_templates.py
@@ -110,11 +110,22 @@ class PromptTemplate(PromptTemplateInterface):
             if message.role in self.template:
                 prepend_tag = self.template[message.role][0]
                 append_tag = self.template[message.role][1]
-                content = (
-                    [{"type": "text", "content": prepend_tag}]
-                    + message.content
-                    + [{"type": "text", "content": append_tag}]
-                )
+                if isinstance(prepend_tag, str) and isinstance(append_tag, str):
+                    content = (
+                        [{"type": "text", "content": prepend_tag}]
+                        + message.content
+                        + [{"type": "text", "content": append_tag}]
+                    )
+                elif not isinstance(prepend_tag, str) and isinstance(append_tag, str):
+                    content = message.content + [
+                        {"type": "text", "content": append_tag}
+                    ]
+                elif isinstance(prepend_tag, str) and not isinstance(append_tag, str):
+                    content = [
+                        {"type": "text", "content": prepend_tag}
+                    ] + message.content
+                else:
+                    content = {message.content}
             else:
                 content = message.content
             formatted_dialogue.append(
@@ -183,13 +194,30 @@ class ChatMLTemplate(PromptTemplateInterface):
                 and index == len(messages) - 1
                 and len(message.text_content) == 0
             ):
-                content = [{"type": "text", "content": prepend_tag}] + message.content
+                if isinstance(prepend_tag, str):
+                    content = [
+                        {"type": "text", "content": prepend_tag}
+                    ] + message.content
+                else:
+                    content = message.content
             else:
-                content = (
-                    [{"type": "text", "content": prepend_tag}]
-                    + message.content
-                    + [{"type": "text", "content": append_tag}]
-                )
+                if isinstance(prepend_tag, str) and isinstance(append_tag, str):
+                    content = (
+                        [{"type": "text", "content": prepend_tag}]
+                        + message.content
+                        + [{"type": "text", "content": append_tag}]
+                    )
+                elif not isinstance(prepend_tag, str) and isinstance(append_tag, str):
+                    content = message.content + [
+                        {"type": "text", "content": append_tag}
+                    ]
+                elif isinstance(prepend_tag, str) and not isinstance(append_tag, str):
+                    content = [
+                        {"type": "text", "content": prepend_tag}
+                    ] + message.content
+                else:
+                    content = {message.content}
+
             formatted_dialogue.append(
                 Message(
                     role=message.role,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
#1565
#### Changelog
What are the changes made in this PR?
* isinstance checks for prepend and append tags.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [X] I did not change any public API
- [ ] I have added an example to docs or docstrings

Add checks that prepend and append tags are actually valid. Did not make None <=> empty string. Pretty minor fix(written in perfomance most efficient way)