### PR TITLE
Add Ascend NPU as a backend

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -261,6 +261,10 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         # should be called before ``_setup_optimizer`` since transforming the optimizer
         # state dict requires the model
         self._compile = cfg.compile
+        if cfg.device == "npu" and cfg.compile:
+            raise ValueError(
+                "NPU does not support model compilation. Please set `compile: False` in the config."
+            )
         self._model = self._setup_model(
             cfg_model=cfg.model,
             enable_activation_checkpointing=self._enable_activation_checkpointing,
@@ -439,7 +443,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         log.info(f"Model is initialized with precision {self._dtype}.")
 
-        if self._device.type == "cuda":
+        if self._device.type != "cpu":
             memory_stats = training.get_memory_stats(device=self._device)
             training.log_memory_stats(memory_stats)
 
@@ -738,7 +742,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                             ),
                             "tokens_per_second_per_gpu": num_tokens / time_per_step,
                         }
-                        if self._device.type == "cuda" and self._log_peak_memory_stats:
+                        if self._device.type != "cpu" and self._log_peak_memory_stats:
                             log_dict.update(
                                 training.get_memory_stats(device=self._device)
                             )

--- a/torchtune/training/precision.py
+++ b/torchtune/training/precision.py
@@ -10,8 +10,10 @@ from typing import Dict, Generator, Iterable, Optional, Tuple
 import torch
 
 from torchtune.utils import get_logger
+from torchtune.utils._device import is_npu_available
 
 log = get_logger()
+
 
 PRECISION_STR_TO_DTYPE: Dict[str, torch.dtype] = {
     "fp16": torch.float16,
@@ -50,6 +52,7 @@ def verify_bf16_support() -> bool:
             - CUDA compute capability >= 8
         - NCCL is available and version >= 2.10
         - MPS is available and torch was built with MPS
+        - NPU is available and supports bf16
 
     Returns:
         bool: True if bf16 is available, False otherwise.
@@ -62,7 +65,8 @@ def verify_bf16_support() -> bool:
         and torch.cuda.nccl.version() >= (2, 10)
     )
     mps_support = torch.backends.mps.is_available() and torch.backends.mps.is_built()
-    return cuda_support or mps_support
+    npu_support = is_npu_available and torch.npu.is_bf16_supported()
+    return cuda_support or mps_support or npu_support
 
 
 def get_dtype(

--- a/torchtune/utils/__init__.py
+++ b/torchtune/utils/__init__.py
@@ -4,7 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._device import batch_to_device, get_device
+from ._device import (
+    batch_to_device,
+    DeviceSupport,
+    get_device,
+    get_device_support,
+    get_torch_device_namespace,
+)
 from ._logging import get_logger, log_rank_zero
 
 from ._version import torch_version_ge
@@ -14,5 +20,8 @@ __all__ = [
     "get_device",
     "get_logger",
     "torch_version_ge",
+    "get_device_support",
+    "get_torch_device_namespace",
+    "DeviceSupport",
     "log_rank_zero",
 ]

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -5,16 +5,33 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+from enum import Enum
 from typing import Optional
 
 import torch
 
 from torchtune.utils._import_guard import _SUPPORTS_FLEX_ATTENTION
+from torchtune.utils._logging import get_logger
+
+logger = get_logger("DEBUG")
 
 if _SUPPORTS_FLEX_ATTENTION:
     from torch.nn.attention.flex_attention import BlockMask
 else:
     BlockMask = torch.Tensor
+
+
+def is_torch_npu_available() -> bool:
+    """Check the availability of NPU"""
+    try:
+        import torch_npu  # noqa: F401
+
+        return torch.npu.is_available()
+    except ImportError:
+        return False
+
+
+is_npu_available = is_torch_npu_available()
 
 
 def _get_local_rank() -> Optional[int]:
@@ -29,8 +46,8 @@ def _get_local_rank() -> Optional[int]:
     return local_rank
 
 
-def _setup_cuda_device(device: torch.device) -> torch.device:
-    """Function that sets the CUDA device and infers the cuda
+def _setup_device(device: torch.device) -> torch.device:
+    """Function that sets the CUDA-like device and infers the device
     index if not set.
 
     Args:
@@ -43,29 +60,35 @@ def _setup_cuda_device(device: torch.device) -> torch.device:
         device
     """
     local_rank = _get_local_rank() or 0
+    device_support = get_device_support()
+    device_type = device_support.device_type
+    device_name = device_support.device_name
+    torch_device = get_torch_device_namespace()
+
     if device.index is None:
-        device = torch.device(type="cuda", index=local_rank)
+        device = torch.device(type=device_type, index=local_rank)
 
     # Ensure index is available before setting device
-    if device.index >= torch.cuda.device_count():
+    if device.index >= torch_device.device_count():
         raise RuntimeError(
-            "The local rank is larger than the number of available GPUs."
+            f"The local rank is larger than the number of available {device_name}s."
         )
-
-    torch.cuda.set_device(device)
+    torch_device.set_device(device)
     return device
 
 
 def _get_device_type_from_env() -> str:
     """Function that gets the torch.device based on the current machine.
 
-    This currently only supports CPU, CUDA.
+    This currently only supports CPU, CUDA, NPU.
 
     Returns:
         device
     """
     if torch.cuda.is_available():
         device = "cuda"
+    elif is_npu_available:
+        device = "npu"
     else:
         device = "cpu"
     return device
@@ -88,12 +111,12 @@ def _validate_device_from_env(device: torch.device) -> None:
     local_rank = _get_local_rank()
 
     # Check if the device index is correct
-    if device.type == "cuda" and local_rank is not None:
+    if device.type != "cpu" and local_rank is not None:
         # Ensure device index matches assigned index when distributed training
         if device.index != local_rank:
             raise RuntimeError(
-                f"You can't specify a device index when using distributed training. \
-                Device specified is {device} but was assigned cuda:{local_rank}"
+                f"You can't specify a device index when using distributed training. "
+                f"Device specified is {device} but local rank is:{local_rank}"
             )
 
     # Check if the device is available on this machine
@@ -110,10 +133,10 @@ def get_device(device: Optional[str] = None) -> torch.device:
     distributed settings, and returns a :func:`~torch.device`. If device string is not provided, this function will
     infer the device based on the environment.
 
-    If CUDA is available and being used, this function also sets the CUDA device.
+    If CUDA-like is available and being used, this function also sets the CUDA-like device.
 
     Args:
-        device (Optional[str]): The name of the device to use, e.g. "cuda" or "cpu".
+        device (Optional[str]): The name of the device to use, e.g. "cuda" or "cpu" or "npu".
 
     Example:
         >>> device = get_device("cuda")
@@ -126,8 +149,8 @@ def get_device(device: Optional[str] = None) -> torch.device:
     if device is None:
         device = _get_device_type_from_env()
     device = torch.device(device)
-    if device.type == "cuda":
-        device = _setup_cuda_device(device)
+    if device.type in ["cuda", "npu"]:
+        device = _setup_device(device)
     _validate_device_from_env(device)
     return device
 
@@ -156,3 +179,63 @@ def batch_to_device(batch: dict, device: torch.device) -> None:
                 f"""To use batch_to_device, all elements in the batch must be a dict or Tensor.
 Got key "{k}" with value of type {type(v)}"""
             )
+
+
+class DeviceSupport(Enum):
+    """
+    This is a simple enum for compute devices,
+    This currently only supports CPU, CUDA, NPU.
+    The following enumeration defines various device configurations with attributes:
+    1. `device_type` (str): The type of device (e.g., "cpu", "cuda", "npu").
+    2. `device_name` (str): A user-friendly name for the device (e.g., "CPU", "GPU", "NPU").
+    3. `communication_backend` (str): Specifies the backend used for communication on this device (e.g., "gloo", "nccl", "hccl").
+    """
+
+    CPU = ("cpu", "CPU", "gloo")
+    CUDA = ("cuda", "GPU", "nccl")
+    NPU = ("npu", "NPU", "hccl")
+
+    def __init__(
+        self,
+        device_type: str,
+        device_name: str,
+        communication_backend: str,
+    ):
+        self.device_type = device_type
+        self.device_name = device_name
+        self.communication_backend = communication_backend
+
+    @staticmethod
+    def from_type(device_type: str):
+        for member in DeviceSupport:
+            if member.device_type == device_type:
+                return member
+        raise ValueError(f"Unknown device type: {device_type}.")
+
+
+def get_device_support() -> DeviceSupport:
+    """function that gets the DeviceSupport with compute devices based on the current machine.
+
+    This currently only supports CPU, CUDA, NPU.
+
+    Returns:
+        device_support: DeviceSupport
+    """
+    device_type = _get_device_type_from_env()
+    return DeviceSupport.from_type(device_type)
+
+
+def get_torch_device_namespace() -> any:
+    """Return the corresponding torch attribute based on the device type string.
+
+    Returns:
+        module: The corresponding torch device namespace, or torch.cuda if not found.
+    """
+    device_type = get_device_support().device_type
+    try:
+        return getattr(torch, device_type)
+    except AttributeError:
+        logger.warning(
+            f"Device namespace '{device_type}' not found in torch, try to load torch.cuda."
+        )
+        return torch.cuda


### PR DESCRIPTION
# What does this PR do?

## Overview

🚀This PR enables the users of `torhtune` to leverage the Ascend NPU for better performance in inferencing when GPU device is not available.
This PR primarily addresses the initial refactoring of device-independent code. In upcoming changes, we’ll focus on further adjustments, using NPU as an example to refine each recipe and complete the remaining device-independent modifications. For now, this PR only touches on recipe lora_finetune_single_device and full_finetune_single_device.

For more details, see: [[#1797](https://github.com/pytorch/torchtune/issues/1797)].

## Environment

- OS: ubuntu 20.04
- NPU: Atlas 300T A2
- CANN: 8.0.RC2
- torch-npu: 2.4.0 rc1
- torch: 2.4.0

Note

To properly install CANN, see [[here](https://ascend.github.io/docs/sources/ascend/quick_install.html)] for more details.

The version of `torch-npu` should match that of `torch`, see [[here](https://github.com/Ascend/pytorch)] for more details.

In addition, `torch_npu` has a pre-release version, 2.4.0 RC1, which is also the basis for this test. For more information, please visit [[here](https://pypi.org/project/torch-npu/2.4.0rc1/)].

## Examples

To start with, the library `torch_npu` should be correctly installed and imported. Part of the codes are showed below:

`torchtune/utils/_device_support.py`:

```python
# Copyright (c) Meta Platforms, Inc. and affiliates.
# All rights reserved.
#
# This source code is licensed under the BSD-style license found in the
# LICENSE file in the root directory of this source tree.
import torch

def is_torch_npu_available():
    try:
        import torch_npu # noqa: F401
    except ImportError:
        return False
    return torch.npu.is_available()
```



Plus, there are some other places of the codes might be adjusted, which won't be too much.

Feel free to leave comments to guide me in further improvements 😊.

