### PR TITLE
fixed error message for GatedRepoError

### DIFF
--- a/torchtune/_cli/download.py
+++ b/torchtune/_cli/download.py
@@ -131,12 +131,18 @@ class Download(Subcommand):
                 token=args.hf_token,
             )
         except GatedRepoError:
-            self._parser.error(
-                "It looks like you are trying to access a gated repository. Please ensure you "
-                "have access to the repository and have provided the proper Hugging Face API token "
-                "using the option `--hf-token` or by running `huggingface-cli login`."
-                "You can find your token by visiting https://huggingface.co/settings/tokens"
-            )
+            if args.hf_token:
+                self._parser.error(
+                    "It looks like you are trying to access a gated repository. Please ensure you "
+                    "have access to the repository."
+                )
+            else:
+                self._parser.error(
+                    "It looks like you are trying to access a gated repository. Please ensure you "
+                    "have access to the repository and have provided the proper Hugging Face API token "
+                    "using the option `--hf-token` or by running `huggingface-cli login`."
+                    "You can find your token by visiting https://huggingface.co/settings/tokens"
+                )
         except RepositoryNotFoundError:
             self._parser.error(
                 f"Repository '{args.repo_id}' not found on the Hugging Face Hub."


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] Cleanup

Please link to any issues this PR addresses.
https://github.com/pytorch/torchtune/issues/1831

#### Changelog
What are the changes made in this PR?
Checked if `args.hf_token` is passed or not. and printed a message accordingly.

#### Test plan
None

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
