### PR TITLE
Remove pad_max_tiles in CLIP

### DIFF
--- a/recipes/configs/llama3_2_vision/11B_full.yaml
+++ b/recipes/configs/llama3_2_vision/11B_full.yaml
@@ -28,6 +28,7 @@ tokenizer:
   _component_: torchtune.models.llama3_2_vision.llama3_2_vision_transform
   path: /tmp/Llama-3.2-11B-Vision-Instruct/original/tokenizer.model
   image_size: 560
+  max_seq_len: 8192
 
 # Checkpointer
 checkpointer:

--- a/recipes/configs/llama3_2_vision/11B_full_single_device.yaml
+++ b/recipes/configs/llama3_2_vision/11B_full_single_device.yaml
@@ -30,6 +30,7 @@ tokenizer:
   _component_: torchtune.models.llama3_2_vision.llama3_2_vision_transform
   path: /tmp/Llama-3.2-11B-Vision-Instruct/original/tokenizer.model
   image_size: 560
+  max_seq_len: 8192
 
 # Checkpointer
 checkpointer:

--- a/recipes/configs/llama3_2_vision/11B_lora.yaml
+++ b/recipes/configs/llama3_2_vision/11B_lora.yaml
@@ -34,6 +34,7 @@ tokenizer:
   _component_: torchtune.models.llama3_2_vision.llama3_2_vision_transform
   path: /tmp/Llama-3.2-11B-Vision-Instruct/original/tokenizer.model
   image_size: 560
+  max_seq_len: 8192
 
 # Checkpointer
 checkpointer:

--- a/recipes/configs/llama3_2_vision/11B_lora_single_device.yaml
+++ b/recipes/configs/llama3_2_vision/11B_lora_single_device.yaml
@@ -32,6 +32,7 @@ tokenizer:
   _component_: torchtune.models.llama3_2_vision.llama3_2_vision_transform
   path: /tmp/Llama-3.2-11B-Vision-Instruct/original/tokenizer.model
   image_size: 560
+  max_seq_len: 8192
 
 # Checkpointer
 checkpointer:

--- a/tests/torchtune/models/clip/test_clip_image_transform.py
+++ b/tests/torchtune/models/clip/test_clip_image_transform.py
@@ -37,17 +37,6 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [1.0, 1.0],
                 "expected_tile_min": [0.0, 0.0],
                 "expected_aspect_ratio": [1, 2],
-                "pad_max_tiles": False,
-            },
-            {
-                "image_size": (100, 400, 3),
-                "expected_shape": torch.Size([4, 3, 224, 224]),
-                "resize_to_max_canvas": False,
-                "expected_tile_means": [0.2230, 0.1763, 0.0, 0.0],
-                "expected_tile_max": [1.0, 1.0, 0.0, 0.0],
-                "expected_tile_min": [0.0, 0.0, 0.0, 0.0],
-                "expected_aspect_ratio": [1, 2],
-                "pad_max_tiles": True,
             },
             {
                 "image_size": (1000, 300, 3),
@@ -57,7 +46,6 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [0.9705, 0.9694, 0.9521, 0.9314],
                 "expected_tile_min": [0.0353, 0.0435, 0.0528, 0.0],
                 "expected_aspect_ratio": [4, 1],
-                "pad_max_tiles": False,
             },
             {
                 "image_size": (200, 200, 3),
@@ -67,7 +55,6 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [0.9922, 0.9926, 0.9970, 0.9908],
                 "expected_tile_min": [0.0056, 0.0069, 0.0059, 0.0033],
                 "expected_aspect_ratio": [2, 2],
-                "pad_max_tiles": False,
                 "pad_tiles": 1,
             },
             {
@@ -78,17 +65,6 @@ class TestCLIPImageTransform:
                 "expected_tile_max": [1.0, 1.0, 1.0],
                 "expected_tile_min": [0.0, 0.0, 0.0],
                 "expected_aspect_ratio": [3, 1],
-                "pad_max_tiles": False,
-            },
-            {
-                "image_size": (600, 200, 3),
-                "expected_shape": torch.Size([4, 3, 224, 224]),
-                "resize_to_max_canvas": False,
-                "expected_tile_means": [0.4473, 0.4469, 0.3032, 0.0],
-                "expected_tile_max": [1.0, 1.0, 1.0, 0.0],
-                "expected_tile_min": [0.0, 0.0, 0.0, 0.0],
-                "expected_aspect_ratio": [3, 1],
-                "pad_max_tiles": True,
             },
         ],
     )
@@ -103,7 +79,6 @@ class TestCLIPImageTransform:
             resample="bilinear",
             dtype=torch.float32,
             resize_to_max_canvas=params["resize_to_max_canvas"],
-            pad_max_tiles=params["pad_max_tiles"],
         )
 
         image_transform_inference = CLIPImageTransformInference(
@@ -115,7 +90,6 @@ class TestCLIPImageTransform:
             resample="bilinear",
             resize_to_max_canvas=params["resize_to_max_canvas"],
             antialias=True,
-            pad_max_tiles=params["pad_max_tiles"],
         )
 
         # Generate a deterministic image using np.arange for reproducibility
@@ -169,13 +143,7 @@ class TestCLIPImageTransform:
         ), f"Expected aspect ratio {params['expected_aspect_ratio']} but got {tuple(output_ar.numpy())}"
 
         # number of tiles matches the product of the aspect ratio
-        if params["pad_max_tiles"]:
-            # max_num_tiles=4.
-            assert (
-                4 == output_image.shape[0]
-            ), f"Expected 4 tiles but got {output_image.shape[0]}"
-        else:
-            expected_num_tiles = output_ar[0] * output_ar[1]
-            assert (
-                expected_num_tiles == output_image.shape[0]
-            ), f"Expected {expected_num_tiles} tiles but got {output_image.shape[0]}"
+        expected_num_tiles = output_ar[0] * output_ar[1]
+        assert (
+            expected_num_tiles == output_image.shape[0]
+        ), f"Expected {expected_num_tiles} tiles but got {output_image.shape[0]}"

--- a/torchtune/models/clip/_transform.py
+++ b/torchtune/models/clip/_transform.py
@@ -15,7 +15,6 @@ from torchtune.modules.transforms.vision_utils.get_canvas_best_fit import (
     find_supported_resolutions,
     get_canvas_best_fit,
 )
-from torchtune.modules.transforms.vision_utils.pad_dim_to_size import pad_dim_to_size
 from torchtune.modules.transforms.vision_utils.resize_with_pad import resize_with_pad
 from torchtune.modules.transforms.vision_utils.tile_crop import tile_crop
 
@@ -63,7 +62,6 @@ class CLIPImageTransform:
             This will be used to generate possible_resolutions,
             e.g. [(224, 224), (224, 448), (448, 224)] if max_num_tiles = 2 and tile_size = 224.
             Default 4.
-        pad_max_tiles (bool): If True, the image will be padded to have tiles == max_num_tiles. Default False.
         dtype (torch.dtype): Data type of the output image. Default torch.bfloat16.
         resample (str): Resampling method used when resizing images. Supports any enum of
             ``torchvision.transforms.InterpolationMode``, e.g. "nearest", "nearest_exact", "bilinear", "bicubic".
@@ -101,7 +99,6 @@ class CLIPImageTransform:
         possible_resolutions: Optional[List[Tuple[int, int]]] = None,
         tile_size: int = 224,
         max_num_tiles: Optional[int] = 4,
-        pad_max_tiles: bool = False,
         dtype: torch.dtype = torch.bfloat16,
         resample: str = "bilinear",
         resize_to_max_canvas: bool = False,
@@ -142,7 +139,6 @@ class CLIPImageTransform:
         # tile_crop
         self.tile_size = tile_size
         self.tile_crop = tile_crop
-        self.pad_tile_size = max_num_tiles if pad_max_tiles else None
 
     def __call__(
         self, sample: Mapping[str, Any], inference: bool = False
@@ -190,8 +186,6 @@ class CLIPImageTransform:
 
         # Divide the image into equally sized tiles
         image = self.tile_crop(image=image, tile_size=self.tile_size)
-        if self.pad_tile_size:
-            image = pad_dim_to_size(image, size=self.pad_tile_size, dim=0)
 
         aspect_ratio = torch.tensor(best_resolution).reshape(-1) // self.tile_size
 

--- a/torchtune/models/llama3_2_vision/_transform.py
+++ b/torchtune/models/llama3_2_vision/_transform.py
@@ -86,7 +86,6 @@ class Llama3VisionTransform(ModelTokenizer, Transform):
             tile_size=tile_size,
             possible_resolutions=None,
             max_num_tiles=max_num_tiles,
-            pad_max_tiles=True,
             resample="bilinear",
             resize_to_max_canvas=False,
         )


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

Currently we have pad_max_tiles in the CLIP transform that will pad the image to 4 tiles. The CLIP model doesn't mask out the padding tiles, so by default we always added padding tiles in case the model relied on these extra tokens. Though in testing, I find the model completely ignores the padding tiles and it's not necessary to include them unless needed for the batch. Apart from this, I found that doing the pad_max_tiles in the CLIP transform instead of padded_collate_tiled_images_and_mask leads to a subtle bug where the cross attention mask is not aware, downstream, of which tiles are padding and should be masked and which shouldn't be.

#### Changelog
* remove pad_max_tiles from CLIPTransform
* add pad_max_tiles to padded_collate_tiled_images_and_mask
	* doing padding during collation (how we do for all other padding) ensures mask transforms are accurate
* Set pad_max_tiles to None by default
	* not padding more masks than necessary enables much faster training

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

This shows three runs for `tune run full_finetune_single_device --config llama3_2_vision/11B_full_single_device`. The "original" run is what's currently in main, the "new_pad_to_4" is with the fixed padding but adding extra padding tiles, and the "new_pad_to_batch" only pads to the max tiles in the batch. All three of these have the same loss, suggesting that the padding isn't important for model quality, but pad_to_batch gets almost double the qps on the ocr dataset since the cross attention sequence lengths can be much shorter.

<img width="1170" alt="Screenshot 2024-10-15 at 1 57 04 PM" src="https://github.com/user-attachments/assets/a373ec1a-d436-413e-b9db-b6576d0926ab">

