### PR TITLE
[WIP] Add KTOLoss

### DIFF
--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -57,6 +57,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         - :class:`~torchtune.rlhf.loss.DPOLoss`: Direct Preference Optimization (DPO).
         - :class:`~torchtune.rlhf.loss.RSOPLoss`: Rejection Sampling Optimization (RSO).
         - :class:`~torchtune.rlhf.loss.SimPOLoss`: Simple Preference Optimization (SimPO).
+        - :class:`~torchtune.rlhf.loss.KTOLoss`: Kahneman-Tversky Optimization (KTO).
+
 
     Assumptions:
         - Checkpoints are ONLY saved at epoch boundaries. In case of failure, work done

--- a/tests/torchtune/rlhf/loss/test_dpo_loss.py
+++ b/tests/torchtune/rlhf/loss/test_dpo_loss.py
@@ -6,7 +6,7 @@
 
 import pytest
 import torch
-from torchtune.rlhf.loss import DPOLoss, RSOLoss, SimPOLoss, KTOLoss
+from torchtune.rlhf.loss import DPOLoss, KTOLoss, RSOLoss, SimPOLoss
 
 
 @pytest.fixture(autouse=True)
@@ -173,9 +173,19 @@ class TestDPOLosses:
         rejected_rewards = torch.tensor([ 0.0000, -0.9900, -2.0900])
         """
 
-        policy_chosen_logprobs, policy_rejected_logprobs, ref_chosen_logprobs, ref_rejected_logprobs = loss_inputs
+        (
+            policy_chosen_logprobs,
+            policy_rejected_logprobs,
+            ref_chosen_logprobs,
+            ref_rejected_logprobs,
+        ) = loss_inputs
 
-        losses, *_ = kto_loss(policy_chosen_logprobs, policy_rejected_logprobs, ref_chosen_logprobs, ref_rejected_logprobs)
+        losses, *_ = kto_loss(
+            policy_chosen_logprobs,
+            policy_rejected_logprobs,
+            ref_chosen_logprobs,
+            ref_rejected_logprobs,
+        )
 
         expected_losses = torch.tensor([0.5000, 0.4975, 0.5225, 0.5000, 0.2709, 0.1101])
         torch.testing.assert_close(losses, expected_losses, atol=1e-4, rtol=1e-5)

--- a/torchtune/rlhf/loss/__init__.py
+++ b/torchtune/rlhf/loss/__init__.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from .dpo import DPOLoss, RSOLoss, SimPOLoss
+from .dpo import DPOLoss, RSOLoss, SimPOLoss, KTOLoss
 from .ppo import PPOLoss
 
-__all__ = ["DPOLoss", "RSOLoss", "SimPOLoss", "PPOLoss"]
+__all__ = ["DPOLoss", "RSOLoss", "SimPOLoss", "PPOLoss", "KTOLoss"]

--- a/torchtune/rlhf/loss/__init__.py
+++ b/torchtune/rlhf/loss/__init__.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from .dpo import DPOLoss, RSOLoss, SimPOLoss, KTOLoss
+from .dpo import DPOLoss, KTOLoss, RSOLoss, SimPOLoss
 from .ppo import PPOLoss
 
 __all__ = ["DPOLoss", "RSOLoss", "SimPOLoss", "PPOLoss", "KTOLoss"]

--- a/torchtune/rlhf/loss/dpo.py
+++ b/torchtune/rlhf/loss/dpo.py
@@ -36,20 +36,20 @@ class DPOLoss(nn.Module):
     """
 
     def __init__(
-            self,
-            beta: float = 0.1,
-            label_smoothing: float = 0.0,
+        self,
+        beta: float = 0.1,
+        label_smoothing: float = 0.0,
     ):
         super().__init__()
         self.beta = beta
         self.label_smoothing = label_smoothing
 
     def forward(
-            self,
-            policy_chosen_logps: torch.Tensor,
-            policy_rejected_logps: torch.Tensor,
-            reference_chosen_logps: torch.Tensor,
-            reference_rejected_logps: torch.Tensor,
+        self,
+        policy_chosen_logps: torch.Tensor,
+        policy_rejected_logps: torch.Tensor,
+        reference_chosen_logps: torch.Tensor,
+        reference_rejected_logps: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the DPO loss for a batch of policy and reference model log probabilities.
@@ -80,15 +80,15 @@ class DPOLoss(nn.Module):
         # We ignore the reference model as beta -> 0. The label_smoothing parameter encodes our uncertainty about the labels and
         # calculates a conservative DPO loss.
         losses = (
-                -F.logsigmoid(self.beta * logits) * (1 - self.label_smoothing)
-                - F.logsigmoid(-self.beta * logits) * self.label_smoothing
+            -F.logsigmoid(self.beta * logits) * (1 - self.label_smoothing)
+            - F.logsigmoid(-self.beta * logits) * self.label_smoothing
         )
 
         chosen_rewards = (
-                self.beta * (policy_chosen_logps - reference_chosen_logps).detach()
+            self.beta * (policy_chosen_logps - reference_chosen_logps).detach()
         )
         rejected_rewards = (
-                self.beta * (policy_rejected_logps - reference_rejected_logps).detach()
+            self.beta * (policy_rejected_logps - reference_rejected_logps).detach()
         )
 
         return losses, chosen_rewards, rejected_rewards
@@ -110,18 +110,18 @@ class RSOLoss(nn.Module):
     """
 
     def __init__(
-            self,
-            gamma: float = 0.1,
+        self,
+        gamma: float = 0.1,
     ):
         super().__init__()
         self.gamma = gamma
 
     def forward(
-            self,
-            policy_chosen_logps: torch.Tensor,
-            policy_rejected_logps: torch.Tensor,
-            reference_chosen_logps: torch.Tensor,
-            reference_rejected_logps: torch.Tensor,
+        self,
+        policy_chosen_logps: torch.Tensor,
+        policy_rejected_logps: torch.Tensor,
+        reference_chosen_logps: torch.Tensor,
+        reference_rejected_logps: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the RSO loss for a batch of policy and reference model log probabilities.
@@ -151,10 +151,10 @@ class RSOLoss(nn.Module):
         losses = torch.relu(1 - self.gamma * logits)
 
         chosen_rewards = (
-                self.gamma * (policy_chosen_logps - reference_chosen_logps).detach()
+            self.gamma * (policy_chosen_logps - reference_chosen_logps).detach()
         )
         rejected_rewards = (
-                self.gamma * (policy_rejected_logps - reference_rejected_logps).detach()
+            self.gamma * (policy_rejected_logps - reference_rejected_logps).detach()
         )
 
         return losses, chosen_rewards, rejected_rewards
@@ -186,10 +186,10 @@ class SimPOLoss(nn.Module):
     """
 
     def __init__(
-            self,
-            beta: float = 2.0,
-            gamma: float = 0.5,
-            label_smoothing: float = 0.0,
+        self,
+        beta: float = 2.0,
+        gamma: float = 0.5,
+        label_smoothing: float = 0.0,
     ):
         super().__init__()
         self.beta = beta
@@ -197,9 +197,9 @@ class SimPOLoss(nn.Module):
         self.label_smoothing = label_smoothing
 
     def forward(
-            self,
-            policy_chosen_logps: torch.Tensor,
-            policy_rejected_logps: torch.Tensor,
+        self,
+        policy_chosen_logps: torch.Tensor,
+        policy_rejected_logps: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the SimPO loss for a batch chosen and rejected average log probabilities.
@@ -223,8 +223,8 @@ class SimPOLoss(nn.Module):
         logits = pi_logratios - gamma_logratios
 
         losses = (
-                -F.logsigmoid(self.beta * logits) * (1 - self.label_smoothing)
-                - F.logsigmoid(-self.beta * logits) * self.label_smoothing
+            -F.logsigmoid(self.beta * logits) * (1 - self.label_smoothing)
+            - F.logsigmoid(-self.beta * logits) * self.label_smoothing
         )
 
         chosen_rewards = self.beta * (policy_chosen_logps).detach()
@@ -252,21 +252,30 @@ class KTOLoss(nn.Module):
     Args:
         beta (float): Parameter controlling the deviation from the reference model. Higher β means less deviation from the
             reference model. Default is 0.1.
-        desirable_weight (float):  Desirable losses are weighed by this factor to counter unequal number of desirable and undesirable paris. Default is 1.0.
-        undesirable_weight (float):  Undesirable losses are weighed by this factor to counter unequal number of desirable and undesirable paris. Default is 1.0.
+        desirable_weight (float):  Desirable losses are weighed by this factor to counter
+            unequal number of desirable and undesirable paris. Default is 1.0.
+        undesirable_weight (float):  Undesirable losses are weighed by this factor to counter
+            unequal number of desirable and undesirable paris. Default is 1.0.
     """
 
-    def __init__(self, beta: float = 0.1,
-                 undesirable_weight: float = 1.0, desirable_weight: float = 1.0):
+    def __init__(
+        self,
+        beta: float = 0.1,
+        desirable_weight: float = 1.0,
+        undesirable_weight: float = 1.0,
+    ):
         super().__init__()
         self.beta = beta
         self.desirable_weight = desirable_weight
         self.undesirable_weight = undesirable_weight
 
-    def forward(self, policy_chosen_logps: torch.FloatTensor,
-                policy_rejected_logps: torch.FloatTensor, reference_chosen_logps: torch.FloatTensor,
-                reference_rejected_logps: torch.FloatTensor) -> Tuple[
-        torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
+    def forward(
+        self,
+        policy_chosen_logps: torch.Tensor,
+        policy_rejected_logps: torch.Tensor,
+        reference_chosen_logps: torch.Tensor,
+        reference_rejected_logps: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the KTO loss for a batch of policy and reference model log probabilities.
 
@@ -299,7 +308,10 @@ class KTOLoss(nn.Module):
         rejected_losses = 1 - F.sigmoid(self.beta * (kl - rejected_logratios))
 
         losses = torch.cat(
-            (self.desirable_weight * chosen_losses, self.undesirable_weight * rejected_losses),
+            (
+                self.desirable_weight * chosen_losses,
+                self.undesirable_weight * rejected_losses,
+            ),
             0,
         )
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
#1850 
#### Changelog
What are the changes made in this PR?
* Adding KTO loss to torchtune

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [X] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [X] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [X] I have added an example to docs or docstrings
