### PR TITLE
fix dora tune_to_peft_adapter_weights

### DIFF
--- a/torchtune/models/convert_weights.py
+++ b/torchtune/models/convert_weights.py
@@ -260,15 +260,26 @@ def tune_to_peft_adapter_weights(
     # re-use the _FROM_HF mapping for base model weights. We iterate over it twice:
     # once to add mappings for LoRA A matrices and once to add mappings for LoRA B matrices.
     for k, v in _TO_PEFT_KEYS.items():
-        full_mapping.update(
-            {
-                vv.replace(".weight", f".{k}.weight"): kk.replace(
-                    ".weight", f".{v}.weight"
-                )
-                for kk, vv in _FROM_HF.items()
-                if vv is not None
-            }
-        )
+        if k == "magnitude":
+            full_mapping.update(
+                {
+                    vv.replace(".weight", f".{k}"): kk.replace(
+                        ".weight", f".{v}"
+                    )
+                    for kk, vv in _FROM_HF.items()
+                    if vv is not None
+                }
+            )
+        else:
+            full_mapping.update(
+                {
+                    vv.replace(".weight", f".{k}.weight"): kk.replace(
+                        ".weight", f".{v}.weight"
+                    )
+                    for kk, vv in _FROM_HF.items()
+                    if vv is not None
+                }
+            )
 
     if head_dim is None:
         head_dim = dim // num_heads


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?

fix `dora tune_to_peft_adapter_weights`. When converting adapter weights, the original code use `xxx.magnitude.weight` as a key to map torchtune weight names to peft weight names. However, `magnitude` is of type `nn.Parameter` and its state dict does not contain `weight`. Finetuning with dora with the original code will raise such error with saving peft adapters:
```log
[rank0]:     self._checkpointer.save_checkpoint(
[rank0]:   File "/mnt/data/torchtune/torchtune/training/checkpointing/_checkpointer.py", line 637, in save_checkpoint
[rank0]:     sys.exit(recipe_main())
[rank0]: The above exception was the direct cause of the following exception:
[rank0]: Traceback (most recent call last):
[rank0]:   File "/mnt/data/torchtune/torchtune/config/_parse.py", line 99, in wrapper
[rank0]: Traceback (most recent call last):
[rank0]:   File "/mnt/data/torchtune/torchtune/models/convert_weights.py", line 285, in tune_to_peft_adapter_weights
[rank0]:     new_key = get_mapped_key(key, full_mapping)
[rank0]: KeyError: 'layers.{}.attn.q_proj.magnitude'
[rank0]: Exception: Error converting the state dict. Found unexpected key: "layers.0.attn.q_proj.magnitude". Please make sure you're loading a checkpoint with the right format. 
[rank0]:   File "/mnt/data/torchtune/recipes/lora_finetune_distributed.py", line 726, in save_checkpoint
[rank0]:   File "/mnt/data/torchtune/recipes/lora_finetune_distributed.py", line 910, in <module>
[rank0]:   File "/mnt/data/torchtune/torchtune/models/convert_weights.py", line 55, in get_mapped_key
[rank0]:     ] = convert_weights.tune_to_peft_adapter_weights(
[rank0]:     recipe.train()
[rank0]:     new_key = mapping_dict[abstract_key]
[rank0]:   File "/mnt/data/torchtune/torchtune/models/convert_weights.py", line 60, in get_mapped_key
```



#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
