### PR TITLE
Kd_loss avg over tokens

### DIFF
--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -47,7 +47,7 @@ class TestKDSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama3": [11.0651, 11.0577, 11.0540, 11.7671],
+            "llama3": [11.7898, 11.7825, 11.7788, 11.7671],
         }
         return loss_values_map[model_type]
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
Follow up to issue #1865
In ForwardKLWithChunkedOutputLoss  the losss is averaged over non-masked tokens instead of chunks
In this [notebook](https://colab.research.google.com/drive/1r6k1VGRKUK76aNTzSLlFrRfGd7BX3zk2?usp=sharing) I show an example.

I ran some experiments to compare the old and the new loss. I followed the tutorial [here](https://pytorch.org/torchtune/stable/tutorials/llama_kd_tutorial.html)

here's the two commands for the training
```
CUDA_VISIBLE_DEVICES=7 tune run knowledge_distillation_single_device --config llama3_2/knowledge_distillation_single_device kd_loss._component_=torchtune.modules.loss.OldForwardKLWithChunkedOutputLoss batch_size=16 gradient_accumulation_steps=8 enable_activation_checkpointing=False metric_logger.log_dir=/tmp/kd_output_old profiler.output_dir=/tmp/kd_output/profiling_outputs_old checkpointer.output_dir=/tmp/Llama-3.2-1B-Instruct_old/
```

```
CUDA_VISIBLE_DEVICES=6 tune run knowledge_distillation_single_device --config llama3_2/knowledge_distillation_single_device kd_loss._component_=torchtune.modules.loss.FixedForwardKLWithChunkedOutputLoss batch_size=16 gradient_accumulation_steps=8 enable_activation_checkpointing=False metric_logger.log_dir=/tmp/kd_output_fixed profiler.output_dir=/tmp/kd_output/profiling_outputs_fixed checkpointer.output_dir=/tmp/Llama-3.2-1B-Instruct_fixed/
```
The results were as follow: 
| Dataset        | Metric       | Old Loss| Fixed Loss|
|----------------|--------------|-----------|-----------|
| TruthfulQA     | mc1          | 0.2766    | 0.2778    |
| TruthfulQA     | mc2          | 0.4348    | 0.4381    |
| HellaSwag      | acc          | 0.4549    | 0.4542    |
| HellaSwag      | acc_norm     | 0.6103    | 0.6113    |
| CommonSenseQA  | acc          | 0.5553    | 0.5594    |

Please let me know if further work should be done


#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
