### PR TITLE
Block on Python 3.13 version

### DIFF
--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -39,11 +39,12 @@ jobs:
         run: |
           import os
           a = os.environ["A"]
-          new_dict = {"include": []}
-          for build in a["include"]:
-            if build["python_version"] != "3.13":
-              new_dict["include"].append(build)
-          print("hello")
+          print(a)
+          # new_dict = {"include": []}
+          # for build in a["include"]:
+          #   if build["python_version"] != "3.13":
+          #     new_dict["include"].append(build)
+          # print("hello")
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: one
-        run: echo ${{ fromJSON(needs.generate-matrix.outputs) }}
+        run: echo '${{ fromJSON(needs.generate-matrix.outputs) }}'
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,14 +34,12 @@ jobs:
     steps:
       - name: step1
         run: |
-        echo $vars
-        echo $matrix
-        echo $env
+        echo "$GITHUB_ENV"
   build:
     needs:
       - generate-matrix
       - test
-    if: ${{ vars.PYTHON_VERSION }} != '3.9'
+    if: env.PYTHON_VERSION != '3.9'
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     strategy:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
-          echo $A['includes']
+          echo $A['include']
           # for item in $A["includes"]; do
           #   python_version=$(echo "$item" | jq -r '.python_version')
           #   echo "Python version: $python_version"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -54,6 +54,16 @@ jobs:
 
           with open(github_output_file, "r") as handle:
             print(handle.read())
+  check-output:
+    needs: filter-python-versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: asdf
+        shell: python
+        env:
+          A: ${{ needs.filter-python-versions.outputs.matrix }}
+        run: |
+          print("hello")
   build:
     needs: filter-python-versions
     name: ${{ matrix.repository }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -28,7 +28,7 @@ jobs:
       with-cuda: enable
       with-rocm: enable
       build-python-only: enable
-  test:
+  filter-python-versions:
     needs: generate-matrix
     runs-on: ubuntu-latest
     steps:
@@ -52,23 +52,20 @@ jobs:
 
           with open(github_output_file, "w") as handle:
             handle.write(f"matrix={json.dumps(new_dict)}")
-  # build:
-  #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
-  #   needs: generate-matrix
-  #   name: ${{ matrix.repository }}
-  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-  #   strategy:
-  #     fail-fast: false
-  #   with:
-  #     repository: pytorch/torchtune
-  #     ref: ""
-  #     package-name: torchtune
-  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-  #     pre-script: .github/scripts/pre_build_script.sh
-  #     trigger-event: ${{ github.event_name }}
-  #     build-platform: 'python-build-package'
-  #     pip-install-torch-extra-args:
-  #       torchvision
-  #       torchao
-      # - name: output-python-version
-      #   run: echo PYTHON_VERSION=$env.PYTHON_VERSION >> "$GITHUB_OUTPUT"
+  build:
+    needs: filter-python-versions
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    strategy:
+      fail-fast: false
+    with:
+      repository: pytorch/torchtune
+      ref: ""
+      package-name: torchtune
+      build-matrix: ${{ needs.filter-python-versions.outputs.matrix }}
+      pre-script: .github/scripts/pre_build_script.sh
+      trigger-event: ${{ github.event_name }}
+      build-platform: 'python-build-package'
+      pip-install-torch-extra-args:
+        torchvision
+        torchao

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -40,7 +40,7 @@ jobs:
       # - test
     env:
       PYTHON_VERSION: ${{ env.python_version }}
-    if: env.PYTHON_VERSION != '3.9'
+    if: ${{ env.PYTHON_VERSION }} != '3.9'
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     strategy:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -30,6 +30,7 @@ jobs:
       build-python-only: enable
   test:
     needs: generate-matrix
+    runs-on: ${{ matrix.validation_runner }}
     steps:
       - name: step1
         run: echo 'PYTHON_VERSION=$matrix.python_version' > $GITHUB_ENV

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,7 +31,9 @@ jobs:
   test:
     needs: generate-matrix
     runs-on: ubuntu-latest
-    run: echo ${{ needs.generate-matrix.outputs }}
+    steps:
+      - name: one
+        run: echo ${{ needs.generate-matrix.outputs }}
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -10,7 +10,6 @@ on:
       # Release candidate tags look like: v1.11.0-rc1
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
-  pull_request:
 
 permissions:
   id-token: write

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -53,6 +53,12 @@ jobs:
             handle.write(f"matrix={new_dict}")
 
           print(str(new_dict))
+          print("asdf")
+          print(json.dumps(new_dict))
+          print("asdf")
+
+          with open(github_output_file, "r") as handle:
+            print(handle.read())
   build:
     needs: filter-python-versions
     name: ${{ matrix.repository }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
-          echo $A['include']
+          echo ${A["include"]}
           # for item in $A["includes"]; do
           #   python_version=$(echo "$item" | jq -r '.python_version')
           #   echo "Python version: $python_version"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           A: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
         run: |
-        for item in "${A[@]}"; do
+        for item in $A.include; do
           python_version=$(echo "$item" | jq -r '.python_version')
           echo "Python version: $python_version"
         done

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,8 +34,12 @@ jobs:
     steps:
       - name: one
         env:
-          A: ${{ needs.generate-matrix.outputs.matrix }}
-        run: echo $A
+          A: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+        run: |
+        for item in "${A[@]}"; do
+          python_version=$(echo "$item" | jq -r '.python_version')
+          echo "Python version: $python_version"
+        done
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,21 +31,19 @@ jobs:
   test:
     needs: generate-matrix
     runs-on: ubuntu-latest
+    shell: python
     steps:
       - name: one
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
-          matrix_builds="${A["include"]}"
-          # new_matrix_builds = ()
-          for item in "${matrix_builds[@]}"; do
-            python_version="${item["python_version"]}"
-            echo $python_version
-            # python_version = ${item["python_version"]}
-            # if "$python_version" != "3.13"; then
-            #   new_matrix_builds+=$item
-            # fi
-          done
+          import os
+          a = os.getenv("A")
+          new_dict = {"include": []}
+          for build in a["include"]:
+            if build["python_version"] != "3.13":
+              new_dict["include"].append(build)
+          print("hello")
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -35,7 +35,7 @@ jobs:
       m-outputs: ${{ fromJSON(needs.generate-matrix.outputs) }}
     steps:
       - name: one
-        run: echo $env.m-outputs
+        run: echo ${{ env.m-outputs }}
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           import os
           a = os.environ["A"]
-          print(a)
+          print(type(a))
           # new_dict = {"include": []}
           # for build in a["include"]:
           #   if build["python_version"] != "3.13":

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: one
-        run: echo ${{ fromJSON(needs.generate-matrix.outputs) }}
+        run: echo ${{ needs.generate-matrix.outputs.python_version }}
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: one
         env:
-          A: ${{ needs.generate-matrix.outputs }}
+          A: ${{ needs.generate-matrix.outputs.matrix }}
         run: echo $A
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,8 +31,8 @@ jobs:
   test:
     needs: generate-matrix
     steps:
-      - run: |
-      echo 'PYTHON_VERSION=$matrix.python_version' > $GITHUB_ENV
+      - name: step1
+        run: echo 'PYTHON_VERSION=$matrix.python_version' > $GITHUB_ENV
   build:
     needs: generate-matrix
     if: ${{ vars.PYTHON_VERSION }} != '3.9'

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -29,8 +29,8 @@ jobs:
       with-rocm: enable
       build-python-only: enable
   build:
-    if: ${{ matrix.python_version }} != '3.9'
     needs: generate-matrix
+    if: ${{ matrix.python_version }} != '3.9'
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     strategy:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,21 +36,22 @@ jobs:
   #       run: echo 'hello'
   build:
     needs: generate-matrix
-    env:
-      PYTHON_VERSION: '3.9'
-    if: ${{ env.PYTHON_VERSION != '3.9' }}
-    name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-    strategy:
-      fail-fast: false
-    with:
-      repository: pytorch/torchtune
-      ref: ""
-      package-name: torchtune
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: .github/scripts/pre_build_script.sh
-      trigger-event: ${{ github.event_name }}
-      build-platform: 'python-build-package'
-      pip-install-torch-extra-args:
-        torchvision
-        torchao
+    steps:
+      - name: output-python-version
+        run: echo PYTHON_VERSION=$env.PYTHON_VERSION >> "$GITHUB_OUTPUT"
+      - name: ${{ matrix.repository }}
+        if: ${{ steps.output-python-version.outputs.PYTHON_VERSION != '3.9' }}
+        uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+        strategy:
+          fail-fast: false
+        with:
+          repository: pytorch/torchtune
+          ref: ""
+          package-name: torchtune
+          build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+          pre-script: .github/scripts/pre_build_script.sh
+          trigger-event: ${{ github.event_name }}
+          build-platform: 'python-build-package'
+          pip-install-torch-extra-args:
+            torchvision
+            torchao

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: one
         env:
-          A: ${{ needs.generate-matrix.outputs.matrix }}
+          A: ${{ needs.generate-matrix.outputs.matrix.include }}
         run: |
           matrix_builds="${A["include"]}"
           # new_matrix_builds = ()

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -29,7 +29,7 @@ jobs:
       with-rocm: enable
       build-python-only: enable
   build:
-    if: ${{ vars.PYTHON_VERSION }} != '3.9'
+    if: ${{ env.PYTHON_VERSION }} != '3.9'
     needs: generate-matrix
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -40,7 +40,7 @@ jobs:
       # - test
     env:
       PYTHON_VERSION: ${{ env.python_version }}
-    if: ${{ env.PYTHON_VERSION }} != '3.9'
+    if: ${{ env.PYTHON_VERSION != '3.9' }}
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     strategy:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,9 +34,9 @@ jobs:
     steps:
       - name: one
         env:
-          A: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+          A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
-          echo $A
+          echo $A['includes']
           # for item in $A["includes"]; do
           #   python_version=$(echo "$item" | jq -r '.python_version')
           #   echo "Python version: $python_version"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -51,7 +51,7 @@ jobs:
           # Filter out any builds for 3.13
           filtered_matrix = {"include": []}
           for build in input_matrix["include"]:
-            if build["python_version"] != "3.9":
+            if build["python_version"] != "3.13":
               filtered_matrix["include"].append(build)
 
           # Write the new matrix to the default outputs file

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -42,7 +42,6 @@ jobs:
 
           a = os.environ["A"]
           github_output_file = os.environ["GITHUB_OUTPUT"]
-          print(github_output_file)
           a_as_dict = json.loads(a)
 
           new_dict = {"include": []}
@@ -51,7 +50,7 @@ jobs:
               new_dict["include"].append(build)
 
           with open(github_output_file, "w") as handle:
-            handle.write(f"matrix={json.dumps(new_dict)}")
+            handle.write(f"matrix={new_dict}")
   build:
     needs: filter-python-versions
     name: ${{ matrix.repository }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -28,16 +28,18 @@ jobs:
       with-cuda: enable
       with-rocm: enable
       build-python-only: enable
-  test:
-    needs: generate-matrix
-    runs-on: ubuntu-latest
-    steps:
-      - name: step1
-        run: echo 'hello'
+  # test:
+  #   needs: generate-matrix
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: step1
+  #       run: echo 'hello'
   build:
     needs:
       - generate-matrix
-      - test
+      # - test
+    env:
+      PYTHON_VERSION: ${{ env.python_version }}
     if: env.PYTHON_VERSION != '3.9'
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,8 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: step1
-        run: |
-        echo "$GITHUB_ENV"
+        run: echo 'hello'
   build:
     needs:
       - generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,12 +34,13 @@ jobs:
     steps:
       - name: one
         env:
-          A: ${{ needs.generate-matrix.outputs.matrix.include }}
+          A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
           matrix_builds="${A["include"]}"
           # new_matrix_builds = ()
           for item in "${matrix_builds[@]}"; do
-            echo "$item"
+            python_version="${item["python_version"]}"
+            echo $python_version
             # python_version = ${item["python_version"]}
             # if "$python_version" != "3.13"; then
             #   new_matrix_builds+=$item

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -29,7 +29,7 @@ jobs:
       with-rocm: enable
       build-python-only: enable
   build:
-    if: ${{ env.PYTHON_VERSION }} != '3.9'
+    if: ${{ matrix.python_version }} != '3.9'
     needs: generate-matrix
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -38,8 +38,11 @@ jobs:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
           import os
+          import json
           a = os.environ["A"]
           print(type(a))
+          a_as_dict = json.loads(a)
+          print(type(a_as_dict))
           # new_dict = {"include": []}
           # for build in a["include"]:
           #   if build["python_version"] != "3.13":

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,14 +31,14 @@ jobs:
   test:
     needs: generate-matrix
     runs-on: ubuntu-latest
-    shell: python
     steps:
       - name: one
+        shell: python
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
           import os
-          a = os.getenv("A")
+          a = os.environ["A"]
           new_dict = {"include": []}
           for build in a["include"]:
             if build["python_version"] != "3.13":

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: one
-        run: echo '${{ fromJSON(needs.generate-matrix.outputs) }}'
+        run: echo ${{ fromJSON(needs.generate-matrix.includes) }}
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           A: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
         run: |
-        for item in $A.include; do
+        for item in $A; do
           python_version=$(echo "$item" | jq -r '.python_version')
           echo "Python version: $python_version"
         done

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,10 +36,11 @@ jobs:
         env:
           A: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
         run: |
-          for item in $A["includes"]; do
-            python_version=$(echo "$item" | jq -r '.python_version')
-            echo "Python version: $python_version"
-          done
+          echo $A
+          # for item in $A["includes"]; do
+          #   python_version=$(echo "$item" | jq -r '.python_version')
+          #   echo "Python version: $python_version"
+          # done
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -28,29 +28,27 @@ jobs:
       with-cuda: enable
       with-rocm: enable
       build-python-only: enable
-  # test:
-  #   needs: generate-matrix
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: step1
-  #       run: echo 'hello'
-  build:
-    if: ${{ needs.generate-matrix.outputs.matrix.python_version != '3.9' }}
+  test:
     needs: generate-matrix
-    name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-    strategy:
-      fail-fast: false
-    with:
-      repository: pytorch/torchtune
-      ref: ""
-      package-name: torchtune
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: .github/scripts/pre_build_script.sh
-      trigger-event: ${{ github.event_name }}
-      build-platform: 'python-build-package'
-      pip-install-torch-extra-args:
-        torchvision
-        torchao
+    runs-on: ubuntu-latest
+    run: echo ${{ needs.generate-matrix.outputs }}
+  # build:
+  #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
+  #   needs: generate-matrix
+  #   name: ${{ matrix.repository }}
+  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+  #   strategy:
+  #     fail-fast: false
+  #   with:
+  #     repository: pytorch/torchtune
+  #     ref: ""
+  #     package-name: torchtune
+  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+  #     pre-script: .github/scripts/pre_build_script.sh
+  #     trigger-event: ${{ github.event_name }}
+  #     build-platform: 'python-build-package'
+  #     pip-install-torch-extra-args:
+  #       torchvision
+  #       torchao
       # - name: output-python-version
       #   run: echo PYTHON_VERSION=$env.PYTHON_VERSION >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,10 +36,10 @@ jobs:
         env:
           A: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
         run: |
-        for item in $A; do
-          python_version=$(echo "$item" | jq -r '.python_version')
-          echo "Python version: $python_version"
-        done
+          for item in $A; do
+            python_version=$(echo "$item" | jq -r '.python_version')
+            echo "Python version: $python_version"
+          done
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -50,12 +50,7 @@ jobs:
               new_dict["include"].append(build)
 
           with open(github_output_file, "w") as handle:
-            handle.write(f"matrix={new_dict}")
-
-          print(str(new_dict))
-          print("asdf")
-          print(json.dumps(new_dict))
-          print("asdf")
+            handle.write(f"matrix={json.dumps(new_dict)}")
 
           with open(github_output_file, "r") as handle:
             print(handle.read())

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: one
         env:
-          A: ${{ fromJSON(needs.generate-matrix.outputs) }}
+          A: ${{ needs.generate-matrix.outputs }}
         run: echo $A
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -41,14 +41,17 @@ jobs:
           import json
 
           a = os.environ["A"]
+          github_output_file = os.environ["GITHUB_OUTPUT"]
+          print(github_output_file)
           a_as_dict = json.loads(a)
 
           new_dict = {"include": []}
           for build in a_as_dict["include"]:
-            if build["python_version"] != "3.9":
+            if build["python_version"] != "3.13":
               new_dict["include"].append(build)
 
-          print(new_dict)
+          with open(github_output_file, "w") as handle:
+            handle.write(f"matrix={json.dumps(new_dict)}")
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -51,9 +51,6 @@ jobs:
 
           with open(github_output_file, "w") as handle:
             handle.write(f"matrix={json.dumps(new_dict)}")
-
-          with open(github_output_file, "r") as handle:
-            print(handle.read())
   check-output:
     needs: filter-python-versions
     runs-on: ubuntu-latest
@@ -61,7 +58,7 @@ jobs:
       - name: asdf
         shell: python
         env:
-          A: ${{ needs.filter-python-versions.outputs.matrix }}
+          A: ${{ needs.filter-python-versions.outputs }}
         run: |
           print("hello")
   build:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,9 +31,11 @@ jobs:
   test:
     needs: generate-matrix
     runs-on: ubuntu-latest
+    env:
+      m-outputs: ${{ fromJSON(needs.generate-matrix.outputs) }}
     steps:
       - name: one
-        run: echo ${{ needs.generate-matrix.outputs }}
+        run: echo $env.m-outputs
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: set-matrix
+      - id: set-matrix
         shell: python
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -28,9 +28,14 @@ jobs:
       with-cuda: enable
       with-rocm: enable
       build-python-only: enable
+  test:
+    needs: generate-matrix
+    steps:
+      - run: |
+      echo 'PYTHON_VERSION=$matrix.python_version' > $GITHUB_ENV
   build:
     needs: generate-matrix
-    if: ${{ matrix.python_version }} != '3.9'
+    if: ${{ vars.PYTHON_VERSION }} != '3.9'
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     strategy:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -51,6 +51,8 @@ jobs:
 
           with open(github_output_file, "w") as handle:
             handle.write(f"matrix={new_dict}")
+
+          print(str(new_dict))
   build:
     needs: filter-python-versions
     name: ${{ matrix.repository }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -35,23 +35,22 @@ jobs:
   #     - name: step1
   #       run: echo 'hello'
   build:
+    if: ${{ needs.generate-matrix.outputs.matrix.python_version != '3.9' }}
     needs: generate-matrix
-    steps:
-      - name: output-python-version
-        run: echo PYTHON_VERSION=$env.PYTHON_VERSION >> "$GITHUB_OUTPUT"
-      - name: ${{ matrix.repository }}
-        if: ${{ steps.output-python-version.outputs.PYTHON_VERSION != '3.9' }}
-        uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-        strategy:
-          fail-fast: false
-        with:
-          repository: pytorch/torchtune
-          ref: ""
-          package-name: torchtune
-          build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-          pre-script: .github/scripts/pre_build_script.sh
-          trigger-event: ${{ github.event_name }}
-          build-platform: 'python-build-package'
-          pip-install-torch-extra-args:
-            torchvision
-            torchao
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    strategy:
+      fail-fast: false
+    with:
+      repository: pytorch/torchtune
+      ref: ""
+      package-name: torchtune
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: .github/scripts/pre_build_script.sh
+      trigger-event: ${{ github.event_name }}
+      build-platform: 'python-build-package'
+      pip-install-torch-extra-args:
+        torchvision
+        torchao
+      # - name: output-python-version
+      #   run: echo PYTHON_VERSION=$env.PYTHON_VERSION >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           A: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
         run: |
-          for item in $A; do
+          for item in $A["includes"]; do
             python_version=$(echo "$item" | jq -r '.python_version')
             echo "Python version: $python_version"
           done

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: one
-        run: echo ${{ needs.generate-matrix.outputs.python_version }}
+        run: echo ${{ needs.generate-matrix.outputs }}
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,8 +31,10 @@ jobs:
   filter-python-versions:
     needs: generate-matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: one
+      - name: set-matrix
         shell: python
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -28,41 +28,35 @@ jobs:
       with-cuda: enable
       with-rocm: enable
       build-python-only: enable
+  # TODO: Remove `filter-python-version` after PyArrow releases v18
   filter-python-versions:
     needs: generate-matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - id: set-matrix
+      - name: Filter matrix to exclude Python 3.13
+        id: set-matrix
         shell: python
         env:
-          A: ${{ needs.generate-matrix.outputs.matrix }}
+          input-matrix: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
           import os
           import json
 
-          a = os.environ["A"]
+          # Grab environment variables
+          input_matrix = json.loads(os.environ["input-matrix"])
           github_output_file = os.environ["GITHUB_OUTPUT"]
-          a_as_dict = json.loads(a)
 
-          new_dict = {"include": []}
-          for build in a_as_dict["include"]:
-            if build["python_version"] != "3.13":
-              new_dict["include"].append(build)
+          # Filter out any builds for 3.13
+          filtered_matrix = {"include": []}
+          for build in input_matrix["include"]:
+            if build["python_version"] != "3.9":
+              filtered_matrix["include"].append(build)
 
+          # Write the new matrix to the default outputs file
           with open(github_output_file, "w") as handle:
-            handle.write(f"matrix={json.dumps(new_dict)}")
-  check-output:
-    needs: filter-python-versions
-    runs-on: ubuntu-latest
-    steps:
-      - name: asdf
-        shell: python
-        env:
-          A: ${{ needs.filter-python-versions.outputs.matrix }}
-        run: |
-          print("hello")
+            handle.write(f"matrix={json.dumps(filtered_matrix)}")
   build:
     needs: filter-python-versions
     name: ${{ matrix.repository }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,11 +36,15 @@ jobs:
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
-          echo ${A["include"]}
-          # for item in $A["includes"]; do
-          #   python_version=$(echo "$item" | jq -r '.python_version')
-          #   echo "Python version: $python_version"
-          # done
+          matrix_builds = ${A["include"]}
+          # new_matrix_builds = ()
+          for item in ${matrix_builds[@]}; do
+            echo "$item"
+            # python_version = ${item["python_version"]}
+            # if "$python_version" != "3.13"; then
+            #   new_matrix_builds+=$item
+            # fi
+          done
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -39,15 +39,16 @@ jobs:
         run: |
           import os
           import json
+
           a = os.environ["A"]
-          print(type(a))
           a_as_dict = json.loads(a)
-          print(type(a_as_dict))
-          # new_dict = {"include": []}
-          # for build in a["include"]:
-          #   if build["python_version"] != "3.13":
-          #     new_dict["include"].append(build)
-          # print("hello")
+
+          new_dict = {"include": []}
+          for build in a_as_dict["include"]:
+            if build["python_version"] != "3.9":
+              new_dict["include"].append(build)
+
+          print(new_dict)
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
-          matrix_builds=${A["include"]}
+          matrix_builds="${A["include"]}"
           # new_matrix_builds = ()
           for item in "${matrix_builds[@]}"; do
             echo "$item"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -35,7 +35,9 @@ jobs:
       - name: step1
         run: echo 'PYTHON_VERSION=$matrix.python_version' > $GITHUB_ENV
   build:
-    needs: generate-matrix
+    needs:
+      - generate-matrix
+      - test
     if: ${{ vars.PYTHON_VERSION }} != '3.9'
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,7 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: one
-        run: echo ${{ fromJSON(needs.generate-matrix.includes) }}
+        env:
+          A: ${{ fromJSON(needs.generate-matrix.includes) }}
+        run: echo $A
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,11 +31,9 @@ jobs:
   test:
     needs: generate-matrix
     runs-on: ubuntu-latest
-    env:
-      m-outputs: ${{ fromJSON(needs.generate-matrix.outputs) }}
     steps:
       - name: one
-        run: echo ${{ env.m-outputs }}
+        run: echo ${{ fromJSON(needs.generate-matrix.outputs) }}
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -30,10 +30,13 @@ jobs:
       build-python-only: enable
   test:
     needs: generate-matrix
-    runs-on: ${{ matrix.validation_runner }}
+    runs-on: ubuntu-latest
     steps:
       - name: step1
-        run: echo 'PYTHON_VERSION=$matrix.python_version' > $GITHUB_ENV
+        run: |
+        echo $vars
+        echo $matrix
+        echo $env
   build:
     needs:
       - generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           A: ${{ needs.generate-matrix.outputs.matrix }}
         run: |
-          matrix_builds = ${A["include"]}
+          matrix_builds=${A["include"]}
           # new_matrix_builds = ()
           for item in "${matrix_builds[@]}"; do
             echo "$item"

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -35,11 +35,9 @@ jobs:
   #     - name: step1
   #       run: echo 'hello'
   build:
-    needs:
-      - generate-matrix
-      # - test
+    needs: generate-matrix
     env:
-      PYTHON_VERSION: ${{ env.python_version }}
+      PYTHON_VERSION: '3.9'
     if: ${{ env.PYTHON_VERSION != '3.9' }}
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: asdf
         shell: python
         env:
-          A: ${{ needs.filter-python-versions.outputs }}
+          A: ${{ needs.filter-python-versions.outputs.matrix }}
         run: |
           print("hello")
   build:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: one
         env:
-          A: ${{ fromJSON(needs.generate-matrix.includes) }}
+          A: ${{ fromJSON(needs.generate-matrix.outputs) }}
         run: echo $A
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: one
-        run: echo ${{ needs.generate-matrix.outputs }}
+        run: echo ${{ fromJSON(needs.generate-matrix.outputs) }}
   # build:
   #   if: ${{ needs.generate-matrix.outputs.python_version != '3.9' }}
   #   needs: generate-matrix

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           matrix_builds = ${A["include"]}
           # new_matrix_builds = ()
-          for item in ${matrix_builds[@]}; do
+          for item in "${matrix_builds[@]}"; do
             echo "$item"
             # python_version = ${item["python_version"]}
             # if "$python_version" != "3.13"; then


### PR DESCRIPTION
The worst hack I've written so far in my life. Github Actions is a (useful) abomination. 

**Goal**: Don't run nightly builds on Python 3.13. We depend on HF Datasets, which depends on PyArrow, who haven't released a Python 3.13 wheel. It is expected to come out soon in version v18. Therefore, Python 3.13 builds break.

Simple enough, right? 

WRONG

SO WRONG

UNBELIEVABLY WRONG.

**Attempt 1**: Figure out a way to make the `build` job conditional on whether the matrix entry way for Python 3.13. Eight hours later, it's pretty clear that this isn't possible (through torchtune) b/c the `build` job is controlled by dev-infra and we just pass in the entire matrix and it handles the actual execution. 

**Attempt 2**: Filter the matrix generated by the `generate-matrix` job to remove all Python 3.13 entries. It was about three hours in that I figured out I could create a Python shell in the filtering job. This sped things up and after another couple hours, here we are. **But, Joe, how do you know it works if Python 3.13 jobs are only kicked off for nightly builds and you've done all your testing on this PR?** I toggled the filtering function to exclude Python 3.9 jobs (since those are the only ones kicked off on PRs) and confirmed that these jobs were not passed down to the `build` job. **Is that good enough?** No probably not, but what are you going to do about it? 

Final question - **Was this a good use of my time?**: Probably not. PyArrow will be out soon and we could've just had broken nightlies for Python 3.13 until then b/c no one is really using Python 3.13. But I know that my teammates will express great admiration and gratitude for making the little box green instead of red and that makes it alllllll worth it. 