### PR TITLE
Patch github link in torchtune docs header

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -17,11 +17,11 @@
 
 <script type="text/javascript">
     var collapsedSections = []
-    </script>
-    {{ super() }}
-    <script type="text/javascript">
-      $(document).ready(function() {
-            $(".main-menu-item a[href='https://github.com/pytorch/pytorch']").attr("href", "https://github.com/pytorch/torchtune");
-      });
-    </script>
+</script>
+{{ super() }}
+<script type="text/javascript">
+    $(document).ready(function() {
+        $(".main-menu-item a[href='https://github.com/pytorch/pytorch']").attr("href", "https://github.com/pytorch/torchtune");
+    });
+</script>
 {% endblock %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -15,7 +15,13 @@
     var collapsedSections = ['Introduction', 'Getting Started', 'Tutorials']
 </script> -->
 
-<script script type="text/javascript">
+<script type="text/javascript">
     var collapsedSections = []
-</script>
+    </script>
+    {{ super() }}
+    <script type="text/javascript">
+      $(document).ready(function() {
+            $(".main-menu-item a[href='https://github.com/pytorch/pytorch']").attr("href", "https://github.com/pytorch/torchtune");
+      });
+    </script>
 {% endblock %}


### PR DESCRIPTION
Fixes #1843 

In our live docs we currently use the default PyTorch Sphinx theme for our header. This includes a Github icon that points to the main PyTorch repo by default, but for torchtune this isn't really where we want to point. This PR takes a similar approach to what is done in torchaudio [here](https://github.com/pytorch/audio/blob/main/docs/source/_templates/layout.html): adding a script to the footer to patch the href pointing to the PyTorch GH page. Unlike in torchaudio, however, we do not pin to an older version of the PyTorch Sphinx theme, so we identify the object to patch slightly differently.

Test plan:

Building docs locally and mousing over the GH icon we can see that it now points to the torchtune page.
 
<img width="1122" alt="Screenshot 2024-10-28 at 4 49 58 PM" src="https://github.com/user-attachments/assets/f3ab65e5-5df2-4a64-b1b0-05046a8ee5a7">
