### PR TITLE
[ez] Fix README download example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ To download Llama3.1, you can run:
 ```bash
 tune download meta-llama/Meta-Llama-3.1-8B-Instruct \
 --output-dir /tmp/Meta-Llama-3.1-8B-Instruct \
+--ignore-patterns "original/consolidated.00.pth" \
 --hf-token <HF_TOKEN> \
 ```
 


### PR DESCRIPTION
The current download example command in the README will download the consolidated weights and not the safetensors, any any `tune run` on llama3.1 will error out. This PR updates to the correct command.

Thanks to @drisspg for pointing this out.