### PR TITLE
[DO NOT LAND] compile more modules

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -767,7 +767,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 self._profiler.step()
 
             self.epochs_run += 1
-            self.save_checkpoint(epoch=curr_epoch)
+            # self.save_checkpoint(epoch=curr_epoch)
 
         self._profiler.stop()
 

--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -481,7 +481,6 @@ class TransformerDecoder(nn.Module):
         for layer in self.layers:
             layer.reset_cache()
 
-    @torch.compiler.disable
     def chunked_output(self, last_hidden_state: torch.Tensor) -> List[torch.Tensor]:
         """
         Apply output projection in chunks. This should be applied in conjunction with

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -50,6 +50,16 @@ def compile_model(
                 m, TransformerCrossAttentionLayer
             ):
                 m.compile(backend=backend)
+
+        if hasattr(model, "norm"):
+            model.norm.compile(backend=backend)
+
+        if hasattr(model, "chunked_output"):
+            model.chunked_output = torch.compile(model.chunked_output, backend=backend)
+
+        if hasattr(model, "token_embeddings"):
+            model.token_embeddings.compile(backend=backend)
+
     else:
         if verbose:
             log.info(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

We compile only transformer layers. However, we could compile embedding, norm and the output layer.

```
if hasattr(model, "norm"):
    model.norm.compile(backend=backend)

if hasattr(model, "chunked_output"):
    model.chunked_output = torch.compile(model.chunked_output, backend=backend)

if hasattr(model, "token_embeddings"):
    model.token_embeddings.compile(backend=backend)
```

#### Test plan

3b with packing
```
tune run full_finetune_single_device --config llama3_2/3B_full_single_device optimizer_in_bwd=True enable_activation_checkpointing=True enable_activation_offloading=True optimizer._component_=torch.optim.AdamW optimizer.fused=True compile=True dataset.packed=True dataset.split=train[:5%] tokenizer.max_seq_len=2048 metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=profiling log_every_n_steps=1 log_peak_memory_stats=True gradient_accumulation_steps=1 max_steps_per_epoch=15 epochs=1 batch_size=5 metric_logger.name=baseline loss=torchtune.modules.loss.CEWithChunkedOutputLoss
```
<img width="1638" alt="image" src="https://github.com/user-attachments/assets/9ad74ee4-103a-40b4-85af-6ddf7c6feaa2">
<img width="1630" alt="image" src="https://github.com/user-attachments/assets/c6837b4d-1ce1-4e47-b5c6-e36f05435e0d">

8b with packing
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/a2b676ed-91cd-4e1a-bc49-257f38d03c22">

11b NO packing, NO act offloading
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/1e5266ef-022e-4f08-8be3-7c00573dfb84">

#### conclusion:
compiling the extra modules seems to help when there is tied embedding. However, if there is not packing, then there are more graph breaks, slowing down early training. We should fix graphs breaks and then potentially land this PR. Optionally, we can compile the extra layers only if we hav tied embeddings.

