### PR TITLE
nit: Correct compile_loss return type hint

### DIFF
--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -61,7 +61,7 @@ def compile_model(
         model.compile(backend=backend)
 
 
-def compile_loss(loss: nn.Module, verbose: bool = True) -> None:
+def compile_loss(loss: nn.Module, verbose: bool = True) -> nn.Module:
     """
     Utility to compile and return loss function. If the loss function is chunked cross-entropy,
     we only compile the upcast + cross-entropy calculation, not the chunking. For other losses


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
What are the changes made in this PR?
* Fix the return type hint for the `compile_loss` utility function
