### PR TITLE
Fix grad accum + FSDP CPU offload, pass None via CLI

### DIFF
--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -173,6 +173,11 @@ def _merge_yaml_and_cli_args(yaml_args: Namespace, cli_args: List[str]) -> DictC
         # key string to reflect this
         if k in yaml_kwargs and _has_component(yaml_kwargs[k]):
             k += "._component_"
+
+        # None passed via CLI will be parsed as string, but we really want OmegaConf null
+        if v == "None":
+            v = "!!null"
+
         # TODO: this is a hack but otherwise we can't pass strings with leading zeroes
         # to define the checkpoint file format. We manually override OmegaConf behavior
         # by prepending the value with !!str to force a string type

--- a/torchtune/training/_grad_scaler.py
+++ b/torchtune/training/_grad_scaler.py
@@ -21,6 +21,11 @@ def scale_grads(model: nn.Module, scaler: torch.Tensor) -> None:
     Outputs:
         None (grad fields are modified in place)
     """
+    device = None
     for p in model.parameters():
+        # First ensure scaler is on the same device as the model
+        if not device:
+            device = p.device
+            scaler = scaler.to(device)
         if p.grad is not None:
             p.grad *= scaler


### PR DESCRIPTION
Fixes #1939 

Two small fixes in this PR. 

The first one is due to not moving our grad scaler to CPU when CPU offloading is enabled. Imo it's cleanest to just do this directly in the utility by inferring the right device from the first parameter we see, rather than relying on the FSDP CPU offload flag. 

The second one is a bit of a hack but makes it possible to pass `some_config_field=None` from CLI and have it mean None in the Python sense. This means we can't ever use "None" as a string in configs or CLI overrides, but it eliminates some confusion around the fact that OmegaConf would expect `some_config_field=null` and instead parses None as a string. 

## Test plan:

### Fix 1:

```
tune run --nproc_per_node 2 full_finetune_distributed --config llama3/8B_full \
gradient_accumulation_steps=2 fsdp_cpu_offload=True
```

#### On main

```
...
[rank0]: RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

#### On this PR

```
...
1|1|Loss: 3.1665189266204834:   0%|                                                                                                                                                                 | 1/6500 [00:25<46:53:08, 25.97s/it]
```

### Fix 2:

```
tune run full_finetune_single_device --config llama3/8B_full_single_device \
clip_grad_norm=None
```

#### On main:

```
...
    raise RuntimeError(
RuntimeError: Gradient clipping is not supported with optimizer in bwd.Please set clip_grad_norm=None, or optimizer_in_bwd=False.
```

#### On this PR:

```
...
1|5|Loss: 2.147994041442871:   0%|                                                                                                                                                                  | 5/26001 [00:08<7:58:13,  1.10s/it]
```