### PR TITLE
[Bug] model_type argument as str for checkpoints classes

### DIFF
--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -443,7 +443,7 @@ For this section we'll use the Llama2 13B model in HF format.
         checkpoint_dir=checkpoint_dir,
         checkpoint_files=pytorch_files,
         output_dir=checkpoint_dir,
-        model_type=ModelType.LLAMA2
+        model_type="LLAMA2"
     )
     torchtune_sd = checkpointer.load_checkpoint()
 

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -111,7 +111,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         checkpoint_dir (str): Directory containing the checkpoint files
         checkpoint_files (List[str]): List of checkpoint files to load. Since the checkpointer takes care
             of sorting by file ID, the order in this list does not matter
-        model_type (ModelType): Model type of the model for which the checkpointer is being loaded
+        model_type (str): Model type of the model for which the checkpointer is being loaded
         output_dir (str): Directory to save the checkpoint files
         adapter_checkpoint (Optional[str]): Path to the adapter weights. Default is None
         recipe_checkpoint (Optional[str]): Path to the recipe state checkpoint file. Default is None
@@ -130,7 +130,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         self,
         checkpoint_dir: str,
         checkpoint_files: List[str],
-        model_type: ModelType,
+        model_type: str,
         output_dir: str,
         adapter_checkpoint: Optional[str] = None,
         recipe_checkpoint: Optional[str] = None,
@@ -159,7 +159,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         )
 
         self._resume_from_checkpoint = resume_from_checkpoint
-        self._model_type = model_type
+        self._model_type = ModelType[model_type]
         self._output_dir = Path(output_dir)
 
         # recipe_checkpoint contains the recipe state. This should be available if
@@ -322,7 +322,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         checkpoint_dir (str): Directory containing the checkpoint files
         checkpoint_files (Union[List[str], Dict[str, str]]): List of checkpoint files to load. Since the checkpointer takes care
             of sorting by file ID, the order in this list does not matter. TODO: update this
-        model_type (ModelType): Model type of the model for which the checkpointer is being loaded
+        model_type (str): Model type of the model for which the checkpointer is being loaded
         output_dir (str): Directory to save the checkpoint files
         adapter_checkpoint (Optional[str]): Path to the adapter weights. Default is None
         recipe_checkpoint (Optional[str]): Path to the recipe state checkpoint file. Default is None
@@ -338,7 +338,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         self,
         checkpoint_dir: str,
         checkpoint_files: Union[List[str], Dict[str, str]],
-        model_type: ModelType,
+        model_type: str,
         output_dir: str,
         adapter_checkpoint: Optional[str] = None,
         recipe_checkpoint: Optional[str] = None,
@@ -723,7 +723,7 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
         checkpoint_dir (str): Directory containing the checkpoint files
         checkpoint_files (List[str]): List of checkpoint files to load. Currently this checkpointer only
             supports loading a single checkpoint file.
-        model_type (ModelType): Model type of the model for which the checkpointer is being loaded
+        model_type (str): Model type of the model for which the checkpointer is being loaded
         output_dir (str): Directory to save the checkpoint files
         adapter_checkpoint (Optional[str]): Path to the adapter weights. Default is None
         recipe_checkpoint (Optional[str]): Path to the recipe state checkpoint file. Default is None
@@ -739,7 +739,7 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
         self,
         checkpoint_dir: str,
         checkpoint_files: List[str],
-        model_type: ModelType,
+        model_type: str,
         output_dir: str,
         adapter_checkpoint: Optional[str] = None,
         recipe_checkpoint: Optional[str] = None,


### PR DESCRIPTION
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

The correct usage of `model_type` argument is as a string as shown  [here](https://github.com/pytorch/torchtune/blob/main/tests/torchtune/training/checkpointing/test_checkpointer.py#L172) 