### PR TITLE
Convert all non-rgb images to rgb

### DIFF
--- a/torchtune/models/clip/_transform.py
+++ b/torchtune/models/clip/_transform.py
@@ -159,10 +159,9 @@ class CLIPImageTransform:
         assert isinstance(image, Image.Image), "Input image must be a PIL image."
 
         # Make image torch.tensor((3, H, W), dtype=dtype), 0<=values<=1
-        if hasattr(image, "mode") and image.mode == "RGBA":
+        if image.mode != "RGB":
             image = image.convert("RGB")
         image = F.to_image(image)
-        image = F.grayscale_to_rgb_image(image)
         image = F.to_dtype(image, dtype=self.dtype, scale=True)
 
         # Find the best canvas to fit the image without distortion


### PR DESCRIPTION
@ebsmothers Ensure that all images are converted to `RGB` format. No longer need to separately convert grayscale images to rgb either. Addresses https://github.com/pytorch/torchtune/issues/1975