### PR TITLE
DOC Fixes custom message transform example

### DIFF
--- a/docs/source/basics/message_transforms.rst
+++ b/docs/source/basics/message_transforms.rst
@@ -35,10 +35,11 @@ column as the model response. Indeed, this is quite similar to :class:`~torchtun
     from torchtune.modules.transforms import Transform
     from torchtune.data import Message
     from typing import Any, Mapping
+    from pprint import pprint
 
     class MessageTransform(Transform):
         def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
-            return [
+            messages = [
                 Message(
                     role="user",
                     content=sample["input"],
@@ -52,17 +53,14 @@ column as the model response. Indeed, this is quite similar to :class:`~torchtun
                     eot=True,
                 ),
             ]
+            return {"messages": messages}
 
-    sample = {"input": "hello world", "output": "bye world"}
+    input_sample = {"input": "hello world", "output": "bye world"}
     transform = MessageTransform()
-    messages = transform(sample)
-    print(messages)
-    # [<torchtune.data._messages.Message at 0x7fb0a10094e0>,
-    # <torchtune.data._messages.Message at 0x7fb0a100a290>]
-    for msg in messages:
-        print(msg.role, msg.text_content)
-    # user hello world
-    # assistant bye world
+    output_sample = transform(input_sample)
+    pprint(output_sample)
+    # {'messages': [Message(role='user', content=['hello world']),
+    #               Message(role='assistant', content=['bye world'])]}
 
 See :ref:`creating_messages` for more details on how to manipulate :class:`~torchtune.data.Message` objects.
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Fixes https://github.com/pytorch/torchtune/issues/1919

Since `Message` has a nice `__repr__`, I think it's enough to print everything with `pprint`.

#### Changelog
What are the changes made in this PR?
* Fixes custom message transform example.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
