### PR TITLE
Make sure CLIP resized pos_embed is contiguous

### DIFF
--- a/tests/torchtune/models/clip/test_pos_embedding_interpolation.py
+++ b/tests/torchtune/models/clip/test_pos_embedding_interpolation.py
@@ -201,6 +201,7 @@ class TestPositionalEmbeddingsInterpolation:
             embedding, tgt_max_num_tiles
         )
 
+        assert resized_pos_embed.is_contiguous()
         assert_expected(resized_pos_embed, expected_output, atol=1e-3, rtol=1e-4)
 
     @pytest.mark.parametrize("params", local_pos_emb_test_cases)
@@ -215,6 +216,7 @@ class TestPositionalEmbeddingsInterpolation:
             )
         )
 
+        assert resized_pos_embed.is_contiguous()
         assert_expected(resized_pos_embed, expected_output, atol=1e-3, rtol=1e-4)
 
     @pytest.mark.parametrize("params", global_pos_emb_test_cases)
@@ -230,6 +232,7 @@ class TestPositionalEmbeddingsInterpolation:
             )
         )
 
+        assert resized_pos_embed.is_contiguous()
         assert_expected(resized_pos_embed, expected_output, atol=1e-3, rtol=1e-4)
 
     @pytest.mark.parametrize(

--- a/torchtune/models/clip/_position_embeddings.py
+++ b/torchtune/models/clip/_position_embeddings.py
@@ -319,7 +319,7 @@ class TiledTokenPositionalEmbedding(nn.Module):
         # add cls token back in
         local_pos_embed = torch.cat([cls_token, local_pos_embed], dim=0)
 
-        return local_pos_embed
+        return local_pos_embed.contiguous()
 
     # TODO: Switch to public method after 2.5 is stable
     @staticmethod
@@ -436,7 +436,7 @@ class TiledTokenPositionalEmbedding(nn.Module):
         # add cls token back in
         global_pos_embed = torch.cat([cls_embed, pos_embed], dim=2)
 
-        return global_pos_embed
+        return global_pos_embed.contiguous()
 
     def forward(self, x: torch.Tensor, aspect_ratio: torch.Tensor) -> torch.Tensor:
         """
@@ -633,7 +633,7 @@ class TilePositionalEmbedding(nn.Module):
         )
         # permute to the original shape
         embedding = embedding.permute(2, 3, 0, 1)
-        return embedding
+        return embedding.contiguous()
 
     def forward(self, x: torch.Tensor, aspect_ratio: torch.Tensor) -> torch.Tensor:
         """


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

Partially address #1978 

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
