### PR TITLE
Add **quantization_kwargs to ``FrozenNF4Linear`` and ``LoRALinear`` and ``DoRALinear``

### DIFF
--- a/tests/torchtune/modules/low_precision/test_nf4_linear.py
+++ b/tests/torchtune/modules/low_precision/test_nf4_linear.py
@@ -47,6 +47,21 @@ class TestNF4Linear:
         assert len(params) == 1
         assert isinstance(params[0], NF4Tensor)
 
+    def test_quantization_kwargs(self):
+        """Test that passing in non-default quantization kwargs works as expected."""
+        quantization_kwargs = {
+            "block_size": 16,
+            "scaler_block_size": 256,
+        }
+        nf4_linear = FrozenNF4Linear(
+            512, 512, device="cpu", dtype=torch.bfloat16, **quantization_kwargs
+        )
+        params = list(nf4_linear.parameters())
+        assert len(params) == 1
+        assert isinstance(params[0], NF4Tensor)
+        assert params[0].block_size == quantization_kwargs["block_size"]
+        assert params[0].scaler_block_size == quantization_kwargs["scaler_block_size"]
+
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
     def test_state_dict(self, dtype):
         nf4_linear = FrozenNF4Linear(512, 512, device="cpu", dtype=dtype)

--- a/torchtune/modules/low_precision/nf4_linear.py
+++ b/torchtune/modules/low_precision/nf4_linear.py
@@ -22,10 +22,11 @@ class FrozenNF4Linear(nn.Linear):
     Args:
         in_dim (int): input dimension
         out_dim (int): output dimension
+        bias (bool): whether to include bias in the linear layer. Default: False
         device (Optional[torch.device]): device to use for the underlying weight. If ``None``, uses the default
             device given by `torch.get_default_device()`.
-        bias (bool): whether to include bias in the linear layer. Default: False
-        **kwargs: any additional arguments to pass to the underlying Linear layer.
+        dtype (Optional[torch.dtype]): dtype to use for the underlying weight. If ``None``, uses the default
+        **quantization_kwargs:
 
     """
 
@@ -33,15 +34,16 @@ class FrozenNF4Linear(nn.Linear):
         self,
         in_dim: int,
         out_dim: int,
-        device: Optional[torch.device] = None,
         bias: bool = False,
-        **kwargs,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+        **quantization_kwargs,
     ):
-        super().__init__(in_dim, out_dim, device=device, bias=bias, **kwargs)
+        super().__init__(in_dim, out_dim, bias=bias, device=device, dtype=dtype)
         self.weight.requires_grad_(False)
         if self.bias is not None:
             self.bias.requires_grad_(False)
-        nf4_weight = to_nf4(self.weight)
+        nf4_weight = to_nf4(self.weight, **quantization_kwargs)
         # re-register self.weight as the nf4 weight, so that the nf4 weight
         # shows up as expected in .parameters, state_dict, etc.
         torch.utils.swap_tensors(

--- a/torchtune/modules/low_precision/nf4_linear.py
+++ b/torchtune/modules/low_precision/nf4_linear.py
@@ -26,8 +26,10 @@ class FrozenNF4Linear(nn.Linear):
         device (Optional[torch.device]): device to use for the underlying weight. If ``None``, uses the default
             device given by `torch.get_default_device()`.
         dtype (Optional[torch.dtype]): dtype to use for the underlying weight. If ``None``, uses the default
-        **quantization_kwargs:
-
+        **quantization_kwargs: Keyword arguments to pass to `to_nf4` when quantizing the base linear weight.
+            Examples of valid arguments are `block_size` and `scaler_block_size`, which control the granularity of
+            weight quantization and scaler quantization respectively. This is only used if `quantize_base` is True.
+            Default None
     """
 
     def __init__(

--- a/torchtune/modules/peft/dora.py
+++ b/torchtune/modules/peft/dora.py
@@ -37,6 +37,13 @@ class DoRALinear(nn.Module, AdapterModule):
             Default: False
         quantize_base (bool): Whether to quantize base linear weight or not.
             Default: False
+        **quantization_kwargs: Keyword arguments to pass to `to_nf4` when quantizing the base linear weight.
+            Examples of valid arguments are `block_size` and `scaler_block_size`, which control the granularity of
+            weight quantization and scaler quantization respectively. This is only used if `quantize_base` is True.
+            Default None
+
+    Raises:
+        ValueError: If ``quantize_base`` is False, but quantization kwargs are provided.
 
     """
 
@@ -49,6 +56,7 @@ class DoRALinear(nn.Module, AdapterModule):
         dropout: float = 0.0,
         use_bias: bool = False,
         quantize_base: bool = False,
+        **quantization_kwargs,
     ):
         super().__init__()
         self.in_dim = in_dim
@@ -56,17 +64,29 @@ class DoRALinear(nn.Module, AdapterModule):
         self.scaling = alpha / rank
         self.use_bias = use_bias
         self._quantize_base = quantize_base
-        weight, bias = self._create_weight_and_bias()
-        self.register_parameter("weight", nn.Parameter(weight))
-        self.register_parameter(
-            "bias", nn.Parameter(bias) if bias is not None else None
+
+        if not self._quantize_base and quantization_kwargs:
+            raise ValueError(
+                f"``quantize_base`` is False, but received the following quantization arguments: {quantization_kwargs}"
+            )
+
+        # Setup weight and bias
+        linear = nn.Linear(in_features=in_dim, out_features=out_dim, bias=self.use_bias)
+        weight = (
+            linear.weight
+            if not self._quantize_base
+            else to_nf4(linear.weight, **quantization_kwargs)
         )
+        bias = linear.bias if self.use_bias else None
 
         # 'self.disabled' is a flag showing whether to turn off DoRA adapters,
         # this can be used in DPO for treating the dora adapters as the policy model
         # and disabling it to treat the base model as the reference model
         self.disabled = False
-
+        self.register_parameter("weight", nn.Parameter(weight))
+        self.register_parameter(
+            "bias", nn.Parameter(bias) if bias is not None else None
+        )
         self.dropout = nn.Dropout(p=dropout) if dropout > 0.0 else nn.Identity()
         self.lora_a = nn.Linear(in_features=in_dim, out_features=rank, bias=False)
         self.lora_b = nn.Linear(in_features=rank, out_features=out_dim, bias=False)
@@ -89,19 +109,6 @@ class DoRALinear(nn.Module, AdapterModule):
         lora_weight = self.lora_b.weight @ self.lora_a.weight
         weight_norm = self._get_weight_norm(base_weight, lora_weight)
         self.magnitude.copy_(weight_norm)
-
-    def _create_weight_and_bias(self):
-        """
-        Creates a linear weight and bias tensor, using NF4 dtype if we're quantizing
-        (indicated via quantize_base=True).
-        """
-        in_dim, out_dim, use_bias = self.in_dim, self.out_dim, self.use_bias
-        linear = nn.Linear(in_features=in_dim, out_features=out_dim, bias=use_bias)
-        weight = linear.weight if not self._quantize_base else to_nf4(linear.weight)
-        bias = None
-        if self.use_bias:
-            bias = linear.bias
-        return weight, bias
 
     def _get_weight_norm(self, weight, lora_weight):
         weight = weight + self.scaling * lora_weight

--- a/torchtune/modules/peft/lora.py
+++ b/torchtune/modules/peft/lora.py
@@ -37,6 +37,8 @@ class LoRALinear(nn.Module, AdapterModule):
             Default: False
         quantize_base (bool): Whether to quantize base linear weight or not.
             Default: False
+        **quantization_kwargs: Keyword arguments to pass to `to_nf4` when quantizing the base linear weight.
+            See `to_nf4` for more details. This is only used if `quantize_base` is True. Default None
     """
 
     def __init__(

--- a/torchtune/modules/peft/lora.py
+++ b/torchtune/modules/peft/lora.py
@@ -38,7 +38,12 @@ class LoRALinear(nn.Module, AdapterModule):
         quantize_base (bool): Whether to quantize base linear weight or not.
             Default: False
         **quantization_kwargs: Keyword arguments to pass to `to_nf4` when quantizing the base linear weight.
-            See `to_nf4` for more details. This is only used if `quantize_base` is True. Default None
+            Examples of valid arguments are `block_size` and `scaler_block_size`, which control the granularity of
+            weight quantization and scaler quantization respectively. This is only used if `quantize_base` is True.
+            Default None
+
+    Raises:
+        ValueError: If ``quantize_base`` is False, but quantization kwargs are provided.
     """
 
     def __init__(
@@ -50,15 +55,30 @@ class LoRALinear(nn.Module, AdapterModule):
         dropout: float = 0.0,
         use_bias: bool = False,
         quantize_base: bool = False,
+        **quantization_kwargs,
     ):
         super().__init__()
         self.in_dim = in_dim
+        self.out_dim = out_dim
         self.rank = rank
         self.alpha = alpha
-        self.out_dim = out_dim
         self.use_bias = use_bias
         self._quantize_base = quantize_base
-        weight, bias = self._create_weight_and_bias()
+
+        if not self._quantize_base and quantization_kwargs:
+            raise ValueError(
+                f"``quantize_base`` is False, but received the following quantization arguments: {quantization_kwargs}"
+            )
+
+        # Setup weight and bias
+        linear = nn.Linear(in_features=in_dim, out_features=out_dim, bias=self.use_bias)
+        weight = (
+            linear.weight
+            if not self._quantize_base
+            else to_nf4(linear.weight, **quantization_kwargs)
+        )
+        bias = linear.bias if self.use_bias else None
+
         # 'self.disabled' is a flag showing whether to turn off LoRA adapters,
         # this can be used in DPO for treating the lora adapters as the policy model
         # and disabling it to treat the base model as the reference model
@@ -86,19 +106,6 @@ class LoRALinear(nn.Module, AdapterModule):
         # https://github.com/microsoft/LoRA/blob/4c0333854cb905966f8cc4e9a74068c1e507c7b7/loralib/layers.py#L119
         _lora_a_init_params(self.lora_a)
         _lora_b_init_params(self.lora_b)
-
-    def _create_weight_and_bias(self):
-        """
-        Creates a linear weight and bias tensor, using NF4 dtype if we're quantizing
-        (indicated via quantize_base=True).
-        """
-        in_dim, out_dim, use_bias = self.in_dim, self.out_dim, self.use_bias
-        linear = nn.Linear(in_features=in_dim, out_features=out_dim, bias=use_bias)
-        weight = linear.weight if not self._quantize_base else to_nf4(linear.weight)
-        bias = None
-        if self.use_bias:
-            bias = linear.bias
-        return weight, bias
 
     def adapter_params(self) -> List[str]:
         """


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

The original error that sparked this investigation was that I was able to run Llama3.2V QLoRA on 4 GPUs, but it failed on 8 GPUs with the following error:
```
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/recipes/lora_finetune_distributed.py", line 274, in setup
[rank0]:     self._model = self._setup_model(
[rank0]:                   ^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/recipes/lora_finetune_distributed.py", line 473, in _setup_model
[rank0]:     training.shard_model(
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torchtune/training/_distributed.py", line 643, in shard_model
[rank0]:     fully_shard(m, **fsdp_kwargs)
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/distributed/_composable/contract.py", line 125, in wrapper
[rank0]:     updated = func(inp_module, *args, **kwargs)
[rank0]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/distributed/_composable/fsdp/fully_shard.py", line 132, in fully_shard
[rank0]:     state._fsdp_param_group = FSDPParamGroup(
[rank0]:                               ^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/distributed/_composable/fsdp/_fsdp_param_group.py", line 114, in __init__
[rank0]:     self.fsdp_params = [
[rank0]:                        ^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/distributed/_composable/fsdp/_fsdp_param_group.py", line 115, in <listcomp>
[rank0]:     FSDPParam(
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/distributed/_composable/fsdp/_fsdp_param.py", line 231, in __init__
[rank0]:     self._init_sharded_param(param, device)
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/distributed/_composable/fsdp/_fsdp_param.py", line 335, in _init_sharded_param
[rank0]:     chunks = _chunk_with_empty(param_data, shard_world_size, dim=0)
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/distributed/_composable/fsdp/_fsdp_common.py", line 95, in _chunk_with_empty
[rank0]:     chunks = list(torch.chunk(tensor, num_chunks, dim=dim))
[rank0]:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torchao/dtypes/nf4tensor.py", line 850, in __torch_function__
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 632, in _fn
[rank0]:     return fn(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torchao/dtypes/nf4tensor.py", line 831, in __torch_dispatch__
[rank0]:     return NF4_OPS_TABLE[func](func, args, kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/tt-v0.4.0-rc2/lib/python3.11/site-packages/torchao/dtypes/nf4tensor.py", line 195, in nf4_split
[rank0]:     inner_tensor.numel() % num_chunks == 0
[rank0]: AssertionError: quantization_factor.numel() not divisible by 8
```

Weird, right? In digging further @pbontrager figured out that the default block_size and scaler_block_size used when converting the weights to NF4 were the wrong size when the model was sharded to 8 GPUs. After consulting with @drisspg, it seems relatively harmless to modify the scaler_block_size when quantizing these weights. Therefore, the fix here is to expose the quantization_kwargs for both FrozenNF4Linear and LoRALinear. A follow up PR will actually land the changes in the model builders to resolve the initial error.

#### Changelog
What are the changes made in this PR?
* Add ``quantization_kwargs`` to ``FrozenNF4Linear``
* Add test for quantization kwargs and FrozenNF4Linear
* Add ``quantization_kwargs`` to ``LoRALinear``
* Add tests for quantization kwargs and LoRALinear
* Add ``quantization_kwargs`` to ``DoRALinear``
* Add tests for quantization kwargs and DoRALinear
* Profit?

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x] I have added an example to docs or docstrings
