### PR TITLE
Enables Python 3.13 for nightly builds

### DIFF
--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -31,7 +31,6 @@ jobs:
     needs: generate-matrix
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-    if: ${{ needs.generate-matrix.outputs.matrix.python_version }} != '3.13'
     strategy:
       fail-fast: false
     with:

--- a/.github/workflows/build_linux_wheels.yaml
+++ b/.github/workflows/build_linux_wheels.yaml
@@ -27,46 +27,18 @@ jobs:
       with-cuda: enable
       with-rocm: enable
       build-python-only: enable
-  # TODO: Remove `filter-python-version` after PyArrow releases v18
-  filter-python-versions:
-    needs: generate-matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Filter matrix to exclude Python 3.13
-        id: set-matrix
-        shell: python
-        env:
-          input-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-        run: |
-          import os
-          import json
-
-          # Grab environment variables
-          input_matrix = json.loads(os.environ["input-matrix"])
-          github_output_file = os.environ["GITHUB_OUTPUT"]
-
-          # Filter out any builds for 3.13
-          filtered_matrix = {"include": []}
-          for build in input_matrix["include"]:
-            if build["python_version"] != "3.13":
-              filtered_matrix["include"].append(build)
-
-          # Write the new matrix to the default outputs file
-          with open(github_output_file, "w") as handle:
-            handle.write(f"matrix={json.dumps(filtered_matrix)}")
   build:
-    needs: filter-python-versions
+    needs: generate-matrix
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    if: ${{ needs.generate-matrix.outputs.matrix.python_version }} != '3.13'
     strategy:
       fail-fast: false
     with:
       repository: pytorch/torchtune
       ref: ""
       package-name: torchtune
-      build-matrix: ${{ needs.filter-python-versions.outputs.matrix }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: .github/scripts/pre_build_script.sh
       trigger-event: ${{ github.event_name }}
       build-platform: 'python-build-package'


### PR DESCRIPTION
This reverts commit 8e013c2.#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (Testing Infra)

Fixes https://github.com/pytorch/torchtune/issues/1947

#### Changelog
What are the changes made in this PR?

* Enables Python 3.13 nightly builds

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
