### PR TITLE
Fixing `special_tokens` arg in `Llama3VisionTransform`

### DIFF
--- a/torchtune/models/llama3_2_vision/_model_builders.py
+++ b/torchtune/models/llama3_2_vision/_model_builders.py
@@ -50,17 +50,12 @@ def llama3_2_vision_transform(
     Returns:
         Llama3VisionTransform: Instantiation of the Llama 3.2 vision transform
     """
-    special_tokens = (
-        parse_hf_tokenizer_json(special_tokens_path)
-        if special_tokens_path is not None
-        else None
-    )
     template = (
         _get_prompt_template(prompt_template) if prompt_template is not None else None
     )
     return Llama3VisionTransform(
         path=path,
-        special_tokens=special_tokens,
+        special_tokens_path=special_tokens_path,
         tile_size=image_size,
         patch_size=14,
         max_num_tiles=4,

--- a/torchtune/models/llama3_2_vision/_transform.py
+++ b/torchtune/models/llama3_2_vision/_transform.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple
 
 from torchtune.data import Message, PromptTemplate
 
@@ -35,9 +35,9 @@ class Llama3VisionTransform(ModelTokenizer, Transform):
             This will be used to generate possible_resolutions,
             e.g. [(224, 224), (224, 448), (448, 224)] if max_num_tiles = 2 and tile_size = 224.
             Default 4.
-        special_tokens (Optional[Dict[str, int]]): mapping containing special text tokens and
-            their registered token IDs. If left as None, this will be set to the canonical
-            Llama3 special tokens.
+        special_tokens_path (Optional[str]): Path to ``tokenizer.json`` from Hugging Face
+            model files that contains all registered special tokens, or a local json file
+            structured similarly. Default is None to use the canonical Llama3 special tokens.
         max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
             after which the input will be truncated. Default is None.
         image_mean (Optional[Tuple[float, float, float]]): Mean values of each channel, used for normalization.
@@ -68,7 +68,7 @@ class Llama3VisionTransform(ModelTokenizer, Transform):
         tile_size: int,
         patch_size: int,
         max_num_tiles: int = 4,
-        special_tokens: Optional[Dict[str, int]] = None,
+        special_tokens_path: Optional[str] = None,
         max_seq_len: Optional[int] = None,
         image_mean: Optional[Tuple[float, float, float]] = None,
         image_std: Optional[Tuple[float, float, float]] = None,
@@ -76,7 +76,7 @@ class Llama3VisionTransform(ModelTokenizer, Transform):
     ):
         self.tokenizer = llama3_tokenizer(
             path,
-            special_tokens_path=special_tokens,
+            special_tokens_path=special_tokens_path,
             max_seq_len=max_seq_len,
             prompt_template=prompt_template,
         )


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

```haskell
                 ()
                /\
               //\\
              <<  >>
          ()   \\//   ()
()._____   /\   \\   /\   _____.()
   \.--.\ //\\ //\\ //\\ /.--./
    \\__\\/__\//__\//__\\/__//
     '--/\\--//\--//\--/\\--'
        \\\\///\\//\\\////
    ()-= >>\\< <\\> >\\<< =-()
        ////\\\//\\///\\\\
     .--\\/--\//--\//--\//--.
    //""/\\""//\""//\""//\""\\
   /'--'/ \\// \\// \\// \'--'\
 ()`"""`   \/   //   \/   `""""`()
          ()   //\\   ()
              <<  >>
               \\//
                \/
                ()

```