### PR TITLE
feat(cli): allow users to download models from Kaggle

### DIFF
--- a/docs/source/tune_cli.rst
+++ b/docs/source/tune_cli.rst
@@ -39,19 +39,25 @@ to download files using the CLI.
 Download a model
 ----------------
 
-The ``tune download <path>`` command downloads any model from the Hugging Face Hub.
+The ``tune download <path>`` command downloads any model from the Hugging Face or Kaggle Model Hub.
 
 .. list-table::
    :widths: 30 60
 
    * - \--output-dir
-     - Directory in which to save the model.
+     - Directory in which to save the model. Note: this is option not yet supported when `--source` is set to `kaggle`.
    * - \--output-dir-use-symlinks
      - To be used with `output-dir`. If set to 'auto', the cache directory will be used and the file will be either duplicated or symlinked to the local directory depending on its size. It set to `True`, a symlink will be created, no matter the file size. If set to `False`, the file will either be duplicated from cache (if already exists) or downloaded from the Hub and not cached.
    * - \--hf-token
      - Hugging Face API token. Needed for gated models like Llama.
    * - \--ignore-patterns
      - If provided, files matching any of the patterns are not downloaded. Defaults to ignoring safetensors files to avoid downloading duplicate weights.
+   * - \--source {huggingface,kaggle}
+     - If provided, downloads model weights from the provided <path> on the designated source hub.
+   * - \--kaggle-username
+     - Kaggle username for authentication. Needed for private models or gated models like Llama2.
+   * - \--kaggle-api-key
+     - Kaggle API key. Needed for private models or gated models like Llama2. You can find your API key at https://kaggle.com/settings.
 
 .. code-block:: bash
 
@@ -62,6 +68,13 @@ The ``tune download <path>`` command downloads any model from the Hugging Face H
     ./model/model-00001-of-00002.bin
     ...
 
+.. code-block:: bash
+
+    $ tune download metaresearch/llama-3.2/pytorch/1b --source kaggle
+    Successfully downloaded model repo and wrote to the following locations:
+    /tmp/llama-3.2/pytorch/1b/tokenizer.model
+    /tmp/llama-3.2/pytorch/1b/params.json
+    /tmp/llama-3.2/pytorch/1b/consolidated.00.pth
 
 **Download a gated model**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "huggingface_hub",
     "safetensors",
 
+    # Kaggle Integrations
+    "kagglehub",
+
     # Tokenization
     "sentencepiece",
     "tiktoken",

--- a/tests/torchtune/_cli/test_download.py
+++ b/tests/torchtune/_cli/test_download.py
@@ -106,3 +106,178 @@ class TestTuneDownloadCommand:
             "Please ensure you have access to the repository and have provided the proper Hugging Face API token"
             not in out_err.err
         )
+
+    # only valid --source parameters supported (expect prompt for supported values)
+    def test_source_parameter(self, capsys, monkeypatch):
+        model = "metaresearch/llama-3.2/pytorch/1b"
+        testargs = f"tune download {model} --source invalid".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        with pytest.raises(SystemExit, match="2"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        output = capsys.readouterr()
+        assert "argument --source: invalid choice: 'invalid'" in output.err
+
+    def test_download_from_kaggle(self, capsys, monkeypatch, mocker, tmpdir):
+        model = "metaresearch/llama-3.2/pytorch/1b"
+        testargs = f"tune download {model} --source kaggle --kaggle-username kaggle_user --kaggle-api-key kaggle_api_key".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+        # mock out kagglehub.model_download to get around key storage
+        mocker.patch("torchtune._cli.download.model_download", return_value=tmpdir)
+
+        runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        output = capsys.readouterr().out
+        assert "Successfully downloaded model repo" in output
+
+    def test_download_from_kaggle_warn_when_output_dir_provided(
+        self, capsys, monkeypatch, mocker, tmpdir
+    ):
+        model = "metaresearch/llama-3.2/pytorch/1b"
+        testargs = f"tune download {model} --source kaggle --output-dir /requested/model/path".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+        # mock out kagglehub.model_download to get around key storage
+        mocker.patch("torchtune._cli.download.model_download", return_value=tmpdir)
+
+        with pytest.warns(
+            UserWarning,
+            match="--output-dir flag is not supported for Kaggle model downloads",
+        ):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        output = capsys.readouterr().out
+        assert "Successfully downloaded model repo" in output
+
+    # passes partial credentials with just --kaggle-api-key (expect prompt for all necessary credentials)
+    def test_download_from_kaggle_partial_credentials_provided(
+        self, capsys, monkeypatch
+    ):
+        model = "metaresearch/llama-3.2/pytorch/1b"
+        testargs = (
+            f"tune download {model} --source kaggle --kaggle-api-key apikey".split()
+        )
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        with pytest.raises(SystemExit, match="2"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        out_err = capsys.readouterr()
+        assert "Missing --kaggle-username." in out_err.err
+        assert "Please provide both your Kaggle username and API key." in out_err.err
+
+        testargs = (
+            f"tune download {model} --source kaggle --kaggle-username username".split()
+        )
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        with pytest.raises(SystemExit, match="2"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        out_err = capsys.readouterr()
+        assert "Missing --kaggle-api-key." in out_err.err
+        assert "Please provide both your Kaggle username and API key." in out_err.err
+        assert "Find your API key at https://kaggle.com/settings." in out_err.err
+
+    # KaggleApiHTTPError::Unauthorized without --kaggle-username and --kaggle-api-key (expect prompt for credentials)
+    def test_download_from_kaggle_unauthorized_credentials(
+        self, capsys, monkeypatch, mocker
+    ):
+        from http import HTTPStatus
+
+        from kagglehub.exceptions import KaggleApiHTTPError
+
+        model = "metaresearch/llama-3.2/pytorch/1b"
+        testargs = f"tune download {model} --source kaggle --kaggle-username username --kaggle-api-key key".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        mock_model_download = mocker.patch("torchtune._cli.download.model_download")
+        mock_model_download.side_effect = KaggleApiHTTPError(
+            "Unauthorized",
+            response=mocker.MagicMock(status_code=HTTPStatus.UNAUTHORIZED),
+        )
+
+        with pytest.raises(SystemExit, match="2"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        out_err = capsys.readouterr()
+        assert (
+            "Please ensure you have access to the model and have provided the proper Kaggle credentials"
+            in out_err.err
+        )
+        assert "You can also set these to environment variables" in out_err.err
+
+    # KaggleApiHTTPError::NotFound
+    def test_download_from_kaggle_model_not_found(self, capsys, monkeypatch, mocker):
+        from http import HTTPStatus
+
+        from kagglehub.exceptions import KaggleApiHTTPError
+
+        model = "mockorganizations/mockmodel/pytorch/mockvariation"
+        testargs = f"tune download {model} --source kaggle --kaggle-username kaggle_user --kaggle-api-key kaggle_api_key".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        mock_model_download = mocker.patch("torchtune._cli.download.model_download")
+        mock_model_download.side_effect = KaggleApiHTTPError(
+            "NotFound", response=mocker.MagicMock(status_code=HTTPStatus.NOT_FOUND)
+        )
+
+        with pytest.raises(SystemExit, match="2"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        out_err = capsys.readouterr()
+        assert f"'{model}' not found on the Kaggle Model Hub." in out_err.err
+
+    # KaggleApiHTTPError::InternalServerError
+    def test_download_from_kaggle_api_error(self, capsys, monkeypatch, mocker):
+        from http import HTTPStatus
+
+        from kagglehub.exceptions import KaggleApiHTTPError
+
+        model = "metaresearch/llama-3.2/pytorch/1b"
+        testargs = f"tune download {model} --source kaggle --kaggle-username kaggle_user --kaggle-api-key kaggle_api_key".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        mock_model_download = mocker.patch("torchtune._cli.download.model_download")
+        mock_model_download.side_effect = KaggleApiHTTPError(
+            "InternalError",
+            response=mocker.MagicMock(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+        )
+
+        with pytest.raises(SystemExit, match="2"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        out_err = capsys.readouterr()
+        assert "Failed to download" in out_err.err
+
+    def test_download_from_kaggle_warn_on_nonmeta_pytorch_models(
+        self, monkeypatch, mocker, tmpdir
+    ):
+        model = "kaggle/kaggle-model-name/pytorch/1b"
+        testargs = f"tune download {model} --source kaggle".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        # stub out model_download to guarantee success
+        mocker.patch(
+            "torchtune._cli.download.model_download",
+            return_value=tmpdir,
+        )
+
+        with pytest.warns(UserWarning, match="may not be compatible with torchtune"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+    def test_download_from_kaggle_warn_on_nonpytorch_nontransformers_model(
+        self, monkeypatch, mocker, tmpdir
+    ):
+        model = "metaresearch/some-model/some-madeup-framework/1b"
+        testargs = f"tune download {model} --source kaggle".split()
+        monkeypatch.setattr(sys, "argv", testargs)
+
+        # stub out model_download to guarantee success
+        mocker.patch(
+            "torchtune._cli.download.model_download",
+            return_value=tmpdir,
+        )
+
+        with pytest.warns(UserWarning, match="may not be compatible with torchtune"):
+            runpy.run_path(TUNE_PATH, run_name="__main__")

--- a/tests/torchtune/_cli/test_download.py
+++ b/tests/torchtune/_cli/test_download.py
@@ -151,6 +151,24 @@ class TestTuneDownloadCommand:
         output = capsys.readouterr().out
         assert "Successfully downloaded model repo" in output
 
+    def test_download_from_kaggle_warn_when_ignore_patterns_provided(
+        self, capsys, monkeypatch, mocker, tmpdir
+    ):
+        model = "metaresearch/llama-3.2/pytorch/1b"
+        testargs = f'tune download {model} --source kaggle --ignore-patterns "*.glob-pattern"'.split()
+        monkeypatch.setattr(sys, "argv", testargs)
+        # mock out kagglehub.model_download to get around key storage
+        mocker.patch("torchtune._cli.download.model_download", return_value=tmpdir)
+
+        with pytest.warns(
+            UserWarning,
+            match="--ignore-patterns flag is not supported for Kaggle model downloads",
+        ):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        output = capsys.readouterr().out
+        assert "Successfully downloaded model repo" in output
+
     # tests when --kaggle-username and --kaggle-api-key are provided as CLI args
     def test_download_from_kaggle_when_credentials_provided(
         self, capsys, monkeypatch, mocker

--- a/torchtune/_cli/download.py
+++ b/torchtune/_cli/download.py
@@ -212,9 +212,14 @@ class Download(Subcommand):
         self._set_kaggle_credentials(args)
 
         # kagglehub doesn't currently support `local_dir` and `ignore_patterns` like huggingface_hub
-        if args.output_dir is not None:
+        if args.output_dir:
             warn(
                 "--output-dir flag is not supported for Kaggle model downloads. "
+                "This argument will be ignored."
+            )
+        if args.ignore_patterns:
+            warn(
+                "--ignore-patterns flag is not supported for Kaggle model downloads. "
                 "This argument will be ignored."
             )
 

--- a/torchtune/_cli/download.py
+++ b/torchtune/_cli/download.py
@@ -62,7 +62,8 @@ class Download(Subcommand):
                 /tmp/llama-3.2/pytorch/1b/consolidated.00.pth
                 ...
 
-            For a list of all models, visit the Hugging Face Hub https://huggingface.co/models or Kaggle Model Hub https://kaggle.com/models.
+            For a list of all models, visit the Hugging Face Hub
+            https://huggingface.co/models or Kaggle Model Hub https://kaggle.com/models.
             """
             ),
             formatter_class=argparse.RawTextHelpFormatter,
@@ -129,7 +130,8 @@ class Download(Subcommand):
             "--kaggle-api-key",
             type=str,
             required=False,
-            help="Kaggle API key. Needed for private models or gated models like Llama2. You can find your API key at https://kaggle.com/settings.",
+            help="Kaggle API key. Needed for private models or gated models like Llama2. You can find your "
+            "API key at https://kaggle.com/settings.",
         )
 
     def _download_cmd(self, args: argparse.Namespace) -> None:
@@ -264,11 +266,13 @@ class Download(Subcommand):
                 and parsed_handle.owner != "metaresearch"
             ):
                 warn(
-                    f"Requested PyTorch model {handle} was not published from Meta, and therefore may not be compatible with torchtune."
+                    f"Requested PyTorch model {handle} was not published from Meta, and therefore "
+                    "may not be compatible with torchtune."
                 )
             if parsed_handle.framework not in {"pytorch", "transformers"}:
                 warn(
-                    f"Requested model {handle} is neither a PyTorch nor a Transformers model, and therefore may not be compatible with torchtune."
+                    f"Requested model {handle} is neither a PyTorch nor a Transformers model, and "
+                    "therefore may not be compatible with torchtune."
                 )
         except Exception as e:
             msg = f"Failed to validate {handle} with error {e}."

--- a/torchtune/_cli/download.py
+++ b/torchtune/_cli/download.py
@@ -7,12 +7,20 @@
 import argparse
 import os
 import textwrap
+import traceback
 
+from http import HTTPStatus
 from pathlib import Path
 from typing import Literal, Union
+from warnings import warn
 
 from huggingface_hub import snapshot_download
 from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+
+from kagglehub import model_download
+from kagglehub.auth import set_kaggle_credentials
+from kagglehub.exceptions import KaggleApiHTTPError
+from kagglehub.handle import parse_model_handle
 from torchtune._cli.subcommand import Subcommand
 
 
@@ -25,8 +33,8 @@ class Download(Subcommand):
             "download",
             prog="tune download",
             usage="tune download <repo-id> [OPTIONS]",
-            help="Download a model from the Hugging Face Hub.",
-            description="Download a model from the Hugging Face Hub.",
+            help="Download a model from the Hugging Face Hub or Kaggle Model Hub.",
+            description="Download a model from the Hugging Face Hub or Kaggle Model Hub.",
             epilog=textwrap.dedent(
                 """\
             examples:
@@ -46,7 +54,15 @@ class Download(Subcommand):
                 /tmp/model/model-00001-of-00002.bin
                 ...
 
-            For a list of all models, visit the Hugging Face Hub https://huggingface.co/models.
+                # Download a model from the Kaggle Model Hub
+                $ tune download metaresearch/llama-3.2/pytorch/1b --source kaggle
+                Successfully downloaded model repo and wrote to the following locations:
+                /tmp/llama-3.2/pytorch/1b/tokenizer.model
+                /tmp/llama-3.2/pytorch/1b/params.json
+                /tmp/llama-3.2/pytorch/1b/consolidated.00.pth
+                ...
+
+            For a list of all models, visit the Hugging Face Hub https://huggingface.co/models or Kaggle Model Hub https://kaggle.com/models.
             """
             ),
             formatter_class=argparse.RawTextHelpFormatter,
@@ -59,7 +75,7 @@ class Download(Subcommand):
         self._parser.add_argument(
             "repo_id",
             type=str,
-            help="Name of the repository on Hugging Face Hub.",
+            help="Name of the repository on Hugging Face Hub or model handle on Kaggle Model Hub.",
         )
         self._parser.add_argument(
             "--output-dir",
@@ -93,10 +109,37 @@ class Download(Subcommand):
             required=False,
             default="*.safetensors",
             help="If provided, files matching any of the patterns are not downloaded. Defaults to ignoring "
-            "safetensors files to avoid downloading duplicate weights.",
+            "safetensors files to avoid downloading duplicate weights. Only supported for Hugging Face Hub models.",
+        )
+        self._parser.add_argument(
+            "--source",
+            type=str,
+            required=False,
+            default="huggingface",
+            choices=["huggingface", "kaggle"],
+            help="If provided, downloads model weights from the provided repo_id on the designated source hub.",
+        )
+        self._parser.add_argument(
+            "--kaggle-username",
+            type=str,
+            required=False,
+            help="Kaggle username for authentication. Needed for private models or gated models like Llama2.",
+        )
+        self._parser.add_argument(
+            "--kaggle-api-key",
+            type=str,
+            required=False,
+            help="Kaggle API key. Needed for private models or gated models like Llama2. You can find your API key at https://kaggle.com/settings.",
         )
 
     def _download_cmd(self, args: argparse.Namespace) -> None:
+        # Note: we're relying on argparse to validate if the provided args.source is supported
+        if args.source == "huggingface":
+            return self._download_from_huggingface(args)
+        if args.source == "kaggle":
+            return self._download_from_kaggle(args)
+
+    def _download_from_huggingface(self, args: argparse.Namespace) -> None:
         """Downloads a model from the Hugging Face Hub."""
         # Download the tokenizer and PyTorch model files
 
@@ -148,8 +191,6 @@ class Download(Subcommand):
                 f"Repository '{args.repo_id}' not found on the Hugging Face Hub."
             )
         except Exception as e:
-            import traceback
-
             tb = traceback.format_exc()
             msg = f"Failed to download {args.repo_id} with error: '{e}' and traceback: {tb}"
             self._parser.error(msg)
@@ -159,3 +200,76 @@ class Download(Subcommand):
             *list(Path(true_output_dir).iterdir()),
             sep="\n",
         )
+
+    def _download_from_kaggle(self, args: argparse.Namespace) -> None:
+        """Downloads a model from the Kaggle Model Hub."""
+
+        # Note: Kaggle doesn't actually use the "repository" terminology, but we still reuse args.repo_id here for simplicity
+        model_handle = args.repo_id
+        self._validate_kaggle_model_handle(model_handle)
+
+        # kagglehub doesn't currently support `local_dir` and `ignore_patterns` like huggingface_hub
+        if args.output_dir is not None:
+            warn("--output-dir flag is not supported for Kaggle model downloads.")
+
+        if args.kaggle_username is not None and args.kaggle_api_key is not None:
+            set_kaggle_credentials(args.kaggle_username, args.kaggle_api_key)
+        elif args.kaggle_username is not None and args.kaggle_api_key is None:
+            self._parser.error(
+                "Missing --kaggle-api-key. Please provide both your Kaggle username "
+                "and API key. Find your API key at https://kaggle.com/settings."
+            )
+        elif args.kaggle_username is None and args.kaggle_api_key is not None:
+            self._parser.error(
+                "Missing --kaggle-username. Please provide both your Kaggle username "
+                "and API key."
+            )
+
+        try:
+            output_dir = model_download(model_handle)
+            print(
+                "Successfully downloaded model repo and wrote to the following locations:",
+                *list(Path(output_dir).iterdir()),
+                sep="\n",
+            )
+        except KaggleApiHTTPError as e:
+            if e.response.status_code in {
+                HTTPStatus.UNAUTHORIZED,
+                HTTPStatus.FORBIDDEN,
+            }:
+                self._parser.error(
+                    "It looks like you are trying to access a gated model. Please ensure you "
+                    "have access to the model and have provided the proper Kaggle credentials "
+                    "using the options `--kaggle-username` and `--kaggle-api-key`. You can also "
+                    "set these to environment variables as detailed in "
+                    "https://github.com/Kaggle/kagglehub/blob/main/README.md#authenticate."
+                )
+            elif e.response.status_code == HTTPStatus.NOT_FOUND:
+                self._parser.error(
+                    f"'{model_handle}' not found on the Kaggle Model Hub."
+                )
+            tb = traceback.format_exc()
+            msg = f"Failed to download {model_handle} with error: '{e}' and traceback: {tb}"
+            self._parser.error(msg)
+        except Exception as e:
+            tb = traceback.format_exc()
+            msg = f"Failed to download {model_handle} with error: '{e}' and traceback: {tb}"
+            self._parser.error(msg)
+
+    def _validate_kaggle_model_handle(self, handle: str) -> None:
+        try:
+            parsed_handle = parse_model_handle(handle)
+            if (
+                parsed_handle.framework == "pytorch"
+                and parsed_handle.owner != "metaresearch"
+            ):
+                warn(
+                    f"Requested PyTorch model {handle} was not published from Meta, and therefore may not be compatible with torchtune."
+                )
+            if parsed_handle.framework not in {"pytorch", "transformers"}:
+                warn(
+                    f"Requested model {handle} is neither a PyTorch nor a Transformers model, and therefore may not be compatible with torchtune."
+                )
+        except Exception as e:
+            msg = f"Failed to validate {handle} with error {e}."
+            self._parser.error(msg)

--- a/torchtune/_cli/download.py
+++ b/torchtune/_cli/download.py
@@ -212,9 +212,13 @@ class Download(Subcommand):
 
         # kagglehub doesn't currently support `local_dir` and `ignore_patterns` like huggingface_hub
         if args.output_dir is not None:
-            warn("--output-dir flag is not supported for Kaggle model downloads.")
+            warn(
+                "--output-dir flag is not supported for Kaggle model downloads. "
+                "This argument will be ignored."
+            )
 
         if args.kaggle_username is not None and args.kaggle_api_key is not None:
+
             set_kaggle_credentials(args.kaggle_username, args.kaggle_api_key)
         elif args.kaggle_username is not None and args.kaggle_api_key is None:
             self._parser.error(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

https://github.com/pytorch/torchtune/issues/1852

#### Changelog
What are the changes made in this PR?
* 5527fd88a193811fd2c471222be582a0b508e203
  * Added 3 new command line arguments: `--source`, `--kaggle-username`, and `--kaggle-api-key`
  * Splits download logic based on `--source` value (only valid options are `huggingface` and `kaggle`). When `--source` is _not_ provided, defaults to `huggingface`
  * Kaggle download logic placed in helper function `_download_from_kaggle()`
  * The new logic _mostly_ mirrors `_download_from_huggingface()` with a few notable exceptions:
    * Authentication with `kagglehub` requires the caller's username and api token as separate arguments to `kagglehub.set_kaggle_credentials()` (these can also be set as environment variables). Since both are required, appropriate error messages are raised when one is omitted. However, since Kaggle supports anonymous downloads on public non-gated models, the option to omit both is also supported.
    * The exceptions thrown by `kagglehub.model_download` are different than those raised by `huggingface_hub.snapshot_download`. 
    * `kagglehub.model_download` doesn't support direct download to a caller-specified directory via `--output-dir`. This feature is being worked on in `kagglehub` (see https://github.com/Kaggle/kagglehub/issues/179), but in the meantime a warning was just placed here instead.
    * some extra validation is done on Kaggle model handles (see `_validate_kaggle_model_handle`) as per the requests made [here](https://github.com/pytorch/torchtune/issues/1852#issuecomment-2443966531). This validation is primarily used to raise warnings when downloads may not be guaranteed to work with torchtune.
* a3776d6a7c0d46b1efe5f723e832feb8681a2f57
    * tests were added to validate the CLI behavior when `--source kaggle` is provided
* b30f741f79c8901ffffd6a02d53e81051a4ae32f
    * updated documentation

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] ~~run recipe tests via `pytest tests -m integration_test`~~
  - [x] screenshot as per the instructions in [this comment](https://github.com/pytorch/torchtune/issues/1852#issuecomment-2454478446): ![8zC8bxfkWnas3ex](https://github.com/user-attachments/assets/13405b04-82bf-4bef-8a4b-91fb0d3dcb16)
- [ ] ~~manually run any new or modified recipes with sufficient proof of correctness~~
- [ ] ~~include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)~~

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x] I have added an example to docs or docstrings
