### PR TITLE
Create _export directory in torchtune

### DIFF
--- a/torchtune/modules/_export/README.md
+++ b/torchtune/modules/_export/README.md
@@ -1,0 +1,3 @@
+# Export
+
+This directory provides [exportable](https://pytorch.org/docs/stable/export.html) variants of torchtune modules.


### PR DESCRIPTION
Summary: Creates a placeholder directory for adding exportable torchtune components

PyTorch Edge and [ExecuTorch](https://github.com/pytorch/executorch) have been working with torchtune folk to create exportable variants of torchtune [modules](https://github.com/pytorch/torchtune/tree/main/torchtune/modules) these past few months. The variants will be used to demonstrate new inference modes via torchtune components in the near future

This new directory will serve to host these components and will be leveraged in other repos, such as ExecuTorch and [torchchat](https://github.com/pytorch/torchchat). These components are NOT meant for use during fine-tuning

Note that this PR only creates the `_export` directory to allow parallel contributions with minimal merge conflict.

Reviewed By: larryliu0820

Differential Revision: D65982921


