### PR TITLE
torchrun defaults for concurrent distributed training jobs

### DIFF
--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -89,9 +89,10 @@ For a list of all possible recipes, run `tune ls`."""
         args.training_script = args.recipe
         args.training_script_args = args.recipe_args
 
-        # We default to letting torchrun choose a random free port
-        args.rdzv_backend = "c10d"
-        args.rdzv_endpoint = "localhost:0"
+        # If the user does not explicitly pass a rendezvous endpoint, run in standalone mode.
+        # This allows running multiple distributed training jobs simultaneously.
+        if not args.rdzv_endpoint:
+            args.standalone = True
 
         # torchtune built-in recipes are specified with an absolute posix path, but
         # custom recipes are specified as a relative module dot path and need to be

--- a/torchtune/_cli/run.py
+++ b/torchtune/_cli/run.py
@@ -88,6 +88,11 @@ For a list of all possible recipes, run `tune ls`."""
         # Have to reset the argv so that the recipe can be run with the correct arguments
         args.training_script = args.recipe
         args.training_script_args = args.recipe_args
+
+        # We default to letting torchrun choose a random free port
+        args.rdzv_backend = "c10d"
+        args.rdzv_endpoint = "localhost:0"
+
         # torchtune built-in recipes are specified with an absolute posix path, but
         # custom recipes are specified as a relative module dot path and need to be
         # run with python -m


### PR DESCRIPTION
Previously it was not possible to launch more than one distributed training job on the same node at the same time, as torchrun will try to use the same port for both of them by default. It's possible to manually pass `--rdzv-backend` and `--rdzv-endpoint` flags to torchrun anytime you kick off a second run, but this is annoying (and not obvious). Instead we can just default to letting torchrun find a free port automatically. 

## Test plan:

Run both the following commands on the same node.

```
CUDA_VISIBLE_DEVICES=0,1 tune run --nproc_per_node 2 lora_finetune_distributed --config llama3_2/1B_lora
CUDA_VISIBLE_DEVICES=2,3 tune run --nproc_per_node 2 lora_finetune_distributed --config llama3_2/1B_lora
```

Before this PR, the second job will fail with an error message like:

```
  File "/home/ebs/.conda/envs/tt-alt-10-24/lib/python3.11/site-packages/torch/distributed/elastic/agent/server/api.py", line 683, in _initialize_workers
    self._rendezvous(worker_group)
  File "/home/ebs/.conda/envs/tt-alt-10-24/lib/python3.11/site-packages/torch/distributed/elastic/metrics/api.py", line 137, in wrapper
    result = f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
  File "/home/ebs/.conda/envs/tt-alt-10-24/lib/python3.11/site-packages/torch/distributed/elastic/agent/server/api.py", line 500, in _rendezvous
    rdzv_info = spec.rdzv_handler.next_rendezvous()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ebs/.conda/envs/tt-alt-10-24/lib/python3.11/site-packages/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py", line 67, in next_rendezvous
    self._store = TCPStore(  # type: ignore[call-arg]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: The server socket has failed to listen on any local network address. port: 29500, useIpv6: 0, code: -98, name: EADDRINUSE, message: address already in use
```

After this PR, both jobs are able to train successfully:

```
1|79|Loss: 1.0284696817398071:  10%|█████████▉                                                                                            | 79/808 [01:44<15:26,  1.27s/it]
1|63|Loss: 1.0152941942214966:   8%|███████▋                                                                                           | 63/808 [01:24<16:20,  1.32s/it]

```