### PR TITLE
Add LR Scheduler to full finetune distributed

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -258,7 +258,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
     def setup(self, cfg: DictConfig) -> None:
         """
         Setup the recipe. This includes training state (if resume_from_checkpoint is True),
-        model, tokenizer, loss, optimizer, sampler, and dataloader.
+        model, tokenizer, loss, optimizer, lr scheduler, sampler, and dataloader.
         """
         if self._is_rank_zero:
             self._metric_logger = config.instantiate(cfg.metric_logger)
@@ -332,6 +332,13 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             self._steps_per_epoch = self.max_steps_per_epoch
         self.global_step = self.epochs_run * self._steps_per_epoch
 
+        # Setup lr scheduler
+        self._lr_scheduler = self._setup_lr_scheduler(
+            cfg_lr_scheduler=cfg.get("lr_scheduler", None),
+            num_training_steps=self.total_epochs * self._steps_per_epoch,
+            last_epoch=self.global_step - 1,
+        )
+
         # Set up profiler, returns DummyProfiler (nullcontext object with no-op `step` method)
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
@@ -340,6 +347,55 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         self.ignore_labels_cache = torch.full(
             (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
         )
+
+    def _setup_lr_scheduler(
+        self,
+        cfg_lr_scheduler: Optional[DictConfig],
+        num_training_steps: int,
+        last_epoch: int,
+    ) -> Optional[Optimizer]:
+        """
+        Set up the learning rate scheduler based on the provided configuration.
+        It supports both standard optimization and optimizer-in-backward cases.
+
+        Args:
+            cfg_lr_scheduler (Optional[DictConfig]): The learning rate scheduler configuration.
+            num_training_steps (int): The total number of training steps.
+            last_epoch (int): The index of the last epoch.
+
+        Returns:
+            lr_scheduler (Optional[Optimizer]): The learning rate scheduler.
+        """
+        if cfg_lr_scheduler is None:
+            if self._is_rank_zero:
+                log.info(
+                    "No learning rate scheduler configured. Using constant learning rate."
+                )
+            return None
+
+        if self._optimizer_in_bwd:
+            # Use the first optimizer from the wrapper to represent the learning rate
+            optimizer = next(iter(self._optim_ckpt_wrapper.optim_map.values()))
+        else:
+            # Standard case: use the single optimizer
+            optimizer = self._optimizer
+
+        # Instantiate the learning rate scheduler
+        lr_scheduler = config.instantiate(
+            cfg_lr_scheduler,
+            optimizer,
+            num_training_steps=num_training_steps,
+            last_epoch=last_epoch,
+        )
+
+        if self._optimizer_in_bwd:
+            # Modify the scheduler for optimizer_in_bwd case
+            self._optim_ckpt_wrapper.set_lr_scheduler(lr_scheduler)
+
+        if self._is_rank_zero:
+            log.info("Learning rate scheduler is initialized.")
+
+        return lr_scheduler
 
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
@@ -817,6 +873,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
                     # Update the number of steps when the weights are updated
                     self.global_step += 1
+
+                    # Step the learning rate scheduler
+                    if self._lr_scheduler is not None:
+                        self._lr_scheduler.step()
 
                     loss_to_log = running_loss.item() / num_tokens
                     pbar.update(1)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature

Please link to any issues this PR addresses: #1308 

**Purpose of this PR:**

This PR adds support for an **optional learning rate scheduler** to the `FullFinetuneRecipeDistributed` class, allowing users to configure and use a learning rate scheduler during training.

You can enable it by adding the following to your config file:

```yaml
lr_scheduler:
  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
  num_warmup_steps: 50
```

#### Changelog
What are the changes made in this PR?

- **Implemented Optional Learning Rate Scheduler:**
  - Added a `_setup_lr_scheduler` method to initialize the scheduler based on the configuration.
  - Modified the `setup` method to call `_setup_lr_scheduler` after computing `self._steps_per_epoch` and `self.global_step`.
  - Updated the training loop in the `train` method to step the scheduler after each optimizer step.

#### Test plan

Tested on **4 GPUs** with various configurations: https://wandb.ai/psarthi/torchtune_lr_scheduler_tests:

1. No Learning Rate Scheduler, No Optimizer-in-Backward: https://wandb.ai/psarthi/torchtune_lr_scheduler_tests/runs/e1ddni13
2. No Learning Rate Scheduler, With Optimizer-in-Backward:
https://wandb.ai/psarthi/torchtune_lr_scheduler_tests/runs/km2jw6rs
3. Cosine Learning Rate Scheduler with 50 Warmup Steps, With Optimizer-in-Backward:
https://wandb.ai/psarthi/torchtune_lr_scheduler_tests/runs/lfacg1b8
4. Cosine Learning Rate Scheduler with 50 Warmup Steps, Without Optimizer-in-Backward:
https://wandb.ai/psarthi/torchtune_lr_scheduler_tests/runs/ymktfbam
5. Resuming Training with Learning Rate Scheduler, Without Optimizer-in-Backward:
https://wandb.ai/psarthi/torchtune_lr_scheduler_tests/runs/ckia4yzi
