### PR TITLE
Some KD recipe cleanup

### DIFF
--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -514,10 +514,12 @@ class KDRecipeDistributed(FTRecipeInterface):
 
         if self._is_rank_zero:
             log.info(
-                f"Instantiating model and loading checkpoint took {time.perf_counter() - init_start:.2f} secs"
+                f"Instantiating student model and loading checkpoint took {time.perf_counter() - init_start:.2f} secs"
             )
             memory_stats = training.get_memory_stats(device=self._device)
-            training.log_memory_stats(memory_stats)
+            training.log_memory_stats(
+                memory_stats, message="Memory stats after student model init:"
+            )
 
         # synchronize before training begins
         torch.distributed.barrier()
@@ -599,7 +601,9 @@ class KDRecipeDistributed(FTRecipeInterface):
                 f"Instantiating teacher model and loading checkpoint took {time.perf_counter() - init_start:.2f} secs"
             )
             memory_stats = training.get_memory_stats(device=self._device)
-            training.log_memory_stats(memory_stats)
+            training.log_memory_stats(
+                memory_stats, message="Memory stats after teacher model init:"
+            )
 
         # synchronize before training begins
         torch.distributed.barrier()

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -444,7 +444,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             self.adapter_params.items(), dtype=self._dtype
         )
 
-        log.info(f"Model is initialized with precision {self._dtype}.")
+        log.info(f"Student model is initialized with precision {self._dtype}.")
 
         if self._device.type == "cuda":
             log.info("Memory stats initializing student model:")

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -19,7 +19,7 @@ from torch import nn
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader, DistributedSampler
 from torchtune import config, modules, training, utils
-from torchtune.data import padded_collate_sft
+from torchtune.data import padded_collate_packed, padded_collate_sft
 from torchtune.datasets import ConcatDataset
 from torchtune.modules.peft import (
     get_adapter_params,
@@ -447,8 +447,11 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         log.info(f"Model is initialized with precision {self._dtype}.")
 
         if self._device.type == "cuda":
+            log.info("Memory stats initializing student model:")
             memory_stats = training.get_memory_stats(device=self._device)
-            training.log_memory_stats(memory_stats)
+            training.log_memory_stats(
+                memory_stats, message="Memory stats after student model init:"
+            )
         return model
 
     def _setup_teacher_model(
@@ -471,6 +474,13 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             model.named_parameters(), dtype=self._dtype
         )
         log.info(f"Teacher model is initialized with precision {self._dtype}.")
+
+        if self._device.type == "cuda":
+            memory_stats = training.get_memory_stats(device=self._device)
+            training.log_memory_stats(
+                memory_stats, message="Memory stats after teacher model init:"
+            )
+
         return model
 
     def _setup_optimizer(
@@ -541,7 +551,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
                     ignore_idx=self._loss_fn.ignore_index,
                 )
                 if not packed
-                else None
+                else padded_collate_packed
             ),
         )
 

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -15,7 +15,10 @@ from torchtune.modules import (
     TransformerDecoder,
     TransformerSelfAttentionLayer,
 )
-from torchtune.modules.loss import CEWithChunkedOutputLoss
+from torchtune.modules.loss import (
+    CEWithChunkedOutputLoss,
+    ForwardKLWithChunkedOutputLoss,
+)
 from torchtune.modules.model_fusion import DeepFusionModel
 from torchtune.utils import get_logger, torch_version_ge
 
@@ -81,6 +84,8 @@ def compile_loss(loss: nn.Module, verbose: bool = True) -> nn.Module:
         loss.compute_cross_entropy = torch.compile(
             loss.compute_cross_entropy, backend=backend
         )
+    elif isinstance(loss, ForwardKLWithChunkedOutputLoss):
+        loss.fkl_loss = torch.compile(loss.fkl_loss, backend=backend)
     else:
         loss = torch.compile(loss, backend=backend)
     return loss

--- a/torchtune/training/memory.py
+++ b/torchtune/training/memory.py
@@ -280,7 +280,12 @@ def get_memory_stats(device: torch.device, reset_stats: bool = True) -> dict:
     return memory_stats
 
 
-def log_memory_stats(stats: Dict[str, float]) -> None:
+DEFAULT_LOG_MESSAGE = "Memory stats after model init:"
+
+
+def log_memory_stats(
+    stats: Dict[str, float], message: str = DEFAULT_LOG_MESSAGE
+) -> None:
     """
     Logs a dict containing memory stats to the logger. ``stats`` should contain the fields
     ``peak_memory_active``, ``peak_memory_alloc``, and ``peak_memory_reserved`` as
@@ -289,10 +294,12 @@ def log_memory_stats(stats: Dict[str, float]) -> None:
     Args:
         stats (Dict[str, float]): A dictionary containing the peak memory active, peak memory
             allocated, and peak memory reserved stats.
+        message (str): An optional message to prepend to the log output.
+            Defaults to "Memory stats after model init:"
     """
     device_support = get_device_support()
     _log.info(
-        "Memory stats after model init:"
+        f"{message}"
         f"\n\t{device_support.device_name} peak memory allocation: {stats['peak_memory_alloc']:.2f} GiB"
         f"\n\t{device_support.device_name} peak memory reserved: {stats['peak_memory_reserved']:.2f} GiB"
         f"\n\t{device_support.device_name} peak memory active: {stats['peak_memory_active']:.2f} GiB"


### PR DESCRIPTION
A few small thing in our KD recipe, mostly pointed out by @joecummings. 

- Packed was not enabled for the single-device recipe. This is an easy fix: we just need to add the packed collate function
- We weren't compiling the chunked loss correctly. Similar to chunked cross-entropy, we shouldn't compile the chunking operation. Luckily the chunked version of the loss already has `self.fkl_loss` pointing to vanilla ForwardKLLoss, so we can just compile that.
- Our memory stats logging on model init is not super clear for KD where there are two separate models. Addressed this by adding an optional message to `log_memory_stats` and explicitly logging peak memory after student and teacher model init separately.

## Test plan:

### Compile
On main (baseline) vs this branch: 
```
tune run knowledge_distillation_single_device --config llama3_2/knowledge_distillation_single_device \
max_steps_per_epoch=50 compile=True metric_logger=torchtune.training.metric_logging.WandBLogger \
metric_logger.project=test-kd metric_logger.name=kd-single-device-compile-{baseline}
```

Results show increased tokens/sec and lower peak memory.

<img width="1366" alt="Screenshot 2024-11-18 at 6 44 11 AM" src="https://github.com/user-attachments/assets/1314e6ca-4aa5-4ae3-b293-d0e7bc78ec2a">

### Packed

Previously the following command didn't work in our single-device recipe.

```
tune run knowledge_distillation_single_device --config llama3_2/knowledge_distillation_single_device dataset.packed=True dataset.split=train[:5%] tokenizer.max_seq_len=2048 metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=test-kd metric_logger.name=kd-single-device-packed
```

<img width="1363" alt="Screenshot 2024-11-18 at 6 45 19 AM" src="https://github.com/user-attachments/assets/94db70e3-b49c-4d33-a5bf-40f23570e776">

### Logging:
Running any of the above single-device commands gives the following in the logs:
```
Memory stats after student model init:
        GPU peak memory allocation: 2.41 GiB
        GPU peak memory reserved: 2.42 GiB
        GPU peak memory active: 2.41 GiB
Teacher model is initialized with precision torch.bfloat16.
Memory stats after teacher model init:
        GPU peak memory allocation: 17.43 GiB
        GPU peak memory reserved: 17.56 GiB
        GPU peak memory active: 17.43 GiB
```