### PR TITLE
[Test] Save local model path in PEFT adapter config

### DIFF
--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -619,6 +619,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 self._apply_lora_to_output,
             ),
             "peft_type": "LORA",
+            "base_model_name_or_path": str(self._checkpointer._checkpoint_dir),
         }
         ckpt_dict.update({training.ADAPTER_CONFIG: adapter_config})
 


### PR DESCRIPTION
It was pointed out in #2025 that the one-liner `AutoModelForCausalLM.from_pretrained(model_id)` doesn't work for our models trained with LoRA (instead you need to call `AutoModelForCausalLM.from_pretrained` on a hub model followed by `PeftModel.from_pretrained` on the LoRA-trained model). This is a demo of saving the checkpointer's directory as part of our adapter_config.json file which should enable this to work. 

Edit: after discussing with @pbontrager this won't integrate well with e.g. push to hub since it assumes a local path. So I'm not sure we want to actually land this as is, the better solution may be to make some changes to tune download.