### PR TITLE
Use hf transfer as default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 
     # Hugging Face integrations
     "datasets",
-    "huggingface_hub",
+    "huggingface_hub[hf_transfer]",
     "safetensors",
 
     # Kaggle Integrations

--- a/torchtune/__init__.py
+++ b/torchtune/__init__.py
@@ -23,6 +23,16 @@ except ImportError as e:
         """
     ) from e
 
+try:
+    import os
+
+    import hf_transfer  # noqa
+
+    if os.environ.get("HF_HUB_ENABLE_HF_TRANSFER") is None:
+        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+except ImportError:
+    pass
+
 from torchtune import datasets, generation, models, modules, utils
 
 __all__ = [datasets, models, modules, utils, generation]

--- a/torchtune/__init__.py
+++ b/torchtune/__init__.py
@@ -23,6 +23,8 @@ except ImportError as e:
         """
     ) from e
 
+# Enables faster downloading. For more info: https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads
+# To disable, run `HF_HUB_ENABLE_HF_TRANSFER=0 tune download <model_config>`
 try:
     import os
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

```
pip install huggingface_hub[hf_transfer]
HF_HUB_ENABLE_HF_TRANSFER=1 tune download <your model>
```
For llama 8b: from 2m12s down to 32s.

doc: https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads

#### Changelog
- Had to add it to __init__, because adding it to /cli/download.py wouldn't work.
- User can still disable it by running `HF_HUB_ENABLE_HF_TRANSFER=0 tune download <model_config>`

#### Test plan
pip installed torchtune
`HF_HUB_ENABLE_HF_TRANSFER=0 tune download <model_config>` --> runs without transfer
`tune download <model_config>` --> runs with transfer
pip uninstall hf_transfer
`tune download <model_config>` --> runs without transfer
