### PR TITLE
Do not require lr_scheduler for all other recipes

### DIFF
--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -315,7 +315,7 @@ class KDRecipeDistributed(FTRecipeInterface):
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
-            cfg_lr_scheduler=cfg.lr_scheduler,
+            cfg_lr_scheduler=cfg.get("lr_scheduler", None),
             num_training_steps=self.total_epochs * self._steps_per_epoch,
             last_epoch=self.global_step - 1,
         )
@@ -626,10 +626,15 @@ class KDRecipeDistributed(FTRecipeInterface):
 
     def _setup_lr_scheduler(
         self,
-        cfg_lr_scheduler: DictConfig,
+        cfg_lr_scheduler: Optional[DictConfig],
         num_training_steps: int,
         last_epoch: int,
-    ) -> Optimizer:
+    ) -> Optional[Optimizer]:
+        if cfg_lr_scheduler is None:
+            log.info(
+                "No learning rate scheduler configured. Using constant learning rate."
+            )
+            return None
         lr_scheduler = config.instantiate(
             cfg_lr_scheduler,
             self._optimizer,
@@ -886,7 +891,8 @@ class KDRecipeDistributed(FTRecipeInterface):
                     kd_loss_to_log = running_kd_loss.item() / num_tokens
                     self._optimizer.step()
                     self._optimizer.zero_grad(set_to_none=True)
-                    self._lr_scheduler.step()
+                    if self._lr_scheduler is not None:
+                        self._lr_scheduler.step()
                     # Update the number of steps when the weights are updated
                     self.global_step += 1
 

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -306,7 +306,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
-            cfg_lr_scheduler=cfg.lr_scheduler,
+            cfg_lr_scheduler=cfg.get("lr_scheduler", None),
             num_training_steps=self.total_epochs * self._steps_per_epoch,
             last_epoch=self.global_step - 1,
         )
@@ -495,10 +495,16 @@ class KDRecipeSingleDevice(FTRecipeInterface):
 
     def _setup_lr_scheduler(
         self,
-        cfg_lr_scheduler: DictConfig,
+        cfg_lr_scheduler: Optional[DictConfig],
         num_training_steps: int,
         last_epoch: int,
-    ) -> Optimizer:
+    ) -> Optional[Optimizer]:
+        if cfg_lr_scheduler is None:
+            log.info(
+                "No learning rate scheduler configured. Using constant learning rate."
+            )
+            return None
+
         lr_scheduler = config.instantiate(
             cfg_lr_scheduler,
             self._optimizer,
@@ -727,7 +733,8 @@ class KDRecipeSingleDevice(FTRecipeInterface):
                             )
                         self._optimizer.step()
                         self._optimizer.zero_grad(set_to_none=True)
-                        self._lr_scheduler.step()
+                        if self._lr_scheduler is not None:
+                            self._lr_scheduler.step()
                         # Update the number of steps when the weights are updated
                         self.global_step += 1
 

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -284,7 +284,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
-            cfg_lr_scheduler=cfg.lr_scheduler,
+            cfg_lr_scheduler=cfg.get("lr_scheduler", None),
             num_training_steps=self.total_epochs * self._steps_per_epoch,
             last_epoch=self.global_step - 1,
         )
@@ -426,10 +426,16 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
 
     def _setup_lr_scheduler(
         self,
-        cfg_lr_scheduler: DictConfig,
+        cfg_lr_scheduler: Optional[DictConfig],
         num_training_steps: int,
         last_epoch: int,
-    ) -> Optimizer:
+    ) -> Optional[Optimizer]:
+        if cfg_lr_scheduler is None:
+            log.info(
+                "No learning rate scheduler configured. Using constant learning rate."
+            )
+            return None
+
         lr_scheduler = config.instantiate(
             cfg_lr_scheduler,
             self._optimizer,
@@ -679,7 +685,8 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 if (idx + 1) % self._gradient_accumulation_steps == 0:
                     self._optimizer.step()
                     self._optimizer.zero_grad(set_to_none=True)
-                    self._lr_scheduler.step()
+                    if self._lr_scheduler is not None:
+                        self._lr_scheduler.step()
 
                     # Update the number of steps when the weights are updated
                     self.global_step += 1

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -334,7 +334,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
-            cfg_lr_scheduler=cfg.lr_scheduler,
+            cfg_lr_scheduler=cfg.get("lr_scheduler", None),
             num_training_steps=self.total_epochs * self._steps_per_epoch,
             last_epoch=self.global_step - 1,
         )
@@ -563,10 +563,16 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
     def _setup_lr_scheduler(
         self,
-        cfg_lr_scheduler: DictConfig,
+        cfg_lr_scheduler: Optional[DictConfig],
         num_training_steps: int,
         last_epoch: int,
-    ) -> Optimizer:
+    ) -> Optional[Optimizer]:
+        if cfg_lr_scheduler is None:
+            log.info(
+                "No learning rate scheduler configured. Using constant learning rate."
+            )
+            return None
+
         lr_scheduler = config.instantiate(
             cfg_lr_scheduler,
             self._optimizer,
@@ -837,7 +843,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                         )
                     self._optimizer.step()
                     self._optimizer.zero_grad(set_to_none=True)
-                    self._lr_scheduler.step()
+                    if self._lr_scheduler is not None:
+                        self._lr_scheduler.step()
 
                     # Update the number of steps when the weights are updated
                     self.global_step += 1

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -331,7 +331,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
         self._lr_scheduler = self._setup_lr_scheduler(
-            cfg_lr_scheduler=cfg.lr_scheduler,
+            cfg_lr_scheduler=cfg.get("lr_scheduler", None),
             num_training_steps=self.total_epochs * self._steps_per_epoch,
             last_epoch=self.global_step - 1,
         )
@@ -497,10 +497,16 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
     def _setup_lr_scheduler(
         self,
-        cfg_lr_scheduler: DictConfig,
+        cfg_lr_scheduler: Optional[DictConfig],
         num_training_steps: int,
         last_epoch: int,
-    ) -> Optimizer:
+    ) -> Optional[Optimizer]:
+        if cfg_lr_scheduler is None:
+            log.info(
+                "No learning rate scheduler configured. Using constant learning rate."
+            )
+            return None
+
         lr_scheduler = config.instantiate(
             cfg_lr_scheduler,
             self._optimizer,
@@ -717,7 +723,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                             )
                         self._optimizer.step()
                         self._optimizer.zero_grad(set_to_none=True)
-                        self._lr_scheduler.step()
+                        if self._lr_scheduler is not None:
+                            self._lr_scheduler.step()
                         # Update the number of steps when the weights are updated
                         self.global_step += 1
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Addresses https://github.com/pytorch/torchtune/issues/2021. This PR uses the pattern in https://github.com/pytorch/torchtune/pull/1991 for the rest of the recipes.

#### Changelog
What are the changes made in this PR?
* Allows `lr_scheduler` to be optional in all recipes.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
