### PR TITLE
Switch to PyTorch's built-in RMSNorm

### DIFF
--- a/tests/torchtune/modules/test_rms_norm.py
+++ b/tests/torchtune/modules/test_rms_norm.py
@@ -5,12 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-
 import torch
 
 from tests.test_utils import assert_expected
 from torch.nn.functional import normalize
-
 from torchtune.modules.rms_norm import RMSNorm
 from torchtune.training.seed import set_seed
 
@@ -66,6 +64,7 @@ class TestRMSNorm:
 
         # convert input to float since rms_norm computes in fp32
         expected_fp16 = normalize(input_random_fp16.float(), p=2, dim=-1) * (dim**0.5)
+        expected_fp16 = expected_fp16.to(torch.float16)
 
         assert_expected(output_fp16, expected_fp16, atol=1e-7, rtol=1e-3)
-        assert output_fp16.dtype == torch.float32
+        assert output_fp16.dtype == torch.float16

--- a/torchtune/modules/rms_norm.py
+++ b/torchtune/modules/rms_norm.py
@@ -5,18 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-
+import torch.nn.functional as F
 from torch import nn
 
 
 class RMSNorm(nn.Module):
     """
-    Implements Root Mean Square Normalization introduced in
-    https://arxiv.org/abs/1910.07467.
+    Root Mean Square Normalization in fp32.
 
-    Reference implementation (used for correctness verification)
-    can be found here:
-    https://github.com/facebookresearch/llama/blob/main/llama/model.py
+    See: https://pytorch.org/docs/stable/generated/torch.nn.RMSNorm.html
 
     Args:
         dim (int): embedding size
@@ -25,6 +22,7 @@ class RMSNorm(nn.Module):
 
     def __init__(self, dim: int, eps: float = 1e-6) -> None:
         super().__init__()
+        self.normalized_shape = (dim,)
         self.eps = eps
         self.scale = nn.Parameter(torch.ones(dim))
 
@@ -37,8 +35,9 @@ class RMSNorm(nn.Module):
             torch.Tensor: The normalized and scaled tensor having the same shape as ``x``.
         """
         # computation is in fp32
-        x_fp32 = x.float()
-        x_normed = (
-            x_fp32 * torch.rsqrt(x_fp32.pow(2).mean(-1, keepdim=True) + self.eps)
-        ).type_as(x)
-        return x_normed * self.scale
+        return F.rms_norm(
+            x.float(),
+            normalized_shape=self.normalized_shape,
+            weight=self.scale,
+            eps=self.eps,
+        ).to(x.dtype)


### PR DESCRIPTION
### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)
- [x] zoom zoom 

### Results
**Inference**
Uncompiled: 31x faster
Compiled:  compilation and first batch = 5x faster, post-first batches = 1.5x faster

**Train (forward + backward)**:
Uncompiled: 22x faster
Compiled:  compilation and first batch = 1.5x faster, post-first batches = 1.2x faster

**Parity**:
Uncompiled: perfect
Compiled: 2.76e-6 MSE

### Test plan

Test code (output is below):
1 = original RMSNorm, 2 = new RMSNorm
```python
 from time import time

import torch
import torch.nn.functional as F

from torchtune.modules.rms_norm import RMSNorm, RMSNorm2


class Time:
    def __init__(s, name):
        s.name = name

    def __enter__(s):
        s.start = time()

    def __exit__(s, *a, **kw):
        print(f"TIME_{s.name}", time() - s.start)


shape = [1024, 512, 4096]
xs = [torch.randn(shape, dtype=torch.bfloat16, device="cuda") for _ in range(10)]

n1 = RMSNorm(shape[-1], eps=1e-6).cuda()
n2 = RMSNorm2(shape[-1], eps=1e-6).cuda()

with torch.no_grad():
    n1 = RMSNorm(shape[-1], eps=1e-6).cuda().eval()
    n2 = RMSNorm2(shape[-1], eps=1e-6).cuda().eval()

    with Time("inference_uncompiled1"):
        for x in xs:
            y1 = n1(x)
    with Time("inference_uncompiled2"):
        for x in xs:
            y2 = n2(x)
    print("inference uncompiled mse", F.mse_loss(y1, y2).item())

    with Time("inference_initial_compile1"):
        n1 = torch.compile(n1)
        n1(xs[0])
    with Time("inference_initial_compile2"):
        n2 = torch.compile(n2)
        n2(xs[0])

    with Time("inference_compiled1"):
        for x in xs:
            y1 = n1(x)
    with Time("inference_compiled2"):
        for x in xs:
            y2 = n2(x)
    print("inference compiled mse", F.mse_loss(y1, y2).item())


n1 = RMSNorm(shape[-1], eps=1e-6).cuda().train()
n2 = RMSNorm2(shape[-1], eps=1e-6).cuda().train()

with Time("train_uncompiled1"):
    for x in xs:
        y1 = n1(x)
        y1.mean().backward()
with Time("train_uncompiled2"):
    for x in xs:
        y2 = n2(x)
        y2.mean().backward()
print("train uncompiled mse", F.mse_loss(y1, y2).item())

with Time("train_initial_compile1"):
    n1 = torch.compile(n1)
    y1 = n1(xs[0])
    y1.mean().backward()
with Time("train_initial_compile2"):
    n2 = torch.compile(n2)
    y2 = n2(xs[0])
    y2.mean().backward()

with Time("train_compiled1"):
    for x in xs:
        y1 = n1(x)
        y1.mean().backward()
with Time("train_compiled2"):
    for x in xs:
        y2 = n2(x)
        y2.mean().backward()
print("train compiled mse", F.mse_loss(y1, y2).item())
```

Output on 1xH100:
```
TIME_inference_uncompiled1 0.057599782943725586
TIME_inference_uncompiled2 0.0018465518951416016
inference uncompiled mse 0.0
TIME_inference_initial_compile1 0.7398524284362793
TIME_inference_initial_compile2 0.1506185531616211
TIME_inference_compiled1 0.0005228519439697266
TIME_inference_compiled2 0.0003452301025390625
inference compiled mse 2.760749339358881e-06
TIME_train_uncompiled1 0.07179093360900879
TIME_train_uncompiled2 0.0031974315643310547
train uncompiled mse 0.0
TIME_train_initial_compile1 0.2178797721862793
TIME_train_initial_compile2 0.15280580520629883
TIME_train_compiled1 0.005212545394897461
TIME_train_compiled2 0.004248380661010742
train compiled mse 2.760749339358881e-06
```
