### PR TITLE
Error message on ``packed=True`` for stack exchange dataset

### DIFF
--- a/tests/torchtune/datasets/test_hh_rlhf_helpful_dataset.py
+++ b/tests/torchtune/datasets/test_hh_rlhf_helpful_dataset.py
@@ -107,3 +107,14 @@ class TestHHRLHFHelpfulDataset:
         else:
             # Check that the input is masked
             assert sample["rejected_labels"].count(CROSS_ENTROPY_IGNORE_IDX) == 16
+
+    def test_dataset_fails_with_packed(self):
+        with pytest.raises(
+            ValueError,
+            match="Packed is currently not supported for preference datasets",
+        ):
+            hh_rlhf_helpful_dataset(
+                tokenizer=DummyTokenizer(),
+                train_on_input=True,
+                packed=True,
+            )

--- a/tests/torchtune/datasets/test_preference_dataset.py
+++ b/tests/torchtune/datasets/test_preference_dataset.py
@@ -155,3 +155,17 @@ class TestPreferenceDataset:
 
         assert expected_chosen_labels[0] == ds[0]["chosen_labels"]
         assert expected_rejected_labels[0] == ds[0]["rejected_labels"]
+
+    def test_dataset_fails_with_packed(self):
+        with pytest.raises(
+            ValueError,
+            match="Packed is currently not supported for preference datasets.",
+        ):
+            preference_dataset(
+                tokenizer=DummyTokenizer(),
+                source="json",
+                data_files=str(ASSETS / "hh_rlhf_tiny.json"),
+                train_on_input=False,
+                split="train",
+                packed=True,
+            )

--- a/tests/torchtune/datasets/test_preference_dataset.py
+++ b/tests/torchtune/datasets/test_preference_dataset.py
@@ -156,6 +156,7 @@ class TestPreferenceDataset:
         assert expected_chosen_labels[0] == ds[0]["chosen_labels"]
         assert expected_rejected_labels[0] == ds[0]["rejected_labels"]
 
+    @mock.patch("torchtune.datasets._preference.load_dataset")
     def test_dataset_fails_with_packed(self):
         with pytest.raises(
             ValueError,

--- a/tests/torchtune/datasets/test_preference_dataset.py
+++ b/tests/torchtune/datasets/test_preference_dataset.py
@@ -156,7 +156,6 @@ class TestPreferenceDataset:
         assert expected_chosen_labels[0] == ds[0]["chosen_labels"]
         assert expected_rejected_labels[0] == ds[0]["rejected_labels"]
 
-    @mock.patch("torchtune.datasets._preference.load_dataset")
     def test_dataset_fails_with_packed(self):
         with pytest.raises(
             ValueError,

--- a/tests/torchtune/datasets/test_stack_exchange_paired_dataset.py
+++ b/tests/torchtune/datasets/test_stack_exchange_paired_dataset.py
@@ -102,7 +102,8 @@ class TestStackExchangePairedDataset:
 
     def test_dataset_fails_with_packed(self):
         with pytest.raises(
-            ValueError, match="StackExchangePairedDataset does not support packing"
+            ValueError,
+            match="Packed is currently not supported for preference datasets",
         ):
             stack_exchange_paired_dataset(
                 tokenizer=DummyTokenizer(),

--- a/tests/torchtune/datasets/test_stack_exchange_paired_dataset.py
+++ b/tests/torchtune/datasets/test_stack_exchange_paired_dataset.py
@@ -100,6 +100,16 @@ class TestStackExchangePairedDataset:
             # Check that the input is masked
             assert sample["rejected_labels"].count(CROSS_ENTROPY_IGNORE_IDX) == 52
 
+    def test_dataset_fails_with_packed(self):
+        with pytest.raises(
+            ValueError, match="StackExchangePairedDataset does not support packing"
+        ):
+            stack_exchange_paired_dataset(
+                tokenizer=DummyTokenizer(),
+                train_on_input=True,
+                packed=True,
+            )
+
 
 class TestStackExchangePairedToMessages:
     @pytest.fixture

--- a/tests/torchtune/datasets/test_stack_exchange_paired_dataset.py
+++ b/tests/torchtune/datasets/test_stack_exchange_paired_dataset.py
@@ -107,7 +107,6 @@ class TestStackExchangePairedDataset:
         ):
             stack_exchange_paired_dataset(
                 tokenizer=DummyTokenizer(),
-                train_on_input=True,
                 packed=True,
             )
 

--- a/torchtune/datasets/_preference.py
+++ b/torchtune/datasets/_preference.py
@@ -109,14 +109,14 @@ class PreferenceDataset(Dataset):
         packed: bool = False,
         **load_dataset_kwargs: Dict[str, Any],
     ) -> None:
-        self._tokenizer = tokenizer
-        self._message_transform = message_transform
-        self._data = load_dataset(source, **load_dataset_kwargs)
-
         if packed:
             raise ValueError(
                 "Packed is currently not supported for preference datasets."
             )
+
+        self._tokenizer = tokenizer
+        self._message_transform = message_transform
+        self._data = load_dataset(source, **load_dataset_kwargs)
 
         if filter_fn is not None:
             self._data = self._data.filter(filter_fn)

--- a/torchtune/datasets/_preference.py
+++ b/torchtune/datasets/_preference.py
@@ -89,9 +89,14 @@ class PreferenceDataset(Dataset):
         filter_fn (Optional[Callable]): callable used to filter the dataset prior to any pre-processing. See
             the Hugging Face `docs <https://huggingface.co/docs/datasets/v2.20.0/process#select-and-filter>`_ for more
             details.
+        packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False. Packed is
+            currently not supported for ``PreferenceDataset`` and a ``ValueError`` will be raised if this is set to True.
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``. See Hugging
             Face's `API ref <https://huggingface.co/docs/datasets/en/package_reference/loading_methods#datasets.load_dataset>`_
             for more details.
+
+    Raises:
+        ValueError: If ``packed`` is True, this feature is not supported for ``PreferenceDataset``.
     """
 
     def __init__(
@@ -101,11 +106,17 @@ class PreferenceDataset(Dataset):
         message_transform: Transform,
         tokenizer: ModelTokenizer,
         filter_fn: Optional[Callable] = None,
+        packed: bool = False,
         **load_dataset_kwargs: Dict[str, Any],
     ) -> None:
         self._tokenizer = tokenizer
         self._message_transform = message_transform
         self._data = load_dataset(source, **load_dataset_kwargs)
+
+        if packed:
+            raise ValueError(
+                "Packed is currently not supported for preference datasets."
+            )
 
         if filter_fn is not None:
             self._data = self._data.filter(filter_fn)

--- a/torchtune/datasets/_stack_exchange_paired.py
+++ b/torchtune/datasets/_stack_exchange_paired.py
@@ -78,6 +78,7 @@ def stack_exchange_paired_dataset(
     source: str = "lvwerra/stack-exchange-paired",
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
+    packed: bool = False,
     filter_fn: Optional[Callable] = None,
     split: str = "train",
     **load_dataset_kwargs: Dict[str, Any],
@@ -101,6 +102,8 @@ def stack_exchange_paired_dataset(
             Keys should be "prompt", "chosen", and "rejected" and values should be the actual column names.
             Default is None, keeping the default column names.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
+        packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False and this
+            is currently not supported for this dataset. A ValueError will be raised if this is set to True.
         filter_fn (Optional[Callable]): callable used to filter the dataset prior to any pre-processing. See
             the Hugging Face `docs <https://huggingface.co/docs/datasets/v2.20.0/process#select-and-filter>`_ for more
             details.
@@ -108,9 +111,15 @@ def stack_exchange_paired_dataset(
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
+    Raises:
+        ValueError: If ``packed`` is True, they are not supported for preference datasets yet.
+
     Returns:
         PreferenceDataset: The preference dataset built from source paired data.
     """
+
+    if packed:
+        raise ValueError("StackExchangePairedDataset does not support packing.")
 
     column_map = column_map or {
         "prompt": "question",

--- a/torchtune/datasets/_stack_exchange_paired.py
+++ b/torchtune/datasets/_stack_exchange_paired.py
@@ -78,7 +78,6 @@ def stack_exchange_paired_dataset(
     source: str = "lvwerra/stack-exchange-paired",
     column_map: Optional[Dict[str, str]] = None,
     train_on_input: bool = False,
-    packed: bool = False,
     filter_fn: Optional[Callable] = None,
     split: str = "train",
     **load_dataset_kwargs: Dict[str, Any],
@@ -102,8 +101,6 @@ def stack_exchange_paired_dataset(
             Keys should be "prompt", "chosen", and "rejected" and values should be the actual column names.
             Default is None, keeping the default column names.
         train_on_input (bool): Whether the model is trained on the prompt or not. Default is False.
-        packed (bool): Whether or not to pack the dataset to ``max_seq_len`` prior to training. Default is False and this
-            is currently not supported for this dataset. A ValueError will be raised if this is set to True.
         filter_fn (Optional[Callable]): callable used to filter the dataset prior to any pre-processing. See
             the Hugging Face `docs <https://huggingface.co/docs/datasets/v2.20.0/process#select-and-filter>`_ for more
             details.
@@ -111,15 +108,9 @@ def stack_exchange_paired_dataset(
             of a given split, e.g. ``split="train[:10%]"``. Default is "train".
         **load_dataset_kwargs (Dict[str, Any]): additional keyword arguments to pass to ``load_dataset``.
 
-    Raises:
-        ValueError: If ``packed`` is True, they are not supported for preference datasets yet.
-
     Returns:
         PreferenceDataset: The preference dataset built from source paired data.
     """
-
-    if packed:
-        raise ValueError("StackExchangePairedDataset does not support packing.")
 
     column_map = column_map or {
         "prompt": "question",


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Add a ValueError that informs user that packed=True is not allowed for StackExchangeDataset yet

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x] I have added an example to docs or docstrings
