### PR TITLE
Implement activation offloading and opt_in_bwd in knowledge_distillation recipes

### DIFF
--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -35,7 +35,7 @@ class TestKDSingleDeviceRecipe:
             "device=cpu",
             f"dtype={dtype_str}",
             "enable_activation_checkpointing=False",
-            "enable_activation_offloading=False",
+            "enable_activation_offloading=True",
             "dataset.train_on_input=False",
             "seed=9",
             f"epochs={epochs}",


### PR DESCRIPTION
Towards #1959 .

So this is the first PR for implementing the changes in
KD recipes:
https://github.com/pytorch/torchtune/blob/main/recipes/knowledge_distillation_single_device.py
https://github.com/pytorch/torchtune/blob/main/recipes/knowledge_distillation_distributed.py

