### PR TITLE
Set gloo process group for FSDP with CPU offload

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -946,7 +946,6 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-
     process_group = "gloo" if cfg.device == "cpu" else "nccl"
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -946,11 +946,14 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-    init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
+
+    process_group = "gloo" if cfg.device == "cpu" else "nccl"
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
+        process_group = "cuda:nccl,cpu:gloo"
+    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="FullFinetuneRecipeDistributed", cfg=cfg)
 

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -946,13 +946,11 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-    process_group = "gloo" if cfg.device == "cpu" else "nccl"
+    init_process_group("cuda:nccl,cpu:gloo")
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-        process_group = "cuda:nccl,cpu:gloo"
-    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="FullFinetuneRecipeDistributed", cfg=cfg)
 

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -971,11 +971,13 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
+    process_group = "gloo" if cfg.device == "cpu" else "nccl"
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-    init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
+        process_group = "cuda:nccl,cpu:gloo"
+    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="KDRecipeDistributed", cfg=cfg)
 

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -971,13 +971,11 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-    process_group = "gloo" if cfg.device == "cpu" else "nccl"
+    init_process_group("cuda:nccl,cpu:gloo")
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-        process_group = "cuda:nccl,cpu:gloo"
-    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="KDRecipeDistributed", cfg=cfg)
 

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -782,11 +782,13 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
+    process_group = "gloo" if cfg.device == "cpu" else "nccl"
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-    init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
+        process_group = "cuda:nccl,cpu:gloo"
+    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="LoRADPORecipeDistributed", cfg=cfg)
 

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -782,13 +782,11 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-    process_group = "gloo" if cfg.device == "cpu" else "nccl"
+    init_process_group("cuda:nccl,cpu:gloo")
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-        process_group = "cuda:nccl,cpu:gloo"
-    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="LoRADPORecipeDistributed", cfg=cfg)
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -920,6 +920,7 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
+    process_group = "gloo" if cfg.device == "cpu" else "nccl"
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -920,13 +920,11 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-    process_group = "gloo" if cfg.device == "cpu" else "nccl"
+    init_process_group("cuda:nccl,cpu:gloo")
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-        process_group = "cuda:nccl,cpu:gloo"
-    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="LoRAFinetuneRecipeDistributed", cfg=cfg)
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -924,7 +924,8 @@ def recipe_main(cfg: DictConfig) -> None:
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-    init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
+        process_group = "cuda:nccl,cpu:gloo"
+    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="LoRAFinetuneRecipeDistributed", cfg=cfg)
 

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -935,11 +935,13 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-    init_process_group(backend="gloo" if cfg.device == "cpu" else "nccl")
+    process_group = "gloo" if cfg.device == "cpu" else "nccl"
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
+        process_group = "cuda:nccl,cpu:gloo"
+    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="QATRecipeDistributed", cfg=cfg)
 

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -935,13 +935,11 @@ def recipe_main(cfg: DictConfig) -> None:
             "Distributed finetune recipe should be run via a distributed launcher."
             "If using tune CLI, please specify --nnodes 1 and --nproc_per_node [num_gpus]"
         )
-    process_group = "gloo" if cfg.device == "cpu" else "nccl"
+    init_process_group("cuda:nccl,cpu:gloo")
     if cfg.get("fsdp_cpu_offload", False):
         # Utilize all available CPU cores for intra-op parallelism. This provides ~2x
         # speed up when benchmarking fused AdamW on CPU
         training.set_torch_num_threads()
-        process_group = "cuda:nccl,cpu:gloo"
-    init_process_group(backend=process_group)
 
     config.log_config(recipe_name="QATRecipeDistributed", cfg=cfg)
 

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -103,6 +103,8 @@ class TestFullFinetuneDistributedRecipe:
         # should be the same.
         if not optim_in_bwd:
             cmd.append("clip_grad_norm=100")
+            # Test that gradient clipping works with CPU offload
+            cmd.append("fsdp_cpu_offload=True")
         else:
             cmd.append("optimizer_in_bwd=True")
 


### PR DESCRIPTION
Addresses #1977.

As discussed in the issue (see [this comment](https://github.com/pytorch/torchtune/issues/1977#issuecomment-2512906526)), FSDP's implementation of gradient clipping uses [_NormPartial](https://github.com/pytorch/pytorch/blob/64d44a39a10a3e4b7abc85ffadd831ace3227460/torch/distributed/tensor/_ops/_math_ops.py#L56), which requires comms primitives (specifically `all_reduce`). This means that when running with CPU offloading we need to initialize the gloo process group to calculate the grad norm for DTensors on CPU. For simplicity this PR enables it whenever CPU offloading is enabled regardless of gradient clipping.

Test plan:

Added a test case for gradient clipping + CPU offload to `test_full_finetune_distributed.py`.

```
pytest -m integration_test tests/recipes/test_full_finetune_distributed.py -k 'test_loss'
...
========= 3 passed, 1 deselected in 43.54s ========
```