### PR TITLE
pass correct arg

### DIFF
--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -190,7 +190,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
             checkpoint_dir=self._checkpoint_dir,
             output_dir=self._output_dir,
             resume_from_checkpoint=self._resume_from_checkpoint,
-            has_adapter_checkpoint=adapter_checkpoint is not None,
+            has_adapter_checkpoint=self._adapter_checkpoint is not None,
         )
 
         # we currently accept only a single file
@@ -447,7 +447,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             checkpoint_dir=self._checkpoint_dir,
             output_dir=self._output_dir,
             resume_from_checkpoint=self._resume_from_checkpoint,
-            has_adapter_checkpoint=adapter_checkpoint is not None,
+            has_adapter_checkpoint=self._adapter_checkpoint is not None,
         )
 
         if self._resume_from_checkpoint:
@@ -944,7 +944,7 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
             checkpoint_dir=self._checkpoint_dir,
             output_dir=self._output_dir,
             resume_from_checkpoint=self._resume_from_checkpoint,
-            has_adapter_checkpoint=adapter_checkpoint is not None,
+            has_adapter_checkpoint=self._adapter_checkpoint is not None,
         )
 
         # we currently accept only a single file


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

In https://github.com/pytorch/torchtune/pull/2074, we allowed user to use resume_from_checkpoint=True without passing the recipe_state and the adapter paths. If they are none, we search for them in the latest epoch.

This PR is a hotfix that actually allows adapter paths to be None.

#### Test plan
No need to pass recipe state and adapter path

```tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device epochs=2 max_steps_per_epoch=5 ```

```tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device epochs=2 max_steps_per_epoch=5 resume_from_checkpoint=True```
