### PR TITLE
[bug fix] remove config download when source is kaggle

### DIFF
--- a/torchtune/_cli/download.py
+++ b/torchtune/_cli/download.py
@@ -207,13 +207,6 @@ class Download(Subcommand):
         try:
             output_dir = model_download(model_handle)
 
-            # save the repo_id. This is necessary because the download step is a separate command
-            # from the rest of the CLI. When saving a model adapter, we have to add the repo_id
-            # to the adapter config.
-            file_path = os.path.join(output_dir, REPO_ID_FNAME + ".json")
-            with open(file_path, "w") as json_file:
-                json.dump({"repo_id": args.repo_id}, json_file, indent=4)
-
             print(
                 "Successfully downloaded model repo and wrote to the following locations:",
                 *list(Path(output_dir).iterdir()),

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -827,7 +827,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 state_dict[
                     training.ADAPTER_CONFIG
                 ] = convert_weights.tune_to_peft_adapter_config(
-                    state_dict[training.ADAPTER_CONFIG],
+                    adapter_config=state_dict[training.ADAPTER_CONFIG],
                     base_model_name_or_path=self.repo_id,
                 )
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

In our recent ckpt directory refactoring, we added "repo_id.json" as a way to keep track of the original model to save it to hf adapter_config.

This does not work for kaggle for two reasons:
- Folder is read only
- repo_id is not a huggingface id, and it wont be useful for the adapter config anyways
