### PR TITLE
Using `FormattedCheckpointFiles` in configs

### DIFF
--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -29,23 +29,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir:  /tmp/Llama-2-70b-hf
-  checkpoint_files: [
-    pytorch_model-00001-of-00015.bin,
-    pytorch_model-00002-of-00015.bin,
-    pytorch_model-00003-of-00015.bin,
-    pytorch_model-00004-of-00015.bin,
-    pytorch_model-00005-of-00015.bin,
-    pytorch_model-00006-of-00015.bin,
-    pytorch_model-00007-of-00015.bin,
-    pytorch_model-00008-of-00015.bin,
-    pytorch_model-00009-of-00015.bin,
-    pytorch_model-00010-of-00015.bin,
-    pytorch_model-00011-of-00015.bin,
-    pytorch_model-00012-of-00015.bin,
-    pytorch_model-00013-of-00015.bin,
-    pytorch_model-00014-of-00015.bin,
-    pytorch_model-00015-of-00015.bin,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00015
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA2

--- a/recipes/configs/llama2/70B_lora.yaml
+++ b/recipes/configs/llama2/70B_lora.yaml
@@ -30,7 +30,7 @@ checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir:  /tmp/Llama-2-70b-hf
   checkpoint_files:
-    filename_format: model-{}-of-{}.safetensors
+    filename_format: pytorch_model-{}-of-{}.bin
     max_filename: 00015
   recipe_checkpoint: null
   output_dir: ${output_dir}

--- a/recipes/configs/llama2/70B_qlora.yaml
+++ b/recipes/configs/llama2/70B_qlora.yaml
@@ -34,23 +34,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir:  /tmp/Llama-2-70b-hf
-  checkpoint_files: [
-    pytorch_model-00001-of-00015.bin,
-    pytorch_model-00002-of-00015.bin,
-    pytorch_model-00003-of-00015.bin,
-    pytorch_model-00004-of-00015.bin,
-    pytorch_model-00005-of-00015.bin,
-    pytorch_model-00006-of-00015.bin,
-    pytorch_model-00007-of-00015.bin,
-    pytorch_model-00008-of-00015.bin,
-    pytorch_model-00009-of-00015.bin,
-    pytorch_model-00010-of-00015.bin,
-    pytorch_model-00011-of-00015.bin,
-    pytorch_model-00012-of-00015.bin,
-    pytorch_model-00013-of-00015.bin,
-    pytorch_model-00014-of-00015.bin,
-    pytorch_model-00015-of-00015.bin,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00015
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA2

--- a/recipes/configs/llama2/70B_qlora.yaml
+++ b/recipes/configs/llama2/70B_qlora.yaml
@@ -35,7 +35,7 @@ checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir:  /tmp/Llama-2-70b-hf
   checkpoint_files:
-    filename_format: model-{}-of-{}.safetensors
+    filename_format: pytorch_model-{}-of-{}.bin
     max_filename: 00015
   recipe_checkpoint: null
   output_dir: ${output_dir}

--- a/recipes/configs/llama3/70B_full.yaml
+++ b/recipes/configs/llama3/70B_full.yaml
@@ -39,38 +39,9 @@ model:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Meta-Llama-3-70B-Instruct
-  checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00030
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA3

--- a/recipes/configs/llama3/70B_lora.yaml
+++ b/recipes/configs/llama3/70B_lora.yaml
@@ -29,38 +29,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir:  /tmp/Meta-Llama-3-70B-Instruct
-  checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00030
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA3

--- a/recipes/configs/llama3_1/70B_full.yaml
+++ b/recipes/configs/llama3_1/70B_full.yaml
@@ -38,38 +38,9 @@ model:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Meta-Llama-3.1-70B-Instruct/
-  checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00030
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA3

--- a/recipes/configs/llama3_1/70B_lora.yaml
+++ b/recipes/configs/llama3_1/70B_lora.yaml
@@ -28,38 +28,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Meta-Llama-3.1-70B-Instruct/
-  checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00030
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA3

--- a/recipes/configs/llama3_3/70B_full.yaml
+++ b/recipes/configs/llama3_3/70B_full.yaml
@@ -38,38 +38,9 @@ model:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Llama-3.3-70B-Instruct/
-  checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00030
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA3

--- a/recipes/configs/llama3_3/70B_lora.yaml
+++ b/recipes/configs/llama3_3/70B_lora.yaml
@@ -28,38 +28,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Llama-3.3-70B-Instruct/
-  checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00030
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA3

--- a/recipes/configs/llama3_3/70B_qlora.yaml
+++ b/recipes/configs/llama3_3/70B_qlora.yaml
@@ -28,38 +28,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Llama-3.3-70B-Instruct/
-  checkpoint_files: [
-    model-00001-of-00030.safetensors,
-    model-00002-of-00030.safetensors,
-    model-00003-of-00030.safetensors,
-    model-00004-of-00030.safetensors,
-    model-00005-of-00030.safetensors,
-    model-00006-of-00030.safetensors,
-    model-00007-of-00030.safetensors,
-    model-00008-of-00030.safetensors,
-    model-00009-of-00030.safetensors,
-    model-00010-of-00030.safetensors,
-    model-00011-of-00030.safetensors,
-    model-00012-of-00030.safetensors,
-    model-00013-of-00030.safetensors,
-    model-00014-of-00030.safetensors,
-    model-00015-of-00030.safetensors,
-    model-00016-of-00030.safetensors,
-    model-00017-of-00030.safetensors,
-    model-00018-of-00030.safetensors,
-    model-00019-of-00030.safetensors,
-    model-00020-of-00030.safetensors,
-    model-00021-of-00030.safetensors,
-    model-00022-of-00030.safetensors,
-    model-00023-of-00030.safetensors,
-    model-00024-of-00030.safetensors,
-    model-00025-of-00030.safetensors,
-    model-00026-of-00030.safetensors,
-    model-00027-of-00030.safetensors,
-    model-00028-of-00030.safetensors,
-    model-00029-of-00030.safetensors,
-    model-00030-of-00030.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00030
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA3

--- a/recipes/configs/qwen2_5/14B_lora_single_device.yaml
+++ b/recipes/configs/qwen2_5/14B_lora_single_device.yaml
@@ -37,16 +37,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Qwen2_5-14B-Instruct
-  checkpoint_files: [
-    model-00001-of-00008.safetensors,
-    model-00002-of-00008.safetensors,
-    model-00003-of-00008.safetensors,
-    model-00004-of-00008.safetensors,
-    model-00005-of-00008.safetensors,
-    model-00006-of-00008.safetensors,
-    model-00007-of-00008.safetensors,
-    model-00008-of-00008.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00008
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: QWEN2

--- a/recipes/configs/qwen2_5/32B_lora.yaml
+++ b/recipes/configs/qwen2_5/32B_lora.yaml
@@ -35,25 +35,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Qwen2_5-32B-Instruct
-  checkpoint_files: [
-    model-00001-of-00017.safetensors,
-    model-00002-of-00017.safetensors,
-    model-00003-of-00017.safetensors,
-    model-00004-of-00017.safetensors,
-    model-00005-of-00017.safetensors,
-    model-00006-of-00017.safetensors,
-    model-00007-of-00017.safetensors,
-    model-00008-of-00017.safetensors,
-    model-00009-of-00017.safetensors,
-    model-00010-of-00017.safetensors,
-    model-00011-of-00017.safetensors,
-    model-00012-of-00017.safetensors,
-    model-00013-of-00017.safetensors,
-    model-00014-of-00017.safetensors,
-    model-00015-of-00017.safetensors,
-    model-00016-of-00017.safetensors,
-    model-00017-of-00017.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00017
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: QWEN2

--- a/recipes/configs/qwen2_5/72B_lora.yaml
+++ b/recipes/configs/qwen2_5/72B_lora.yaml
@@ -35,45 +35,9 @@ tokenizer:
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
   checkpoint_dir: /tmp/Qwen2_5-72B-Instruct
-  checkpoint_files: [
-    model-00001-of-00037.safetensors,
-    model-00002-of-00037.safetensors,
-    model-00003-of-00037.safetensors,
-    model-00004-of-00037.safetensors,
-    model-00005-of-00037.safetensors,
-    model-00006-of-00037.safetensors,
-    model-00007-of-00037.safetensors,
-    model-00008-of-00037.safetensors,
-    model-00009-of-00037.safetensors,
-    model-00010-of-00037.safetensors,
-    model-00011-of-00037.safetensors,
-    model-00012-of-00037.safetensors,
-    model-00013-of-00037.safetensors,
-    model-00014-of-00037.safetensors,
-    model-00015-of-00037.safetensors,
-    model-00016-of-00037.safetensors,
-    model-00017-of-00037.safetensors,
-    model-00018-of-00037.safetensors,
-    model-00019-of-00037.safetensors,
-    model-00020-of-00037.safetensors,
-    model-00021-of-00037.safetensors,
-    model-00022-of-00037.safetensors,
-    model-00023-of-00037.safetensors,
-    model-00024-of-00037.safetensors,
-    model-00025-of-00037.safetensors,
-    model-00026-of-00037.safetensors,
-    model-00027-of-00037.safetensors,
-    model-00028-of-00037.safetensors,
-    model-00029-of-00037.safetensors,
-    model-00030-of-00037.safetensors,
-    model-00031-of-00037.safetensors,
-    model-00032-of-00037.safetensors,
-    model-00033-of-00037.safetensors,
-    model-00034-of-00037.safetensors,
-    model-00035-of-00037.safetensors,
-    model-00036-of-00037.safetensors,
-    model-00037-of-00037.safetensors,
-  ]
+  checkpoint_files:
+    filename_format: model-{}-of-{}.safetensors
+    max_filename: 00037
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: QWEN2


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

Please link to any issues this PR addresses.

closes #2073 

A super duper sanity check since we didn't have an example of the `pytorch_model-{}-of-{}.bin` format
```python
from torchtune.training.checkpointing._utils import FormattedCheckpointFiles
fmt = FormattedCheckpointFiles(filename_format="pytorch_model-{}-of-{}.bin", max_filename="00015")
fmt.build_checkpoint_filenames()
['pytorch_model-00001-of-00015.bin',
 'pytorch_model-00002-of-00015.bin',
 'pytorch_model-00003-of-00015.bin',
 'pytorch_model-00004-of-00015.bin',
 'pytorch_model-00005-of-00015.bin',
 'pytorch_model-00006-of-00015.bin',
 'pytorch_model-00007-of-00015.bin',
 'pytorch_model-00008-of-00015.bin',
 'pytorch_model-00009-of-00015.bin',
 'pytorch_model-00010-of-00015.bin',
 'pytorch_model-00011-of-00015.bin',
 'pytorch_model-00012-of-00015.bin',
 'pytorch_model-00013-of-00015.bin',
 'pytorch_model-00014-of-00015.bin',
 'pytorch_model-00015-of-00015.bin']
```