### PR TITLE
Ensure that user does not resume training a model with LoRA and custo…

### DIFF
--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -439,7 +439,7 @@ class KDRecipeDistributed(FTRecipeInterface):
         # LoRA weights + trainable base params
         if self._resume_from_checkpoint:
             for k, v in model.named_parameters():
-                if v.requires_grad() and k not in adapter_params:
+                if v.requires_grad and k not in adapter_params:
                     raise ValueError(
                         f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
                         "no way to merge the base params with the LoRA weights."

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -432,8 +432,18 @@ class KDRecipeDistributed(FTRecipeInterface):
         with training.set_default_dtype(self._dtype), torch.device("meta"):
             model = config.instantiate(cfg_model)
 
-        self.adapter_params = get_adapter_params(model)
-        set_trainable_params(model, self.adapter_params)
+        adapter_params = get_adapter_params(model)
+        set_trainable_params(model, adapter_params)
+
+        # TODO: Remove this when we have a better way to handle saving/loading of
+        # LoRA weights + trainable base params
+        if self._resume_from_checkpoint:
+            for k, v in model.named_parameters():
+                if v.requires_grad() and k not in adapter_params:
+                    raise ValueError(
+                        f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
+                        "no way to merge the base params with the LoRA weights."
+                    )
 
         if self._compile:
             training.compile_model(model, verbose=self._is_rank_zero)

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -405,7 +405,18 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         self._apply_lora_to_output = getattr(cfg_model, "apply_lora_to_output", False)
         self.adapter_params = get_adapter_params(model)
         self._is_dora = any(["magnitude" in k for k in self.adapter_params.keys()])
-        set_trainable_params(model, self.adapter_params)
+        adapter_params = get_adapter_params(model)
+        set_trainable_params(model, adapter_params)
+
+        # TODO: Remove this when we have a better way to handle saving/loading of
+        # LoRA weights + trainable base params
+        if self._resume_from_checkpoint:
+            for k, v in model.named_parameters():
+                if v.requires_grad() and k not in adapter_params:
+                    raise ValueError(
+                        f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
+                        "no way to merge the base params with the LoRA weights."
+                    )
 
         if compile_model:
             training.compile_model(model)

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -412,7 +412,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         # LoRA weights + trainable base params
         if self._resume_from_checkpoint:
             for k, v in model.named_parameters():
-                if v.requires_grad() and k not in adapter_params:
+                if v.requires_grad and k not in adapter_params:
                     raise ValueError(
                         f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
                         "no way to merge the base params with the LoRA weights."

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -358,8 +358,18 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         with training.set_default_dtype(self._dtype), torch.device("meta"):
             model = config.instantiate(cfg_model)
 
-        self.adapter_params = get_adapter_params(model)
-        set_trainable_params(model, self.adapter_params)
+        adapter_params = get_adapter_params(model)
+        set_trainable_params(model, adapter_params)
+
+        # TODO: Remove this when we have a better way to handle saving/loading of
+        # LoRA weights + trainable base params
+        if self._resume_from_checkpoint:
+            for k, v in model.named_parameters():
+                if v.requires_grad() and k not in adapter_params:
+                    raise ValueError(
+                        f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
+                        "no way to merge the base params with the LoRA weights."
+                    )
 
         if enable_activation_checkpointing:
             training.set_activation_checkpointing(

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -365,7 +365,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         # LoRA weights + trainable base params
         if self._resume_from_checkpoint:
             for k, v in model.named_parameters():
-                if v.requires_grad() and k not in adapter_params:
+                if v.requires_grad and k not in adapter_params:
                     raise ValueError(
                         f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
                         "no way to merge the base params with the LoRA weights."

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -290,8 +290,18 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self._apply_lora_to_mlp = cfg_model.apply_lora_to_mlp
         self._apply_lora_to_output = getattr(cfg_model, "apply_lora_to_output", False)
         self.adapter_params = get_adapter_params(model)
-        set_trainable_params(model, self.adapter_params)
+        adapter_params = get_adapter_params(model)
+        set_trainable_params(model, adapter_params)
 
+        # TODO: Remove this when we have a better way to handle saving/loading of
+        # LoRA weights + trainable base params
+        if self._resume_from_checkpoint:
+            for k, v in model.named_parameters():
+                if v.requires_grad() and k not in adapter_params:
+                    raise ValueError(
+                        f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
+                        "no way to merge the base params with the LoRA weights."
+                    )
         if enable_activation_checkpointing:
             training.set_activation_checkpointing(
                 model, auto_wrap_policy={modules.TransformerSelfAttentionLayer}

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -297,7 +297,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         # LoRA weights + trainable base params
         if self._resume_from_checkpoint:
             for k, v in model.named_parameters():
-                if v.requires_grad() and k not in adapter_params:
+                if v.requires_grad and k not in adapter_params:
                     raise ValueError(
                         f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
                         "no way to merge the base params with the LoRA weights."

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -459,7 +459,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # LoRA weights + trainable base params
         if self._resume_from_checkpoint:
             for k, v in model.named_parameters():
-                if v.requires_grad() and k not in adapter_params:
+                if v.requires_grad and k not in adapter_params:
                     raise ValueError(
                         f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
                         "no way to merge the base params with the LoRA weights."

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -438,7 +438,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         # LoRA weights + trainable base params
         if self._resume_from_checkpoint:
             for k, v in model.named_parameters():
-                if v.requires_grad() and k not in adapter_params:
+                if v.requires_grad and k not in adapter_params:
                     raise ValueError(
                         f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
                         "no way to merge the base params with the LoRA weights."

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -431,7 +431,18 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._apply_lora_to_output = getattr(cfg_model, "apply_lora_to_output", False)
         self.adapter_params = get_adapter_params(model)
         self._is_dora = any(["magnitude" in k for k in self.adapter_params.keys()])
-        set_trainable_params(model, self.adapter_params)
+        adapter_params = get_adapter_params(model)
+        set_trainable_params(model, adapter_params)
+
+        # TODO: Remove this when we have a better way to handle saving/loading of
+        # LoRA weights + trainable base params
+        if self._resume_from_checkpoint:
+            for k, v in model.named_parameters():
+                if v.requires_grad() and k not in adapter_params:
+                    raise ValueError(
+                        f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
+                        "no way to merge the base params with the LoRA weights."
+                    )
 
         if compile_model:
             training.compile_model(model)

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -490,7 +490,18 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
             model = config.instantiate(cfg_model)
             self._convert_model_to_qat(model, quantizer_cfg)
 
-        set_trainable_params(model, get_adapter_params(model))
+        adapter_params = get_adapter_params(model)
+        set_trainable_params(model, adapter_params)
+
+        # TODO: Remove this when we have a better way to handle saving/loading of
+        # LoRA weights + trainable base params
+        if self._resume_from_checkpoint:
+            for k, v in model.named_parameters():
+                if v.requires_grad() and k not in adapter_params:
+                    raise ValueError(
+                        f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
+                        "no way to merge the base params with the LoRA weights."
+                    )
 
         if self._compile:
             training.compile_model(model, verbose=self._is_rank_zero)

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -497,7 +497,7 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # LoRA weights + trainable base params
         if self._resume_from_checkpoint:
             for k, v in model.named_parameters():
-                if v.requires_grad() and k not in adapter_params:
+                if v.requires_grad and k not in adapter_params:
                     raise ValueError(
                         f"Found a trainable base param: {k}. This is not allowed when resuming from training b/c we have "
                         "no way to merge the base params with the LoRA weights."


### PR DESCRIPTION
…m trainable params

#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
