### PR TITLE
Fix `adapter_config.json` saving in DPO recipes

### DIFF
--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -26,6 +26,7 @@ from torchtune.modules.peft import (
     DoRALinear,
     get_adapter_params,
     get_adapter_state_dict,
+    get_lora_module_names,
     get_merged_lora_ckpt,
     LoRALinear,
     set_trainable_params,
@@ -595,6 +596,17 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     }
                 )
 
+            adapter_config = {
+                "r": self._lora_rank,
+                "lora_alpha": self._lora_alpha,
+                "target_modules": get_lora_module_names(
+                    self._lora_attn_modules,
+                    self._apply_lora_to_mlp,
+                    self._apply_lora_to_output,
+                ),
+                "peft_type": "LORA",
+            }
+            checkpoint_dict.update({training.ADAPTER_CONFIG: adapter_config})
             self._checkpointer.save_checkpoint(
                 checkpoint_dict,
                 epoch=epoch,

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -24,6 +24,7 @@ from torchtune.modules.peft import (
     disable_adapter,
     get_adapter_params,
     get_adapter_state_dict,
+    get_lora_module_names,
     get_merged_lora_ckpt,
     set_trainable_params,
     validate_missing_and_unexpected_for_lora,
@@ -447,6 +448,18 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             )
 
             ckpt_dict.update({training.MODEL_KEY: merged_state_dict})
+
+        adapter_config = {
+            "r": self._lora_rank,
+            "lora_alpha": self._lora_alpha,
+            "target_modules": get_lora_module_names(
+                self._lora_attn_modules,
+                self._apply_lora_to_mlp,
+                self._apply_lora_to_output,
+            ),
+            "peft_type": "LORA",
+        }
+        ckpt_dict.update({training.ADAPTER_CONFIG: adapter_config})
 
         self._checkpointer.save_checkpoint(
             ckpt_dict,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Closes #2159 

#### Changelog
What are the changes made in this PR?
* Saving `adapter_config.json` in the recipes.

Running
```bash
root@53555da4568b:~/torchtune# tune run lora_dpo_single_device --config llama3_1/8B_lora_dpo_single_device  max_steps_per_epoch=5
...
root@53555da4568b:~/torchtune# tune run --nnodes 1 --nproc_per_node 2 lora_dpo_distributed --config llama3_1/8B_lora_dpo max_steps_per_epoch=5
```
Single device:

```python
from peft import PeftModel
from transformers import AutoModelForCausalLM, AutoTokenizer

token="NICE TRY"
base_model_path= "/workspace/Meta-Llama-3.1-8B-Instruct/"
trained_model_path_single_device = "/workspace/torchtune/llama3_1_8B/lora_dpo_single_device/epoch_0"

model = AutoModelForCausalLM.from_pretrained(base_model_path, token=token)
peft_model = PeftModel.from_pretrained(model, trained_model_path_single_device)
print("Good job! I'm proud of you")
# ------ On main
# Traceback (most recent call last):
#   File "/root/torchtune/test.py", line 11, in <module>
#     peft_model = PeftModel.from_pretrained(model, trained_model_path)
#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "/usr/local/lib/python3.11/dist-packages/peft/peft_model.py", line 479, in from_pretrained
#     PeftConfig._get_peft_type(
#   File "/usr/local/lib/python3.11/dist-packages/peft/config.py", line 263, in _get_peft_type
#     raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}'")
# ValueError: Can't find 'adapter_config.json' at /workspace/torchtune/llama3_1_8B/lora_dpo_single_device/epoch_0/'
# ------ This branch
# Good job! I'm proud of you
```
Distributed: 

```python
from peft import PeftModel
from transformers import AutoModelForCausalLM, AutoTokenizer

token="NICE TRY"
base_model_path= "/workspace/Meta-Llama-3.1-8B-Instruct/"
trained_model_path_distributed= "/workspace/torchtune/llama3_1_8B/lora_dpo/epoch_0/"

model = AutoModelForCausalLM.from_pretrained(base_model_path, token=token)
peft_model = PeftModel.from_pretrained(model, trained_model_path_distributed)
print("Good job! I'm proud of you")
# ------ On main
# Traceback (most recent call last):
#   File "/root/torchtune/test_dist.py", line 10, in <module>
#     peft_model = PeftModel.from_pretrained(model, trained_model_path_distributed)
#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "/usr/local/lib/python3.11/dist-packages/peft/peft_model.py", line 479, in from_pretrained
#     PeftConfig._get_peft_type(
#   File "/usr/local/lib/python3.11/dist-packages/peft/config.py", line 263, in _get_peft_type
#     raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}'")
# ValueError: Can't find 'adapter_config.json' at '/workspace/torchtune/llama3_1_8B/lora_dpo/epoch_0'
# ------ This branch
# "Good job! I'm proud of you"
```

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
