### PR TITLE
change saving logic

### DIFF
--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -19,7 +19,6 @@ from torchtune.models import convert_weights
 from torchtune.training.checkpointing._utils import (
     ADAPTER_CONFIG_FNAME,
     ADAPTER_MODEL_FNAME,
-    BASE_MODEL_DIRNAME,
     copy_files,
     get_adapter_checkpoint_path,
     get_model_checkpoint_path,
@@ -157,14 +156,6 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         self._model_type = ModelType[model_type]
         self._output_dir = Path(output_dir)
         self._output_dir.mkdir(parents=True, exist_ok=True)
-
-        # save all files in input_dir, except model weights and mapping, to output_dir
-        # this is useful to preserve the tokenizer, configs, license, etc.
-        copy_files(
-            self._checkpoint_dir,
-            Path.joinpath(self._output_dir, BASE_MODEL_DIRNAME),
-            ignore_suffixes=SUFFIXES_TO_NOT_COPY,
-        )
 
         #  resume from adapter_model ckpt
         self._adapter_checkpoint = get_adapter_checkpoint_path(
@@ -309,6 +300,14 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 "Adapter checkpoint not found in state_dict. Please ensure that the state_dict contains adapter weights."
             )
 
+        # Save all files in ckpt_dir, except model weights and mapping, to output_dir/epoch_{epoch}
+        # So its easy to run inference with the model using this epoch's checkpoint
+        copy_files(
+            self._checkpoint_dir,
+            Path.joinpath(self._output_dir, f"epoch_{epoch}"),
+            ignore_suffixes=SUFFIXES_TO_NOT_COPY,
+        )
+
         # If the recipe state needs to be output, first remove the model state dict
         if intermediate_checkpoint:
             _ = state_dict.pop(training.MODEL_KEY, None)
@@ -401,14 +400,6 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         # the config.json file contains model params needed for state dict conversion
         self._config = json.loads(
             Path.joinpath(self._checkpoint_dir, "config.json").read_text()
-        )
-
-        # save all files in input_dir, except model weights and mapping, to output_dir
-        # this is useful to preserve the tokenizer, configs, license, etc.
-        copy_files(
-            self._checkpoint_dir,
-            Path.joinpath(self._output_dir, BASE_MODEL_DIRNAME),
-            ignore_suffixes=SUFFIXES_TO_NOT_COPY,
         )
 
         # repo_id is necessary for when saving an adapter config, so its compatible with HF.
@@ -840,6 +831,14 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     f"saved to {output_path}"
                 )
 
+        # Save all files in ckpt_dir, except model weights and mapping, to output_dir/epoch_{epoch}
+        # So its easy to run inference with the model using this epoch's checkpoint
+        copy_files(
+            self._checkpoint_dir,
+            Path.joinpath(self._output_dir, f"epoch_{epoch}"),
+            ignore_suffixes=SUFFIXES_TO_NOT_COPY,
+        )
+
         # If the recipe state needs to be output, first remove the model state dict
         # and if it exists, remove the adapter state dict as well
         if intermediate_checkpoint:
@@ -923,14 +922,6 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
         self._model_type = ModelType[model_type]
         self._output_dir = Path(output_dir)
         self._output_dir.mkdir(parents=True, exist_ok=True)
-
-        # save all files in input_dir, except model weights and mapping, to output_dir
-        # this is useful to preserve the tokenizer, configs, license, etc.
-        copy_files(
-            self._checkpoint_dir,
-            Path.joinpath(self._output_dir, BASE_MODEL_DIRNAME),
-            ignore_suffixes=SUFFIXES_TO_NOT_COPY,
-        )
 
         #  resume from adapter_model ckpt
         self._adapter_checkpoint = get_adapter_checkpoint_path(
@@ -1083,6 +1074,14 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
             raise ValueError(
                 "Adapter checkpoint not found in state_dict. Please ensure that the state_dict contains adapter weights."
             )
+
+        # Save all files in ckpt_dir, except model weights and mapping, to output_dir/epoch_{epoch}
+        # So its easy to run inference with the model using this epoch's checkpoint
+        copy_files(
+            self._checkpoint_dir,
+            Path.joinpath(self._output_dir, f"epoch_{epoch}"),
+            ignore_suffixes=SUFFIXES_TO_NOT_COPY,
+        )
 
         # If the recipe state needs to be output, first remove the model state dict
         # and if it exists, remove the adapter state dict as well

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -382,7 +382,7 @@ def copy_files(
             # Check the file size
             if os.path.getsize(src_file) > max_file_size:
                 print(
-                    f"Skipping copying {src_file} to {output_dir} as it exceeds the size limit of 100 MiB."
+                    f"Skipping copying {src_file} to {output_dir} as it exceeds the size limit of {max_file_size_mb} MiB."
                 )
                 continue
 

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -38,7 +38,6 @@ TORCH_INDEX_FNAME = "pytorch_model.bin.index.json"
 # standardize checkpointing
 SHARD_FNAME = "ft-model-{cpt_idx}-of-{num_shards}"
 RECIPE_STATE_DIRNAME = "recipe_state"
-BASE_MODEL_DIRNAME = "base_model"
 
 # Needed when setting up output dir in checkpointing
 REPO_ID_FNAME = "original_repo_id"
@@ -330,6 +329,7 @@ def copy_files(
     output_dir: Union[str, Path],
     *,
     ignore_suffixes: Optional[List[str]] = None,
+    max_file_size_mb: int = 100,
 ) -> None:
     """
     Copies files from the input directory to the output directory, preserving the directory structure.
@@ -342,6 +342,7 @@ def copy_files(
         output_dir (Union[str, Path]): The path to the output directory where files should be copied.
         ignore_suffixes (Optional[List[str]]): A list of file suffixes to exclude from copying.
           Defaults to ['.pt', '.bin', '.safetensors'] if not provided.
+        max_file_size_mb (int): The maximum file size in megabytes to copy. Defaults to 100 MB.
     Returns:
         None
     Example:
@@ -351,6 +352,7 @@ def copy_files(
     already exist in the destination or have the specified suffixes.
     """
 
+    max_file_size = max_file_size_mb * 1024 * 1024
     for root, dirs, files in os.walk(input_dir):
 
         # Filter out directories that start with '.'. E.g. ".cache/"
@@ -376,6 +378,13 @@ def copy_files(
 
             src_file = os.path.join(root, file)
             dest_file = os.path.join(dest_dir, file)
+
+            # Check the file size
+            if os.path.getsize(src_file) > max_file_size:
+                print(
+                    f"Skipping copying {src_file} to {output_dir} as it exceeds the size limit of 100 MiB."
+                )
+                continue
 
             # Copy the file if it doesn't already exist in the destination
             if not os.path.exists(dest_file):


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
- Instead of saving model files to output_dir/base_model, we save them to output_dir/epoch_{}. That way, every epoch is ready for inference, without requiring an extra step. In the future, we can design this extra step better, e.g. 'tune prepare_for_inference args'
- Have a file size limit of 100MiB. All expected files are configs + tokenizer, so they shouldn't be larger than that.

#### Test plan
tree -a /tmp/torchtune/llama3_2_3B/full_single_device
![image](https://github.com/user-attachments/assets/8a2cb9f8-2db9-4554-9b12-dea8ce908c4f)

testing with HF
![image](https://github.com/user-attachments/assets/591693a2-24f7-494b-9cfb-3fc00a363bb0)

resuming from ckpt
![image](https://github.com/user-attachments/assets/61baa9a3-acb5-4567-9526-33c97ab4a779)


