### PR TITLE
Add output dir to top of all configs

### DIFF
--- a/recipes/configs/eleuther_evaluation.yaml
+++ b/recipes/configs/eleuther_evaluation.yaml
@@ -3,6 +3,8 @@
 # To launch, run the following command from root torchtune directory:
 #    tune run eleuther_eval --config eleuther_evaluation tasks=["truthfulqa_mc2","hellaswag"]
 
+output_dir: ./ # Not needed
+
 # Model Arguments
 model:
   _component_: torchtune.models.llama2.llama2_7b
@@ -14,7 +16,7 @@ checkpointer:
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin,
   ]
-  output_dir: /tmp/Llama-2-7b-hf
+  output_dir: ${output_dir}
   model_type: LLAMA2
 
 # Tokenizer

--- a/recipes/configs/gemma/evaluation.yaml
+++ b/recipes/configs/gemma/evaluation.yaml
@@ -3,6 +3,8 @@
 # To launch, run the following command:
 #    tune run eleuther_eval --config gemma/evaluation
 
+output_dir: ./ # Not needed
+
 # Model Arguments
 model:
   _component_: torchtune.models.gemma.gemma_2b
@@ -15,7 +17,7 @@ checkpointer:
     model-00001-of-00002.safetensors,
     model-00002-of-00002.safetensors,
   ]
-  output_dir: ./ # Not needed
+  output_dir: ${output_dir}
   model_type: GEMMA
 
 # Tokenizer

--- a/recipes/configs/generation.yaml
+++ b/recipes/configs/generation.yaml
@@ -3,6 +3,8 @@
 # To launch, run the following command from root torchtune directory:
 #    tune run generate --config generation
 
+output_dir: ./ # Not needed
+
 # Model arguments
 model:
   _component_: torchtune.models.llama2.llama2_7b
@@ -14,7 +16,7 @@ checkpointer:
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin,
   ]
-  output_dir: /tmp/Llama-2-7b-hf/
+  output_dir: ${output_dir}
   model_type: LLAMA2
 
 device: cuda

--- a/recipes/configs/llama2/generation_v2.yaml
+++ b/recipes/configs/llama2/generation_v2.yaml
@@ -6,6 +6,8 @@
 # To launch, run the following command:
 #    tune run dev/generate_v2 --config llama2/generation_v2
 
+output_dir: ./ # Not needed
+
 # Model arguments
 model:
   _component_: torchtune.models.llama2.llama2_7b
@@ -24,7 +26,7 @@ checkpointer:
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin
   ]
-  output_dir: ./
+  output_dir: ${output_dir}
   model_type: LLAMA2
 
 # Device

--- a/recipes/configs/llama3_2_vision/11B_evaluation.yaml
+++ b/recipes/configs/llama3_2_vision/11B_evaluation.yaml
@@ -9,6 +9,8 @@
 # To launch, run the following command from root torchtune directory:
 #    tune run eleuther_eval --config llama3_2_vision/11B_evaluation
 
+output_dir: ./ # Not needed
+
 # Model arguments
 model:
   _component_: torchtune.models.llama3_2_vision.llama3_2_vision_11b
@@ -26,7 +28,7 @@ checkpointer:
   checkpoint_files:
     filename_format: model-{}-of-{}.safetensors
     max_filename: "00005"
-  output_dir: ./
+  output_dir: ${output_dir}
   model_type: LLAMA3_VISION
 
 # Environment

--- a/recipes/configs/llama3_2_vision/11B_generation_v2.yaml
+++ b/recipes/configs/llama3_2_vision/11B_generation_v2.yaml
@@ -7,6 +7,8 @@
 # To launch, run the following command from root torchtune directory:
 #    tune run dev/generate_v2 --config llama3_2_vision/generation_v2
 
+output_dir: ./ # Not needed
+
 # Model arguments
 model:
   _component_: torchtune.models.llama3_2_vision.llama3_2_vision_11b
@@ -25,7 +27,7 @@ checkpointer:
   checkpoint_files:
     filename_format: model-{}-of-{}.safetensors
     max_filename: "00005"
-  output_dir: ./
+  output_dir: ${output_dir}
   model_type: LLAMA3_VISION
 
 # Device

--- a/recipes/configs/mistral/evaluation.yaml
+++ b/recipes/configs/mistral/evaluation.yaml
@@ -3,6 +3,8 @@
 # To launch, run the following command:
 #    tune run eleuther_eval --config mistral/evaluation
 
+output_dir: ./ # Not needed
+
 # Model Arguments
 model:
   _component_: torchtune.models.mistral.mistral_7b
@@ -15,7 +17,7 @@ checkpointer:
     pytorch_model-00001-of-00002.bin,
     pytorch_model-00002-of-00002.bin
   ]
-  output_dir: /tmp/Mistral-7B-v0.1/
+  output_dir: ${output_dir}
   model_type: MISTRAL
 resume_from_checkpoint: False
 

--- a/recipes/configs/phi3/evaluation.yaml
+++ b/recipes/configs/phi3/evaluation.yaml
@@ -3,6 +3,8 @@
 # To launch, run the following command:
 #    tune run eleuther_eval --config phi3/evaluation
 
+output_dir: ./ # Not needed
+
 # Model Arguments
 model:
   _component_: torchtune.models.phi3.phi3_mini
@@ -16,7 +18,7 @@ checkpointer:
     model-00002-of-00002.safetensors
   ]
   recipe_checkpoint: null
-  output_dir: /tmp/Phi-3-mini-4k-instruct
+  output_dir: ${output_dir}
   model_type: PHI3_MINI
 resume_from_checkpoint: False
 

--- a/recipes/configs/quantization.yaml
+++ b/recipes/configs/quantization.yaml
@@ -3,6 +3,8 @@
 # To launch, run the following command from root torchtune directory:
 #    tune run quantize --config quantization
 
+output_dir: /tmp/torchtune/llama2_7B/quantized # /tmp may be deleted by your system. Change it to your preference.
+
 #
 # Model arguments
 model:
@@ -16,7 +18,7 @@ checkpointer:
     pytorch_model-00002-of-00002.bin,
   ]
   recipe_checkpoint: null
-  output_dir: /tmp/Llama-2-7b-hf
+  output_dir: ${output_dir}
   model_type: LLAMA2
 
 device: cuda

--- a/recipes/configs/qwen2/evaluation.yaml
+++ b/recipes/configs/qwen2/evaluation.yaml
@@ -3,6 +3,8 @@
 # To launch, run the following command:
 #    tune run eleuther_eval --config qwen2/evaluation
 
+output_dir: ./ # Not needed
+
 # Model Arguments
 model:
   _component_: torchtune.models.qwen2.qwen2_7b
@@ -17,7 +19,7 @@ checkpointer:
     model-00003-of-00004.safetensors,
     model-00004-of-00004.safetensors
   ]
-  output_dir: ./ # Not needed
+  output_dir: ${output_dir}
   model_type: QWEN2
 
 # Tokenizer

--- a/recipes/dev/7B_full_early_exit.yaml
+++ b/recipes/dev/7B_full_early_exit.yaml
@@ -93,8 +93,7 @@ dtype: bf16
 # Logging
 metric_logger:
   _component_: torchtune.training.metric_logging.DiskLogger
-  log_dir: ${output_dir}
-output_dir: /tmp/topv2-llama2-finetune
+  log_dir: ${output_dir}/logs
 log_every_n_steps: 1
 log_peak_memory_stats: True
 

--- a/recipes/dev/7B_full_early_exit.yaml
+++ b/recipes/dev/7B_full_early_exit.yaml
@@ -30,6 +30,7 @@
 # This config works best for distributed training, hence when the model is being fine-tuned on 2+ GPUs.
 #
 
+output_dir: /tmp/torchtune/llama2_7b/full_early_exit # /tmp may be deleted by your system. Change it to your preference.
 
 # Tokenizer
 tokenizer:
@@ -61,7 +62,7 @@ checkpointer:
     pytorch_model-00002-of-00002.bin
   ]
   recipe_checkpoint: null
-  output_dir: /tmp/Llama-2-7b-hf
+  output_dir: ${output_dir}
   model_type: LLAMA2
 resume_from_checkpoint: False
 


### PR DESCRIPTION
A bunch of our generation and eval configs don't match the format of our finetuning configs where the output_dir is at the top. This PR moves them to match the same format. It's a no-op for most configs touched here since output_dir is not used by generation or eval configs, but this way that's clear right at the top. The two configs that are not no-ops are early exit and quantization configs. This PR also helps ensure that `output_dir != checkpoint_dir` in all our configs. This is a constraint that we will now be enforcing so that we don't pollute HF's cached files with our finetuning artifacts


Script to find the files to update:
```
#!/bin/bash
find_yaml_files() {
  local dir="$1"
  while IFS= read -r -d '' file; do
    first_line=$(grep -v '^ *#' "$file" | sed '/^$/d' | head -n 1)
    if [[ ! $first_line = output_dir* ]]; then
      echo "$file"
    fi
  done < <(find "$dir" -type f -name '*.yaml' -print0)
}
find_yaml_files "/data/users/ebs/ebs-torchtune-alt/recipes"
```

## Test plan: 

### Quantize recipe

```
tune run quantize --config quantization
...
INFO:torchtune.utils._logging:Model checkpoint of size 6.49 GiB saved to /tmp/torchtune/llama2_7B/quantized/pytorch_model-00001-of-00002-8da4w.pt
```

### Early exit recipe

```
tune run --nnodes 1 --nproc_per_node 4 dev/early_exit_finetune_distributed --config recipes/dev/7B_full_early_exit.yaml max_steps_per_epoch=10
...
INFO:torchtune.utils._logging:Model checkpoint of size 9.29 GiB saved to /tmp/torchtune/llama2_7b/full_early_exit/epoch_0/ft-model-00001-of-00002.safetensors
INFO:torchtune.utils._logging:Model checkpoint of size 3.26 GiB saved to /tmp/torchtune/llama2_7b/full_early_exit/epoch_0/ft-model-00002-of-00002.safetensors
INFO:torchtune.utils._logging:Saving final epoch checkpoint.
INFO:torchtune.utils._logging:The full model checkpoint, including all weights and configurations, has been saved successfully.You can now use this checkpoint for further training or inference.
```

### Generate V2 recipe

```
tune run dev/generate_v2 --config llama2/generation_v2
...
 Oh, how delightful! *adjusts glasses* The capital of France is... *drumroll* Paris! 🇫🇷 Yes, the City of Light, the City of Love, the City of Art... *sigh* You know, I've always wanted to visit Paris. It's on my AI bucket list. 😍 How about you? Have you been to Paris? 🤔
```

