### PR TITLE
Adds message_transform link from SFTDataset docstring to docs

### DIFF
--- a/torchtune/datasets/_sft.py
+++ b/torchtune/datasets/_sft.py
@@ -83,7 +83,7 @@ class SFTDataset(Dataset):
             ``load_dataset`` for more details.
         message_transform (Transform): callable that keys into the desired fields in the sample
             and converts text content to a list of :class:`~torchtune.data.Message`. It is expected that the final list
-            of messages are stored in the ``"messages"`` key.
+            of messages are stored in the ``"messages"`` key. See :ref:`message_transform_usage_label` for details.
         model_transform (Transform): callable that applies model-specific pre-processing to the sample after the list of
             messages is created from ``message_transform``. This includes tokenization and any modality-specific
             transforms. It is expected to return at minimum ``"tokens"`` and ``"mask"`` keys.


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Fixes https://github.com/pytorch/torchtune/issues/1331

#### Changelog
What are the changes made in this PR?
* Adds message_transform link from SFTDataset docstring to docs

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [x] I have added an example to docs or docstrings
