### PR TITLE
Remove example inputs from aoti_compile_and_package

### DIFF
--- a/tests/torchtune/modules/_export/test_export_position_embeddings.py
+++ b/tests/torchtune/modules/_export/test_export_position_embeddings.py
@@ -161,7 +161,6 @@ class TiledTokenPositionalEmbeddingTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = torch._inductor.aoti_compile_and_package(
                 tpe_ep,
-                (self.x, self.aspect_ratio),
                 package_path=os.path.join(tmpdir, "tpe.pt2"),
             )
             tpe_aoti = load_package(path)


### PR DESCRIPTION
Summary: The args were removed in https://github.com/pytorch/pytorch/pull/140991

Differential Revision: D67998952


