### PR TITLE
Update QuantizationRecipe to use checkpointer.save_checkpoint

### DIFF
--- a/recipes/quantize.py
+++ b/recipes/quantize.py
@@ -51,12 +51,13 @@ class QuantizationRecipe:
         training.set_seed(seed=cfg.seed)
 
     def load_checkpoint(self, checkpointer_cfg: DictConfig) -> Dict[str, Any]:
-        logger.info(
-            "Setting safe_serialization to False. TorchAO quantization is compatible "
-            "only with HuggingFace's non-safetensor serialization and deserialization."
-        )
-        checkpointer_cfg.safe_serialization = False
         self._checkpointer = config.instantiate(checkpointer_cfg)
+        if hasattr(self._checkpointer, "_safe_serialization"):
+            logger.info(
+                "Setting safe_serialization to False. TorchAO quantization is compatible "
+                "only with HuggingFace's non-safetensor serialization and deserialization."
+            )
+            self._checkpointer._safe_serialization = False
         checkpoint_dict = self._checkpointer.load_checkpoint()
         return checkpoint_dict
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [X] other (refactor)

Please link to any issues this PR addresses #2229 

#### Changelog
What are the changes made in this PR?
* Simplified `save_checkpoint` method by making use of `checkpointer.save_checkpoint` instead of custom implementation.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [X] manually run any new or modified recipes with sufficient proof of correctness
- [X] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

Quantization recipe:
```yaml

# Config for QuantizationRecipe in quantize.py
#
# To launch, run the following command from root torchtune directory:
#    tune download Qwen/Qwen2.5-0.5B-Instruct --output-dir /tmp/Qwen2_5-0_5B-Instruct
#    tune run quantize --config quantization

output_dir: ./quantized # /tmp may be deleted by your system. Change it to your preference.

#
# Model arguments
model:
  _component_: torchtune.models.qwen2_5.qwen2_5_0_5b

checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Qwen2_5-0_5B-Instruct
  checkpoint_files: [model.safetensors]
  recipe_checkpoint: null
  output_dir: ${output_dir}
  model_type: QWEN2

device: cuda
dtype: bf16
seed: 1234

quantizer:
  _component_: torchtune.training.quantization.Int8DynActInt4WeightQuantizer
  groupsize: 256

```

Output:
```bash
(tune) ➜  torchtune git:(refactor/quantization-recipe-save-checkpoint) ✗ tune run quantize --config ./custom_quant.yaml
Running QuantizationRecipe with resolved config:

checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Qwen2_5-0_5B-Instruct
  checkpoint_files:
  - model.safetensors
  model_type: QWEN2
  output_dir: ./quantized
  recipe_checkpoint: null
device: cuda
dtype: bf16
model:
  _component_: torchtune.models.qwen2_5.qwen2_5_0_5b
output_dir: ./quantized
quantizer:
  _component_: torchtune.training.quantization.Int8DynActInt4WeightQuantizer
  groupsize: 256
seed: 1234

Setting manual seed to local seed 1234. Local seed is seed + rank = 1234 + 0
Model is initialized with precision torch.bfloat16.
Time for quantization: 0.08 sec
Memory used: 1.45 GB
Model checkpoint of size 0.82 GiB saved to quantized/epoch_0/ft-model-00001-of-00001.bin
Saving final epoch checkpoint.
The full model checkpoint, including all weights and configurations, has been saved successfully.You can now use this checkpoint for further training or inference.
```

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [X] I did not change any public API
- [ ] I have added an example to docs or docstrings
