### PR TITLE
Fix a bug in set float32 precision

### DIFF
--- a/tests/torchtune/training/test_precision.py
+++ b/tests/torchtune/training/test_precision.py
@@ -57,8 +57,7 @@ class TestPrecisionUtils:
             get_dtype(torch.bfloat16)
 
     @pytest.mark.skipif(not cuda_available, reason="The test requires GPUs to run.")
-    @mock.patch("torchtune.training.precision.is_npu_available", return_value=True)
-    def test_set_float32_precision(self, mock_npu_available) -> None:
+    def test_set_float32_precision(self) -> None:
         setattr(  # noqa: B010
             torch.backends, "__allow_nonbracketed_mutation_flag", True
         )

--- a/torchtune/training/precision.py
+++ b/torchtune/training/precision.py
@@ -34,7 +34,7 @@ def _set_float32_precision(precision: str = "high") -> None:
         precision (str): The setting to determine which datatypes to use for matrix multiplication and convolution operations.
     """
     # Not relevant for non-CUDA or non-NPU devices
-    if not torch.cuda.is_available() or not is_npu_available:
+    if not (torch.cuda.is_available() or is_npu_available):
         return
     # set precision for matrix multiplications
     torch.set_float32_matmul_precision(precision)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
- Fix a bug in _set_float32_precision, it should return without either GPU or NPU.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
