### PR TITLE
Logging resolved config

### DIFF
--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -42,7 +42,6 @@ def save_config(config: DictConfig) -> Path:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         output_config_fname = output_dir / "torchtune_config.yaml"
-        log.info(f"Writing config to {output_config_fname}")
         OmegaConf.save(config, output_config_fname)
         return output_config_fname
     except Exception as e:
@@ -259,7 +258,6 @@ class WandBLogger(MetricLoggerInterface):
             # Also try to save the config as a file
             output_config_fname = save_config(config)
             try:
-                log.info(f"Uploading {output_config_fname} to W&B under Files")
                 self._wandb.save(
                     output_config_fname, base_path=output_config_fname.parent
                 )
@@ -459,7 +457,6 @@ class CometLogger(MetricLoggerInterface):
             # Also try to save the config as a file
             output_config_fname = save_config(config)
             try:
-                log.info(f"Uploading {output_config_fname} to Comet as an asset.")
                 self.experiment.log_asset(
                     output_config_fname, file_name=output_config_fname.name
                 )

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -22,6 +22,7 @@ Scalar = Union[torch.Tensor, ndarray, int, float]
 
 log = get_logger("DEBUG")
 
+
 def save_config(config):
     try:
         output_config_fname = Path(
@@ -30,13 +31,10 @@ def save_config(config):
                 "torchtune_config.yaml",
             )
         )
+        log.info(f"Writing resolved config to {output_config_fname}")
         OmegaConf.save(config, output_config_fname)
-        log.info(f"Logging {output_config_fname}")
     except Exception as e:
-        log.warning(
-            f"Error saving {output_config_fname} to disk.\nError: \n{e}."
-        )
-
+        log.warning(f"Error saving {output_config_fname} to disk.\nError: \n{e}.")
 
 
 class MetricLoggerInterface(Protocol):

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -46,7 +46,7 @@ def save_config(config: DictConfig) -> Path:
         OmegaConf.save(config, output_config_fname)
         return output_config_fname
     except Exception as e:
-        log.warning(f"Error saving config to {output_config_fname}.\nError: \n{e}.")
+        log.warning(f"Error saving config.\nError: \n{e}.")
 
 
 class MetricLoggerInterface(Protocol):
@@ -421,7 +421,8 @@ class CometLogger(MetricLoggerInterface):
             ) from e
 
         # Remove 'log_dir' from kwargs as it is not a valid argument for comet_ml.ExperimentConfig
-        del kwargs["log_dir"]
+        if "log_dir" in kwargs:
+            del kwargs["log_dir"]
 
         _, self.rank = get_world_size_and_rank()
 

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -22,6 +22,22 @@ Scalar = Union[torch.Tensor, ndarray, int, float]
 
 log = get_logger("DEBUG")
 
+def save_config(config):
+    try:
+        output_config_fname = Path(
+            os.path.join(
+                config.output_dir,
+                "torchtune_config.yaml",
+            )
+        )
+        OmegaConf.save(config, output_config_fname)
+        log.info(f"Logging {output_config_fname}")
+    except Exception as e:
+        log.warning(
+            f"Error saving {output_config_fname} to disk.\nError: \n{e}."
+        )
+
+
 
 class MetricLoggerInterface(Protocol):
     """Abstract metric logger."""
@@ -98,6 +114,9 @@ class DiskLogger(MetricLoggerInterface):
     def log(self, name: str, data: Scalar, step: int) -> None:
         self._file.write(f"Step {step} | {name}:{data}\n")
         self._file.flush()
+
+    def log_config(self, config: DictConfig) -> None:
+        save_config(config)
 
     def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         self._file.write(f"Step {step} | ")

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -23,18 +23,30 @@ Scalar = Union[torch.Tensor, ndarray, int, float]
 log = get_logger("DEBUG")
 
 
-def save_config(config):
+def save_config(config: DictConfig) -> Path:
+    """
+    Save the OmegaConf configuration to a YAML file at `{config.output_dir}/torchtune_config.yaml`.
+
+    Args:
+        config (DictConfig): The OmegaConf config object to be saved. It must contain an `output_dir` attribute
+            specifying where the configuration file should be saved.
+
+    Returns:
+        Path: The path to the saved configuration file.
+
+    Note:
+        If the specified `output_dir` does not exist, it will be created.
+    """
     try:
-        output_config_fname = Path(
-            os.path.join(
-                config.output_dir,
-                "torchtune_config.yaml",
-            )
-        )
-        log.info(f"Writing resolved config to {output_config_fname}")
+        output_dir = Path(config.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        output_config_fname = output_dir / "torchtune_config.yaml"
+        log.info(f"Writing config to {output_config_fname}")
         OmegaConf.save(config, output_config_fname)
+        return output_config_fname
     except Exception as e:
-        log.warning(f"Error saving {output_config_fname} to disk.\nError: \n{e}.")
+        log.warning(f"Error saving config to {output_config_fname}.\nError: \n{e}.")
 
 
 class MetricLoggerInterface(Protocol):
@@ -56,7 +68,7 @@ class MetricLoggerInterface(Protocol):
         pass
 
     def log_config(self, config: DictConfig) -> None:
-        """Logs the config
+        """Logs the config as file
 
         Args:
             config (DictConfig): config to log
@@ -114,7 +126,7 @@ class DiskLogger(MetricLoggerInterface):
         self._file.flush()
 
     def log_config(self, config: DictConfig) -> None:
-        save_config(config)
+        _ = save_config(config)
 
     def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         self._file.write(f"Step {step} | ")
@@ -135,6 +147,9 @@ class StdoutLogger(MetricLoggerInterface):
 
     def log(self, name: str, data: Scalar, step: int) -> None:
         print(f"Step {step} | {name}:{data}")
+
+    def log_config(self, config: DictConfig) -> None:
+        _ = save_config(config)
 
     def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         print(f"Step {step} | ", end="")
@@ -200,6 +215,10 @@ class WandBLogger(MetricLoggerInterface):
         # Use dir if specified, otherwise use log_dir.
         self.log_dir = kwargs.pop("dir", log_dir)
 
+        # create log_dir if missing
+        if not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
+
         _, self.rank = get_world_size_and_rank()
 
         if self._wandb.run is None and self.rank == 0:
@@ -236,23 +255,17 @@ class WandBLogger(MetricLoggerInterface):
             self._wandb.config.update(
                 resolved, allow_val_change=self.config_allow_val_change
             )
-            try:
-                output_config_fname = Path(
-                    os.path.join(
-                        config.output_dir,
-                        "torchtune_config.yaml",
-                    )
-                )
-                OmegaConf.save(config, output_config_fname)
 
-                log.info(f"Logging {output_config_fname} to W&B under Files")
+            # Also try to save the config as a file
+            output_config_fname = save_config(config)
+            try:
+                log.info(f"Uploading {output_config_fname} to W&B under Files")
                 self._wandb.save(
                     output_config_fname, base_path=output_config_fname.parent
                 )
-
             except Exception as e:
                 log.warning(
-                    f"Error saving {output_config_fname} to W&B.\nError: \n{e}."
+                    f"Error uploading {output_config_fname} to W&B.\nError: \n{e}."
                     "Don't worry the config will be logged the W&B workspace"
                 )
 
@@ -321,6 +334,9 @@ class TensorBoardLogger(MetricLoggerInterface):
     def log(self, name: str, data: Scalar, step: int) -> None:
         if self._writer:
             self._writer.add_scalar(name, data, global_step=step, new_style=True)
+
+    def log_config(self, config: DictConfig) -> None:
+        _ = save_config(config)
 
     def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
         for name, data in payload.items():
@@ -404,13 +420,15 @@ class CometLogger(MetricLoggerInterface):
                 "Alternatively, use the ``StdoutLogger``, which can be specified by setting metric_logger_type='stdout'."
             ) from e
 
+        # Remove 'log_dir' from kwargs as it is not a valid argument for comet_ml.ExperimentConfig
+        del kwargs["log_dir"]
+
         _, self.rank = get_world_size_and_rank()
 
         # Declare it early so further methods don't crash in case of
         # Experiment Creation failure due to mis-named configuration for
         # example
         self.experiment = None
-
         if self.rank == 0:
             self.experiment = comet_ml.start(
                 api_key=api_key,
@@ -438,24 +456,14 @@ class CometLogger(MetricLoggerInterface):
             self.experiment.log_parameters(resolved)
 
             # Also try to save the config as a file
+            output_config_fname = save_config(config)
             try:
-                self._log_config_as_file(config)
+                log.info(f"Uploading {output_config_fname} to Comet as an asset.")
+                self.experiment.log_asset(
+                    output_config_fname, file_name=output_config_fname.name
+                )
             except Exception as e:
-                log.warning(f"Error saving Config to disk.\nError: \n{e}.")
-                return
-
-    def _log_config_as_file(self, config: DictConfig):
-        output_config_fname = Path(
-            os.path.join(
-                config.checkpointer.checkpoint_dir,
-                "torchtune_config.yaml",
-            )
-        )
-        OmegaConf.save(config, output_config_fname)
-
-        self.experiment.log_asset(
-            output_config_fname, file_name="torchtune_config.yaml"
-        )
+                log.warning(f"Failed to upload config to Comet assets. Error: {e}")
 
     def close(self) -> None:
         if self.experiment is not None:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses #1968 

#### Changelog
What are the changes made in this PR?
* Created `save_config` utility function
* Implemented `DiskLogger.log_config` method

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [X] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

Stdout: 
```bash
(tune) ankur@nuc:~/github/torchtune$ tune run full_finetune_single_device --config llama3_2/1B_full_single_device output_dir=./logs/ max_steps_per_epoch=10 device=cpu optimizer._component_=torch.optim.AdamW
INFO:torchtune.utils._logging:Running FullFinetuneRecipeSingleDevice with resolved config:

batch_size: 4
checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Llama-3.2-1B-Instruct/
  checkpoint_files:
  - model.safetensors
  model_type: LLAMA3_2
  output_dir: ./logs/
  recipe_checkpoint: null
clip_grad_norm: null
compile: false
dataset:
  _component_: torchtune.datasets.alpaca_dataset
  packed: false
device: cpu
dtype: bf16
enable_activation_checkpointing: false
enable_activation_offloading: false
epochs: 1
gradient_accumulation_steps: 1
log_every_n_steps: 1
log_peak_memory_stats: true
loss:
  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
max_steps_per_epoch: 10
metric_logger:
  _component_: torchtune.training.metric_logging.DiskLogger
  log_dir: ./logs//logs
model:
  _component_: torchtune.models.llama3_2.llama3_2_1b
optimizer:
  _component_: torch.optim.AdamW
  lr: 2.0e-05
optimizer_in_bwd: true
output_dir: ./logs/
profiler:
  _component_: torchtune.training.setup_torch_profiler
  active_steps: 2
  cpu: true
  cuda: true
  enabled: false
  num_cycles: 1
  output_dir: ./logs//profiling_outputs
  profile_memory: false
  record_shapes: true
  wait_steps: 5
  warmup_steps: 3
  with_flops: false
  with_stack: false
resume_from_checkpoint: false
seed: null
shuffle: true
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  max_seq_len: null
  path: /tmp/Llama-3.2-1B-Instruct/original/tokenizer.model

INFO:torchtune.utils._logging:log_peak_memory_stats was set to True, however, training does not use cuda. Setting log_peak_memory_stats=False.
DEBUG:torchtune.utils._logging:Setting manual seed to local seed 3022706700. Local seed is seed + rank = 3022706700 + 0
Writing logs to logs/logs/log_1737066872.txt
INFO:torchtune.utils._logging:Writing resolved config to logs/torchtune_config.yaml
INFO:torchtune.utils._logging:Model is initialized with precision torch.bfloat16.
INFO:torchtune.utils._logging:Tokenizer is initialized from file.
INFO:torchtune.utils._logging:In-backward optimizers are set up.
INFO:torchtune.utils._logging:Loss is initialized.
INFO:torchtune.utils._logging:Dataset and Sampler are initialized.
INFO:torchtune.utils._logging:No learning rate scheduler configured. Using constant learning rate.
WARNING:torchtune.utils._logging: Profiling disabled.
INFO:torchtune.utils._logging: Profiler config after instantiation: {'enabled': False}
1|10|Loss: 1.088627576828003: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:33<00:00,  3.01s/it]INFO:torchtune.utils._logging:Model checkpoint of size 2.30 GiB saved to logs/epoch_0/ft-model-00001-of-00001.safetensors
INFO:torchtune.utils._logging:Saving final epoch checkpoint.
INFO:torchtune.utils._logging:The full model checkpoint, including all weights and configurations, has been saved successfully.You can now use this checkpoint for further training or inference.
1|10|Loss: 1.088627576828003: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:41<00:00,  4.15s/it]
```

Generated Log file at `./logs/torchtune_config.yaml`:
```yaml
output_dir: ./logs/
model:
  _component_: torchtune.models.llama3_2.llama3_2_1b
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  path: /tmp/Llama-3.2-1B-Instruct/original/tokenizer.model
  max_seq_len: null
dataset:
  _component_: torchtune.datasets.alpaca_dataset
  packed: false
seed: null
shuffle: true
checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /tmp/Llama-3.2-1B-Instruct/
  checkpoint_files:
  - model.safetensors
  recipe_checkpoint: null
  output_dir: ${output_dir}
  model_type: LLAMA3_2
resume_from_checkpoint: false
batch_size: 4
epochs: 1
optimizer:
  _component_: torch.optim.AdamW
  lr: 2.0e-05
loss:
  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
max_steps_per_epoch: 10
gradient_accumulation_steps: 1
optimizer_in_bwd: true
clip_grad_norm: null
compile: false
device: cpu
enable_activation_checkpointing: false
enable_activation_offloading: false
dtype: bf16
metric_logger:
  _component_: torchtune.training.metric_logging.DiskLogger
  log_dir: ${output_dir}/logs
log_every_n_steps: 1
log_peak_memory_stats: true
profiler:
  _component_: torchtune.training.setup_torch_profiler
  enabled: false
  output_dir: ${output_dir}/profiling_outputs
  cpu: true
  cuda: true
  profile_memory: false
  with_stack: false
  record_shapes: true
  with_flops: false
  wait_steps: 5
  warmup_steps: 3
  active_steps: 2
  num_cycles: 1
```

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [X] I did not change any public API
- [ ] I have added an example to docs or docstrings
