### PR TITLE
Proper prefix handling in EarlyFusion sd hooks

### DIFF
--- a/tests/torchtune/modules/model_fusion/test_early_fusion.py
+++ b/tests/torchtune/modules/model_fusion/test_early_fusion.py
@@ -334,3 +334,17 @@ class TestEarlyFusionModel:
         actual = fused_model.state_dict()
         expected = state_dict
         assert_expected(actual, expected)
+
+    def test_sequential_state_dict_hooks(self, fused_model, state_dict):
+        """
+        Test that state dict hooks work when EarlyFusion is wrapped in a larger model
+        """
+        sequential_model = nn.Sequential(fused_model, nn.Linear(10, 10, bias=False))
+        linear_weight = torch.randn(10, 10)
+        sequential_state_dict = {f"0.{k}": v for k, v in state_dict.items()}
+        sequential_state_dict.update({"1.weight": linear_weight})
+        sequential_model.load_state_dict(sequential_state_dict)
+        actual = sequential_model.state_dict()
+        expected = sequential_state_dict
+        expected.update({"1.weight": linear_weight})
+        assert_expected(actual, expected)

--- a/torchtune/modules/model_fusion/_early_fusion.py
+++ b/torchtune/modules/model_fusion/_early_fusion.py
@@ -130,23 +130,25 @@ class EarlyFusionModel(nn.Module):
         set_trainable_params(self, trainable_params)
 
     @staticmethod
-    def _state_dict_hook(module, state_dict, *args, **kwargs):
+    def _state_dict_hook(module, state_dict, prefix, *args, **kwargs):
         """
         Keep tok_embeddings inside of decoder state_dict
 
         [!Note] This update changes the order of the OrderedDict
         """
         for n, p in module.tok_embeddings.named_parameters():
-            state_dict[f"decoder.tok_embeddings.{n}"] = p
-            del state_dict[f"tok_embeddings.{n}"]
+            state_dict[f"{prefix}decoder.tok_embeddings.{n}"] = p
+            del state_dict[f"{prefix}tok_embeddings.{n}"]
 
     @staticmethod
-    def _load_state_dict_hook(module, state_dict, *args, **kwargs):
+    def _load_state_dict_hook(module, state_dict, prefix, *args, **kwargs):
         """Undo the change from _state_dict_hook"""
         old_keys = list(state_dict.keys())
         for key in old_keys:
-            if key.startswith("decoder.tok_embeddings"):
-                state_dict[key[len("decoder.") :]] = state_dict[key]
+            if "decoder.tok_embeddings" in key:
+                state_dict[prefix + key[len("decoder.") + len(prefix) :]] = state_dict[
+                    key
+                ]
                 del state_dict[key]
 
     def set_num_output_chunks(self, num_output_chunks: int) -> None:


### PR DESCRIPTION
Thanks to @mkrainin for pointing this out and making the initial fix.

Our `EarlyFusion` state dict hooks don't work when an `EarlyFusion` module is wrapped as part of a larger model (as is the case with e.g. DDP). This is because state dict keys in the hooks have global key names, so we can't just use e.g. `del state_dict["decoder.tok_embeddings.weight"]` since `decoder` may not be a top-level module.

The fix is to use the `prefix` arg to state dict hooks, which gets recursively prepended while traversing the module tree ([ref](https://github.com/pytorch/pytorch/blob/a56af029133ba0e87ed4c099e7e4efc40a24e20c/torch/nn/modules/module.py#L1892-L1894)).

## Test plan

Added a unit test wrapping `EarlyFusion` into an `nn.Sequential` so that the state dict keys have integer prefixes. This plus the existing test of state dict hooks pass after these changes:

```
pytest tests/torchtune/modules/model_fusion/test_early_fusion.py
...
================== 12 passed in 0.18s =============
```