### PR TITLE
Fix stop tokens in PPO

### DIFF
--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -357,7 +357,7 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
                     "This may lead to unexpected behaviour."
                 )
         else:
-            if not hasattr(self._tokenizer.stop_tokens):
+            if not hasattr(self._tokenizer, "stop_tokens"):
                 warn(
                     "No stop tokens defined in tokenizer, and no stop_token_ids provided. This may lead to unexpected behaviour."
                 )


### PR DESCRIPTION
Quick fix -- I saw that in the PPO recipe, when determining stop tokens to use for generation, the branch where they're not listed in the config fails due to a simple bug (it was `hasattr(tokenizer.stop_tokens)`, should be `hasattr(tokenizer, "stop_tokens")`. 

I'm guessing it never came up in any tests since the default config lists the tokens explicitly, so this branch is never hit. 




#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
What are the changes made in this PR?
* Fixed reading stop tokens from the tokenizer, if not specified in the config

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
