### PR TITLE
Text-to-Image Dataset and Flux Transform

### DIFF
--- a/tests/torchtune/datasets/test_text_to_image_dataset.py
+++ b/tests/torchtune/datasets/test_text_to_image_dataset.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+
+import pytest
+from PIL import Image
+
+from torchtune.datasets import text_to_image_dataset
+from torchvision import transforms
+
+
+class TestTextToImageDataset:
+    @pytest.fixture
+    def img_dir(self, tmp_path):
+        # Create directory with two small images (one red and one green)
+        img_dir = tmp_path / "img"
+        img_dir.mkdir()
+        Image.new("RGB", (16, 16), (255, 0, 0)).save(img_dir / "0.png")
+        Image.new("RGB", (16, 16), (0, 255, 0)).save(img_dir / "1.png")
+        return img_dir
+
+    def test_text_to_image_dataset(self, tmp_path, img_dir):
+        # Create dataset json file
+        ds_path = tmp_path / "ds.json"
+        with open(ds_path, "w") as f:
+            json.dump(
+                [
+                    {"text": "caption0", "image": "0.png"},
+                    {"text": "caption1", "image": "1.png"},
+                ],
+                f,
+            )
+
+        # Create dataset
+        ds = text_to_image_dataset(
+            _DummyTransform(),
+            source="json",
+            data_files=str(ds_path),
+            image_dir=str(img_dir),
+        )
+
+        assert len(ds) == 2
+
+        # Check first row of data
+        row = ds[0]
+        assert len(row) == 2
+        assert "".join(chr(x) for x in row["text"]) == "caption0"
+        assert row["image"].shape == (3, 16, 16)
+        assert row["image"].mean(dim=(1, 2)).numpy().tolist() == [1.0, 0.0, 0.0]
+
+        # Check second row of data
+        row = ds[1]
+        assert len(row) == 2
+        assert "".join(chr(x) for x in row["text"]) == "caption1"
+        assert row["image"].shape == (3, 16, 16)
+        assert row["image"].mean(dim=(1, 2)).numpy().tolist() == [0.0, 1.0, 0.0]
+
+    def test_include_id(self, tmp_path, img_dir):
+        # Create dataset json file
+        ds_path = tmp_path / "ds.json"
+        with open(ds_path, "w") as f:
+            json.dump(
+                [
+                    {"id": "0", "text": "caption0", "image": "0.png"},
+                    {"id": "1", "text": "caption1", "image": "1.png"},
+                ],
+                f,
+            )
+
+        # Create dataset
+        ds = text_to_image_dataset(
+            _DummyTransform(),
+            source="json",
+            data_files=str(ds_path),
+            image_dir=str(img_dir),
+            include_id=True,
+        )
+
+        assert len(ds) == 2
+        assert len(ds[0]) == 3
+        assert ds[0]["id"] == "0"
+        assert ds[1]["id"] == "1"
+
+    def test_column_map(self, tmp_path, img_dir):
+        # Create dataset json file
+        ds_path = tmp_path / "ds.json"
+        with open(ds_path, "w") as f:
+            json.dump(
+                [
+                    {"text_": "caption0", "image_": "0.png"},
+                    {"text_": "caption1", "image_": "1.png"},
+                ],
+                f,
+            )
+
+        # Create dataset
+        ds = text_to_image_dataset(
+            _DummyTransform(),
+            source="json",
+            data_files=str(ds_path),
+            image_dir=str(img_dir),
+            column_map={"text": "text_", "image": "image_"},
+        )
+
+        assert len(ds) == 2
+        assert len(ds[0]) == 2
+        assert "text" in ds[0]
+        assert "image" in ds[0]
+
+
+class _DummyTransform:
+    def __init__(self):
+        self._img_transform = transforms.ToTensor()
+
+    def __call__(self, sample):
+        return {
+            "image": self._img_transform(sample["image"]),
+            "text": [ord(x) for x in sample["text"]],
+        }

--- a/tests/torchtune/models/flux/test_flux_autoencoder.py
+++ b/tests/torchtune/models/flux/test_flux_autoencoder.py
@@ -27,7 +27,6 @@ class TestFluxAutoencoder:
     @pytest.fixture
     def model(self):
         model = flux_1_autoencoder(
-            resolution=RESOLUTION,
             ch_in=CH_IN,
             ch_out=3,
             ch_base=32,

--- a/tests/torchtune/models/flux/test_flux_flow_model.py
+++ b/tests/torchtune/models/flux/test_flux_flow_model.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from torchtune.models.flux._flow_model import FluxFlowModel
+from torchtune.models.flux._util import predict_noise
+from torchtune.training.seed import set_seed
+
+BSZ = 32
+CH = 4
+RES = 8
+Y_DIM = 16
+TXT_DIM = 8
+
+# model inputs/outputs are sequences of 2x2 latent patches
+MODEL_CH = CH * 4
+
+
+@pytest.fixture(autouse=True)
+def random():
+    set_seed(0)
+
+
+class TestFluxFlowModel:
+    @pytest.fixture
+    def model(self):
+        model = FluxFlowModel(
+            in_channels=MODEL_CH,
+            out_channels=MODEL_CH,
+            vec_in_dim=Y_DIM,
+            context_in_dim=TXT_DIM,
+            hidden_size=16,
+            mlp_ratio=2.0,
+            num_heads=2,
+            depth=1,
+            depth_single_blocks=1,
+            axes_dim=[2, 2, 4],
+            theta=10_000,
+            qkv_bias=True,
+            use_guidance=True,
+        )
+
+        for param in model.parameters():
+            param.data.uniform_(0, 0.1)
+
+        return model
+
+    @pytest.fixture
+    def latents(self):
+        return torch.randn(BSZ, CH, RES, RES)
+
+    @pytest.fixture
+    def clip_encodings(self):
+        return torch.randn(BSZ, Y_DIM)
+
+    @pytest.fixture
+    def t5_encodings(self):
+        return torch.randn(BSZ, 8, TXT_DIM)
+
+    @pytest.fixture
+    def timesteps(self):
+        return torch.rand(BSZ)
+
+    @pytest.fixture
+    def guidance(self):
+        return torch.rand(BSZ) * 3 + 1
+
+    def test_forward(
+        self, model, latents, clip_encodings, t5_encodings, timesteps, guidance
+    ):
+        actual = predict_noise(
+            model, latents, clip_encodings, t5_encodings, timesteps, guidance
+        )
+        assert actual.shape == (BSZ, CH, RES, RES)
+
+        actual = torch.mean(actual, dim=(0, 2, 3))
+        print(actual)
+        expected = torch.tensor([1.9532, 2.0414, 2.2768, 2.2754])
+        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+    def test_backward(
+        self, model, latents, clip_encodings, t5_encodings, timesteps, guidance
+    ):
+        pred = predict_noise(
+            model, latents, clip_encodings, t5_encodings, timesteps, guidance
+        )
+        loss = pred.mean()
+        loss.backward()

--- a/tests/torchtune/models/flux/test_flux_flow_model.py
+++ b/tests/torchtune/models/flux/test_flux_flow_model.py
@@ -4,10 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from copy import deepcopy
+
 import pytest
 import torch
 
 from torchtune.models.flux._flow_model import FluxFlowModel
+from torchtune.models.flux._model_builders import _replace_linear_with_lora
 from torchtune.models.flux._util import predict_noise
 from torchtune.training.seed import set_seed
 
@@ -91,3 +94,49 @@ class TestFluxFlowModel:
         )
         loss = pred.mean()
         loss.backward()
+
+    def test_lora(
+        self, model, latents, clip_encodings, t5_encodings, timesteps, guidance
+    ):
+        # Setup LoRA model
+        lora_model = deepcopy(model)
+        _replace_linear_with_lora(
+            lora_model,
+            rank=2,
+            alpha=2,
+            dropout=0.0,
+            quantize_base=False,
+            use_dora=False,
+        )
+        lora_model.load_state_dict(model.state_dict(), strict=False)
+        lora_model.requires_grad_(False)
+        _lora_enable_grad(lora_model)
+
+        # Check param counts
+        total_params = sum(p.numel() for p in lora_model.parameters())
+        trainable_params = sum(
+            p.numel() for p in lora_model.parameters() if p.requires_grad
+        )
+        assert total_params == 24416
+        assert trainable_params == 3280
+
+        # Check parity with original model
+        pred = predict_noise(
+            model, latents, clip_encodings, t5_encodings, timesteps, guidance
+        )
+        lora_pred = predict_noise(
+            lora_model, latents, clip_encodings, t5_encodings, timesteps, guidance
+        )
+        torch.testing.assert_close(pred, lora_pred, atol=1e-4, rtol=1e-4)
+
+        # Check backward pass works
+        loss = lora_pred.mean()
+        loss.backward()
+
+
+def _lora_enable_grad(module):
+    for name, child in module.named_children():
+        if name.startswith("lora_"):
+            child.requires_grad_(True)
+        else:
+            _lora_enable_grad(child)

--- a/tests/torchtune/models/flux/test_flux_transform.py
+++ b/tests/torchtune/models/flux/test_flux_transform.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from PIL import Image
+
+from tests.common import ASSETS
+from torchtune.models.flux import FluxTransform
+
+
+class TestFluxTransform:
+    @pytest.fixture
+    def img(self):
+        return Image.new("RGB", (16, 16), (255, 0, 0))
+
+    def test_flux_transform(self, img):
+        # Create transform
+        transform = FluxTransform(
+            flux_model_name="FLUX.1-dev",
+            img_width=8,
+            img_height=8,
+            clip_tokenizer_path=str(ASSETS / "tiny_bpe_merges.txt"),
+            t5_tokenizer_path=str(ASSETS / "sentencepiece.model"),
+        )
+
+        # Tranform a row of data
+        x = transform({"image": img, "text": "test"})
+
+        assert len(x) == 3  # image, clip tokens, and t5 tokens
+
+        # Check that image was cropped and normalized
+        assert x["image"].shape == (3, 8, 8)
+        assert torch.min(x["image"]).item() == -1.0
+        assert torch.max(x["image"]).item() == 1.0
+
+        # Check that the tokens are the correct sequence length
+        assert x["clip_tokens"].shape == (77,)
+        assert x["t5_tokens"].shape == (512,)
+
+    def test_truncation(self, img):
+        data = {"image": img, "text": "x" * 10_000}
+
+        # Check that long sequences raise an error if truncate_text is false
+        transform = FluxTransform(
+            flux_model_name="FLUX.1-dev",
+            img_width=8,
+            img_height=8,
+            clip_tokenizer_path=str(ASSETS / "tiny_bpe_merges.txt"),
+            t5_tokenizer_path=str(ASSETS / "sentencepiece.model"),
+            truncate_text=False,
+        )
+        with pytest.raises(AssertionError):
+            x = transform(data)
+
+        # Check that long sequences are truncated if truncate_text is true
+        transform = FluxTransform(
+            flux_model_name="FLUX.1-dev",
+            img_width=8,
+            img_height=8,
+            clip_tokenizer_path=str(ASSETS / "tiny_bpe_merges.txt"),
+            t5_tokenizer_path=str(ASSETS / "sentencepiece.model"),
+            truncate_text=True,
+        )
+        x = transform(data)
+        assert x["clip_tokens"].shape == (77,)
+        assert x["t5_tokens"].shape == (512,)
+
+    def test_flux_schnell_transform(self, img):
+        # FLUX.1-schnell has a smaller T5 max seq len
+        transform = FluxTransform(
+            flux_model_name="FLUX.1-schnell",
+            img_width=8,
+            img_height=8,
+            clip_tokenizer_path=str(ASSETS / "tiny_bpe_merges.txt"),
+            t5_tokenizer_path=str(ASSETS / "sentencepiece.model"),
+        )
+        x = transform({"image": img, "text": "test"})
+        assert x["t5_tokens"].shape == (256,)

--- a/torchtune/datasets/__init__.py
+++ b/torchtune/datasets/__init__.py
@@ -22,6 +22,7 @@ from torchtune.datasets._text_completion import (
     text_completion_dataset,
     TextCompletionDataset,
 )
+from torchtune.datasets._text_to_image import text_to_image_dataset
 from torchtune.datasets._wikitext import wikitext_dataset
 
 __all__ = [
@@ -44,4 +45,5 @@ __all__ = [
     "SFTDataset",
     "hh_rlhf_helpful_dataset",
     "multimodal",
+    "text_to_image_dataset",
 ]

--- a/torchtune/datasets/_text_to_image.py
+++ b/torchtune/datasets/_text_to_image.py
@@ -88,7 +88,6 @@ class TextToImageDataset(Dataset):
     def __getitem__(self, index: int) -> Dict[str, Any]:
         sample = self._data[index]
 
-        id = sample[self._column_map["id"]]
         text = sample[self._column_map["text"]]
         image_path = sample[self._column_map["image"]]
 
@@ -101,7 +100,8 @@ class TextToImageDataset(Dataset):
         transformed_sample = self._model_transform({"text": text, "image": image})
 
         if self._include_id:
-            transformed_sample["id"] = id
+            transformed_sample["id"] = sample[self._column_map["id"]]
+
         return transformed_sample
 
 

--- a/torchtune/datasets/_text_to_image.py
+++ b/torchtune/datasets/_text_to_image.py
@@ -1,0 +1,183 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from datasets import load_dataset
+from torch.utils.data import Dataset
+
+from torchtune.data._utils import load_image
+from torchtune.modules.transforms import Transform
+
+
+class TextToImageDataset(Dataset):
+    """
+    Dataset of image-text pairs from HuggingFace or local files.
+
+    Args:
+        source (str): Either a path to a huggingface dataset or the type of the local dataset (e.g. json)
+            See https://huggingface.co/docs/datasets/en/loading for more info
+        image_dir (Optional[str]): The directory that image paths are relative to.
+            Default: None (the image paths are absolute paths)
+        column_map (Optional[Dict[str, str]]): a mapping to change the expected "text"/"image" (and optionally "id")
+            column names to the actual column names in the dataset. Keys should be "text" and "image", and values
+            should be the actual column names.
+            Default: None (use default column names)
+        include_id (bool): Set to True if the dataset includes unique ids and you'd like to include them in the output
+            (e.g. for preprocessing purposes).
+            Default: False
+        model_transform (Transform): Callable that applies model-specific preprocessing to the sample.
+            See :class:`~torchtune.models.flux.FluxTransform` for an example.
+        filter_fn (Optional[Callable]): Callable used to filter the dataset prior to any pre-processing.
+            See https://huggingface.co/docs/datasets/v2.20.0/process#select-and-filter
+            Default: None
+        **load_dataset_kwargs (Dict[str, Any]): Additional keyword arguments to pass to `load_dataset`.
+            See https://huggingface.co/docs/datasets/en/loading
+
+    Raises:
+        ValueError: if `column_map` is invalid.
+    """
+
+    def __init__(
+        self,
+        *,
+        source: str,
+        image_dir: Optional[str] = None,
+        column_map: Optional[Dict[str, str]] = None,
+        include_id: bool = False,
+        model_transform: Transform,
+        filter_fn: Optional[Callable] = None,
+        **load_dataset_kwargs: Dict[str, Any],
+    ) -> None:
+        self._image_dir = Path(image_dir) if image_dir is not None else None
+
+        if column_map is None:
+            self._column_map = {"text": "text", "image": "image"}
+            if include_id:
+                self._column_map["id"] = "id"
+        else:
+            if "text" not in column_map:
+                raise ValueError(
+                    f"Expected a key of 'text' in column_map but found {column_map.keys()}."
+                )
+            if "image" not in column_map:
+                raise ValueError(
+                    f"Expected a key of 'image' in column_map but found {column_map.keys()}."
+                )
+            if include_id and "id" not in column_map:
+                raise ValueError(
+                    f"Expected a key of 'id' in column_map but found {column_map.keys()}."
+                )
+            self._column_map = column_map
+
+        self._model_transform = model_transform
+
+        self._data = load_dataset(source, **load_dataset_kwargs)
+        if filter_fn is not None:
+            self._data = self._data.filter(filter_fn)
+
+        self._include_id = include_id
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __getitem__(self, index: int) -> Dict[str, Any]:
+        sample = self._data[index]
+
+        id = sample[self._column_map["id"]]
+        text = sample[self._column_map["text"]]
+        image_path = sample[self._column_map["image"]]
+
+        image = load_image(
+            Path(image_path)
+            if self._image_dir is None
+            else self._image_dir / image_path
+        )
+
+        transformed_sample = self._model_transform({"text": text, "image": image})
+
+        if self._include_id:
+            transformed_sample["id"] = id
+        return transformed_sample
+
+
+def text_to_image_dataset(
+    model_transform: Transform,
+    *,
+    source: str,
+    image_dir: Optional[str] = None,
+    column_map: Optional[Dict[str, str]] = None,
+    include_id: bool = False,
+    filter_fn: Optional[Callable] = None,
+    split: str = "train",
+    **load_dataset_kwargs: Dict[str, Any],
+) -> TextToImageDataset:
+    """
+    Builder for a dataset of image-text pairs from HuggingFace or local files.
+
+    ---
+
+    For a local dataset in the following format:
+
+    /path/to/my_image_folder
+        - 0.png
+        ...
+
+    /path/to/my_dataset.json
+    [
+        {"text": "my caption", "image": "0.png"},
+        ...
+    ]
+
+    Your dataset config will look like this:
+
+    .. code-block:: yaml
+        dataset:
+          _component_: torchtune.datasets.text_to_image_dataset
+          source: json
+          data_files: /path/to/my_dataset.json
+          image_dir: /path/to/my_image_folder
+
+    ---
+
+    Args:
+        model_transform (Transform): Callable that applies model-specific preprocessing to the sample.
+            See :class:`~torchtune.models.flux.FluxTransform` for an example.
+        source (str): Either a path to a huggingface dataset or the type of the local dataset (e.g. json)
+            See https://huggingface.co/docs/datasets/en/loading for more info
+        image_dir (Optional[str]): The directory that image paths are relative to.
+            Default: None (the image paths are absolute paths)
+        column_map (Optional[Dict[str, str]]): a mapping to change the expected "text"/"image" (and optionally "id")
+            column names to the actual column names in the dataset. Keys should be "text" and "image", and values
+            should be the actual column names.
+            Default: None (use default column names)
+        include_id (bool): Set to True if the dataset includes unique ids and you'd like to include them in the output
+            (e.g. for preprocessing purposes).
+            Default: False
+        filter_fn (Optional[Callable]): Callable used to filter the dataset prior to any pre-processing.
+            See https://huggingface.co/docs/datasets/v2.20.0/process#select-and-filter
+            Default: None
+        split (str): Load a specific subset of a dataset.
+            See https://huggingface.co/docs/datasets/en/loading
+            Default: "train"
+        **load_dataset_kwargs (Dict[str, Any]): Additional keyword arguments to pass to `load_dataset`.
+            See https://huggingface.co/docs/datasets/en/loading
+
+    Returns:
+        TextToImageDataset
+    """
+    ds = TextToImageDataset(
+        source=source,
+        image_dir=image_dir,
+        column_map=column_map,
+        include_id=include_id,
+        model_transform=model_transform,
+        filter_fn=filter_fn,
+        split=split,
+        **load_dataset_kwargs,
+    )
+    return ds

--- a/torchtune/models/flux/__init__.py
+++ b/torchtune/models/flux/__init__.py
@@ -10,8 +10,10 @@ from ._model_builders import (
     lora_flux_1_dev_flow_model,
     lora_flux_1_schnell_flow_model,
 )
+from ._transform import FluxTransform
 
 __all__ = [
+    "FluxTransform",
     "flux_1_autoencoder",
     "flux_1_dev_flow_model",
     "flux_1_schnell_flow_model",

--- a/torchtune/models/flux/__init__.py
+++ b/torchtune/models/flux/__init__.py
@@ -3,8 +3,18 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-from ._model_builders import flux_1_autoencoder
+from ._model_builders import (
+    flux_1_autoencoder,
+    flux_1_dev_flow_model,
+    flux_1_schnell_flow_model,
+    lora_flux_1_dev_flow_model,
+    lora_flux_1_schnell_flow_model,
+)
 
 __all__ = [
     "flux_1_autoencoder",
+    "flux_1_dev_flow_model",
+    "flux_1_schnell_flow_model",
+    "lora_flux_1_dev_flow_model",
+    "lora_flux_1_schnell_flow_model",
 ]

--- a/torchtune/models/flux/_autoencoder.py
+++ b/torchtune/models/flux/_autoencoder.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import List, Tuple
+from typing import List
 
 import torch
 import torch.nn.functional as F
@@ -19,19 +19,16 @@ class FluxAutoencoder(nn.Module):
     The image autoencoder for Flux diffusion models.
 
     Args:
-        img_shape (Tuple[int, int, int]): The shape of the input image (without the batch dimension).
         encoder (nn.Module): The encoder module.
         decoder (nn.Module): The decoder module.
     """
 
     def __init__(
         self,
-        img_shape: Tuple[int, int, int],
         encoder: nn.Module,
         decoder: nn.Module,
     ):
         super().__init__()
-        self._img_shape = img_shape
         self.encoder = encoder
         self.decoder = decoder
 
@@ -55,7 +52,6 @@ class FluxAutoencoder(nn.Module):
         Returns:
             Tensor: latent encodings (shape = [bsz, ch_z, latent resolution, latent resolution])
         """
-        assert x.shape[1:] == self._img_shape
         return self.encoder(x)
 
     def decode(self, z: Tensor) -> Tensor:

--- a/torchtune/models/flux/_flow_model.py
+++ b/torchtune/models/flux/_flow_model.py
@@ -1,0 +1,443 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import math
+from dataclasses import dataclass
+
+import torch
+from torch import nn, Tensor
+
+
+class FluxFlowModel(nn.Module):
+    """
+    Flow-matching model for Flux v1 from https://github.com/black-forest-labs/flux
+
+    Args:
+        in_channels (int): The number of channels of the "img" input (the latent from the autoencoder).
+        out_channels (int): The number of channels of the output.
+        vec_in_dim (int): The number of dimensions of the "y" input (the CLIP embedding).
+        context_in_dim (int): The number of dimensions of the "txt" input (the T5 text encoding).
+        hidden_size (int): The inner dimension of the model.
+        mlp_ratio (float): The size of the dimension relative to the hidden size of the MLPs in the attention blocks.
+        num_heads (int): The number of attention heads.
+        depth (int): The number of double stream blocks.
+        depth_single_blocks (int): The number of single stream blocks.
+        axes_dim (list[int]): The dimension of the rope embeddings.
+        theta (int): The theta of the rope embeddings.
+        qkv_bias (bool): Enable bias for the QKV projections.
+        use_guidance (bool): Enable guidance (True for dev models and False for schnell).
+
+    Raises:
+        ValueError: If hidden_size, num_heads, axes_dim, or pe_dim is invalid.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        vec_in_dim: int,
+        context_in_dim: int,
+        hidden_size: int,
+        mlp_ratio: float,
+        num_heads: int,
+        depth: int,
+        depth_single_blocks: int,
+        axes_dim: list[int],
+        theta: int,
+        qkv_bias: bool,
+        use_guidance: bool,
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        if hidden_size % num_heads != 0:
+            raise ValueError(
+                f"Hidden size {hidden_size} must be divisible by num_heads {num_heads}"
+            )
+        pe_dim = hidden_size // num_heads
+        if sum(axes_dim) != pe_dim:
+            raise ValueError(f"Got {axes_dim} but expected positional dim {pe_dim}")
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.pe_embedder = EmbedND(dim=pe_dim, theta=theta, axes_dim=axes_dim)
+        self.img_in = nn.Linear(self.in_channels, self.hidden_size, bias=True)
+        self.time_in = MLPEmbedder(in_dim=256, hidden_dim=self.hidden_size)
+        self.vector_in = MLPEmbedder(vec_in_dim, self.hidden_size)
+        self.guidance_in = (
+            MLPEmbedder(in_dim=256, hidden_dim=self.hidden_size)
+            if use_guidance
+            else None
+        )
+        self.txt_in = nn.Linear(context_in_dim, self.hidden_size)
+
+        self.double_blocks = nn.ModuleList(
+            [
+                DoubleStreamBlock(
+                    self.hidden_size,
+                    self.num_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=qkv_bias,
+                )
+                for _ in range(depth)
+            ]
+        )
+
+        self.single_blocks = nn.ModuleList(
+            [
+                SingleStreamBlock(self.hidden_size, self.num_heads, mlp_ratio=mlp_ratio)
+                for _ in range(depth_single_blocks)
+            ]
+        )
+
+        self.final_layer = LastLayer(self.hidden_size, 1, self.out_channels)
+
+    def forward(
+        self,
+        img: Tensor,
+        img_ids: Tensor,
+        txt: Tensor,
+        txt_ids: Tensor,
+        timesteps: Tensor,
+        y: Tensor,
+        guidance: Tensor | None = None,
+    ) -> Tensor:
+        if img.ndim != 3 or txt.ndim != 3:
+            raise ValueError("Input img and txt tensors must have 3 dimensions.")
+
+        # running on sequences img
+        img = self.img_in(img)
+        vec = self.time_in(timestep_embedding(timesteps, 256))
+        if self.guidance_in is not None:
+            if guidance is None:
+                raise ValueError(
+                    "Didn't get guidance strength for guidance distilled model."
+                )
+            vec = vec + self.guidance_in(timestep_embedding(guidance, 256))
+        vec = vec + self.vector_in(y)
+        txt = self.txt_in(txt)
+
+        ids = torch.cat((txt_ids, img_ids), dim=1)
+        pe = self.pe_embedder(ids)
+
+        for block in self.double_blocks:
+            img, txt = block(img=img, txt=txt, vec=vec, pe=pe)
+
+        img = torch.cat((txt, img), 1)
+        for block in self.single_blocks:
+            img = block(img, vec=vec, pe=pe)
+        img = img[:, txt.shape[1] :, ...]
+
+        img = self.final_layer(img, vec)  # (N, T, patch_size ** 2 * out_channels)
+        return img
+
+
+class EmbedND(nn.Module):
+    def __init__(self, dim: int, theta: int, axes_dim: list[int]):
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+        self.axes_dim = axes_dim
+
+    def forward(self, ids: Tensor) -> Tensor:
+        n_axes = ids.shape[-1]
+        emb = torch.cat(
+            [rope(ids[..., i], self.axes_dim[i], self.theta) for i in range(n_axes)],
+            dim=-3,
+        )
+
+        return emb.unsqueeze(1)
+
+
+def timestep_embedding(t: Tensor, dim, max_period=10000, time_factor: float = 1000.0):
+    """
+    Create sinusoidal timestep embeddings.
+    :param t: a 1-D Tensor of N indices, one per batch element.
+                      These may be fractional.
+    :param dim: the dimension of the output.
+    :param max_period: controls the minimum frequency of the embeddings.
+    :return: an (N, D) Tensor of positional embeddings.
+    """
+    t = time_factor * t
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period)
+        * torch.arange(start=0, end=half, dtype=torch.float32)
+        / half
+    ).to(t.device)
+
+    args = t[:, None].float() * freqs[None]
+    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    if dim % 2:
+        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+    if torch.is_floating_point(t):
+        embedding = embedding.to(t)
+    return embedding
+
+
+class MLPEmbedder(nn.Module):
+    def __init__(self, in_dim: int, hidden_dim: int):
+        super().__init__()
+        self.in_layer = nn.Linear(in_dim, hidden_dim, bias=True)
+        self.silu = nn.SiLU()
+        self.out_layer = nn.Linear(hidden_dim, hidden_dim, bias=True)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.out_layer(self.silu(self.in_layer(x)))
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.scale = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: Tensor):
+        x_dtype = x.dtype
+        x = x.float()
+        rrms = torch.rsqrt(torch.mean(x**2, dim=-1, keepdim=True) + 1e-6)
+        return (x * rrms).to(dtype=x_dtype) * self.scale
+
+
+class QKNorm(torch.nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.query_norm = RMSNorm(dim)
+        self.key_norm = RMSNorm(dim)
+
+    def forward(self, q: Tensor, k: Tensor, v: Tensor) -> tuple[Tensor, Tensor]:
+        q = self.query_norm(q)
+        k = self.key_norm(k)
+        return q.to(v), k.to(v)
+
+
+class SelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int = 8, qkv_bias: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.norm = QKNorm(head_dim)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: Tensor, pe: Tensor) -> Tensor:
+        qkv = self.qkv(x)
+        q, k, v = unpack_qkv(qkv, self.num_heads)
+        q, k = self.norm(q, k, v)
+        x = attention(q, k, v, pe=pe)
+        x = self.proj(x)
+        return x
+
+
+@dataclass
+class ModulationOut:
+    shift: Tensor
+    scale: Tensor
+    gate: Tensor
+
+
+class Modulation(nn.Module):
+    def __init__(self, dim: int, double: bool):
+        super().__init__()
+        self.is_double = double
+        self.multiplier = 6 if double else 3
+        self.lin = nn.Linear(dim, self.multiplier * dim, bias=True)
+
+    def forward(self, vec: Tensor) -> tuple[ModulationOut, ModulationOut | None]:
+        out = self.lin(nn.functional.silu(vec))[:, None, :].chunk(
+            self.multiplier, dim=-1
+        )
+
+        return (
+            ModulationOut(*out[:3]),
+            ModulationOut(*out[3:]) if self.is_double else None,
+        )
+
+
+class DoubleStreamBlock(nn.Module):
+    def __init__(
+        self, hidden_size: int, num_heads: int, mlp_ratio: float, qkv_bias: bool = False
+    ):
+        super().__init__()
+
+        mlp_hidden_dim = int(hidden_size * mlp_ratio)
+        self.num_heads = num_heads
+        self.hidden_size = hidden_size
+        self.img_mod = Modulation(hidden_size, double=True)
+        self.img_norm1 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.img_attn = SelfAttention(
+            dim=hidden_size, num_heads=num_heads, qkv_bias=qkv_bias
+        )
+
+        self.img_norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.img_mlp = nn.Sequential(
+            nn.Linear(hidden_size, mlp_hidden_dim, bias=True),
+            nn.GELU(approximate="tanh"),
+            nn.Linear(mlp_hidden_dim, hidden_size, bias=True),
+        )
+
+        self.txt_mod = Modulation(hidden_size, double=True)
+        self.txt_norm1 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.txt_attn = SelfAttention(
+            dim=hidden_size, num_heads=num_heads, qkv_bias=qkv_bias
+        )
+
+        self.txt_norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.txt_mlp = nn.Sequential(
+            nn.Linear(hidden_size, mlp_hidden_dim, bias=True),
+            nn.GELU(approximate="tanh"),
+            nn.Linear(mlp_hidden_dim, hidden_size, bias=True),
+        )
+
+    def forward(
+        self, img: Tensor, txt: Tensor, vec: Tensor, pe: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        img_mod1, img_mod2 = self.img_mod(vec)
+        txt_mod1, txt_mod2 = self.txt_mod(vec)
+
+        # prepare image for attention
+        img_modulated = self.img_norm1(img)
+        img_modulated = (1 + img_mod1.scale) * img_modulated + img_mod1.shift
+        img_qkv = self.img_attn.qkv(img_modulated)
+        img_q, img_k, img_v = unpack_qkv(img_qkv, self.num_heads)
+        img_q, img_k = self.img_attn.norm(img_q, img_k, img_v)
+
+        # prepare txt for attention
+        txt_modulated = self.txt_norm1(txt)
+        txt_modulated = (1 + txt_mod1.scale) * txt_modulated + txt_mod1.shift
+        txt_qkv = self.txt_attn.qkv(txt_modulated)
+        txt_q, txt_k, txt_v = unpack_qkv(txt_qkv, self.num_heads)
+        txt_q, txt_k = self.txt_attn.norm(txt_q, txt_k, txt_v)
+
+        # run actual attention
+        q = torch.cat((txt_q, img_q), dim=2)
+        k = torch.cat((txt_k, img_k), dim=2)
+        v = torch.cat((txt_v, img_v), dim=2)
+
+        attn = attention(q, k, v, pe=pe)
+        txt_attn, img_attn = attn[:, : txt.shape[1]], attn[:, txt.shape[1] :]
+
+        # calculate the img bloks
+        img = img + img_mod1.gate * self.img_attn.proj(img_attn)
+        img = img + img_mod2.gate * self.img_mlp(
+            (1 + img_mod2.scale) * self.img_norm2(img) + img_mod2.shift
+        )
+
+        # calculate the txt bloks
+        txt = txt + txt_mod1.gate * self.txt_attn.proj(txt_attn)
+        txt = txt + txt_mod2.gate * self.txt_mlp(
+            (1 + txt_mod2.scale) * self.txt_norm2(txt) + txt_mod2.shift
+        )
+        return img, txt
+
+
+class SingleStreamBlock(nn.Module):
+    """
+    A DiT block with parallel linear layers as described in
+    https://arxiv.org/abs/2302.05442 and adapted modulation interface.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        qk_scale: float | None = None,
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_size
+        self.num_heads = num_heads
+        head_dim = hidden_size // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+
+        self.mlp_hidden_dim = int(hidden_size * mlp_ratio)
+        # qkv and mlp_in
+        self.linear1 = nn.Linear(hidden_size, hidden_size * 3 + self.mlp_hidden_dim)
+        # proj and mlp_out
+        self.linear2 = nn.Linear(hidden_size + self.mlp_hidden_dim, hidden_size)
+
+        self.norm = QKNorm(head_dim)
+
+        self.hidden_size = hidden_size
+        self.pre_norm = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+
+        self.mlp_act = nn.GELU(approximate="tanh")
+        self.modulation = Modulation(hidden_size, double=False)
+
+    def forward(self, x: Tensor, vec: Tensor, pe: Tensor) -> Tensor:
+        mod, _ = self.modulation(vec)
+        x_mod = (1 + mod.scale) * self.pre_norm(x) + mod.shift
+        qkv, mlp = torch.split(
+            self.linear1(x_mod), [3 * self.hidden_size, self.mlp_hidden_dim], dim=-1
+        )
+
+        q, k, v = unpack_qkv(qkv, self.num_heads)
+        q, k = self.norm(q, k, v)
+
+        # compute attention
+        attn = attention(q, k, v, pe=pe)
+        # compute activation in mlp stream, cat again and run second linear layer
+        output = self.linear2(torch.cat((attn, self.mlp_act(mlp)), 2))
+        return x + mod.gate * output
+
+
+class LastLayer(nn.Module):
+    def __init__(self, hidden_size: int, patch_size: int, out_channels: int):
+        super().__init__()
+        self.norm_final = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.linear = nn.Linear(
+            hidden_size, patch_size * patch_size * out_channels, bias=True
+        )
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(), nn.Linear(hidden_size, 2 * hidden_size, bias=True)
+        )
+
+    def forward(self, x: Tensor, vec: Tensor) -> Tensor:
+        shift, scale = self.adaLN_modulation(vec).chunk(2, dim=1)
+        x = (1 + scale[:, None, :]) * self.norm_final(x) + shift[:, None, :]
+        x = self.linear(x)
+        return x
+
+
+def attention(q: Tensor, k: Tensor, v: Tensor, pe: Tensor) -> Tensor:
+    q, k = apply_rope(q, k, pe)
+    x = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    # B H L D -> B L (H D)
+    B, H, L, D = x.shape  # noqa: N806
+    x = x.permute(0, 2, 1, 3).reshape(B, L, H * D)
+
+    return x
+
+
+def rope(pos: Tensor, dim: int, theta: int) -> Tensor:
+    assert dim % 2 == 0
+    scale = torch.arange(0, dim, 2, dtype=torch.float64, device=pos.device) / dim
+    omega = 1.0 / (theta**scale)
+    out = torch.einsum("...n,d->...nd", pos, omega)
+    out = torch.stack(
+        [torch.cos(out), -torch.sin(out), torch.sin(out), torch.cos(out)], dim=-1
+    )
+
+    # B N D 4 -> B N D 2 2
+    B, N, D, _ = out.shape  # noqa: N806
+    out = out.reshape(B, N, D, 2, 2)
+
+    return out.float()
+
+
+def apply_rope(xq: Tensor, xk: Tensor, freqs_cis: Tensor) -> tuple[Tensor, Tensor]:
+    xq_ = xq.float().reshape(*xq.shape[:-1], -1, 1, 2)
+    xk_ = xk.float().reshape(*xk.shape[:-1], -1, 1, 2)
+    xq_out = freqs_cis[..., 0] * xq_[..., 0] + freqs_cis[..., 1] * xq_[..., 1]
+    xk_out = freqs_cis[..., 0] * xk_[..., 0] + freqs_cis[..., 1] * xk_[..., 1]
+    return xq_out.reshape(*xq.shape).type_as(xq), xk_out.reshape(*xk.shape).type_as(xk)
+
+
+def unpack_qkv(qkv, num_heads):
+    # B L (3 H D) -> 3 B H L D
+    B, L, _ = qkv.shape  # noqa: N806
+    q, k, v = qkv.reshape(B, L, 3, num_heads, -1).permute(2, 0, 3, 1, 4).unbind(0)
+    return q, k, v

--- a/torchtune/models/flux/_transform.py
+++ b/torchtune/models/flux/_transform.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Mapping, Tuple
+
+import torch
+from torch import Tensor
+
+from torchtune.models.clip import clip_tokenizer
+from torchtune.models.flux._util import get_t5_max_seq_len
+from torchtune.models.t5 import t5_tokenizer
+from torchtune.modules.transforms import Transform
+from torchvision import transforms
+
+
+class FluxTransform(Transform):
+    """
+    Transform general text-to-image data to Flux-specific data.
+
+    Args:
+        flux_model_name (str): "FLUX.1-dev" or "FLUX.1-schnell" (affects the T5 max seq len)
+        img_width (int): Resize images to this width.
+        img_height (int): Resize images to this height.
+        clip_tokenizer_path (str): Path to the CLIP tokenizer `merges.txt` file.
+        t5_tokenizer_path (str): Path to the T5 tokenizer `spiece.model` file.
+        truncate_text (bool): Whether to truncate the tokenized text if longer than the max seq len.
+            If false, raises an `AssertionError` if the text is too long.
+            Default: False
+    """
+
+    def __init__(
+        self,
+        flux_model_name: str,
+        img_width: int,
+        img_height: int,
+        clip_tokenizer_path: str,
+        t5_tokenizer_path: str,
+        truncate_text: bool = False,
+    ):
+        self._clip_tokenizer = clip_tokenizer(
+            clip_tokenizer_path, truncate=truncate_text
+        )
+
+        self._t5_tokenizer = t5_tokenizer(
+            t5_tokenizer_path, max_seq_len=get_t5_max_seq_len(flux_model_name)
+        )
+
+        self._img_transform = transforms.Compose(
+            [
+                transforms.Resize(max(img_width, img_height)),
+                transforms.CenterCrop((img_width, img_height)),
+                transforms.ToTensor(),
+                _FluxImgNormalize(),
+            ]
+        )
+
+    def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
+        """
+        Transform a general text-to-image row to Flux-specific row.
+
+        Args:
+            sample (Mapping[str, Any]): PIL image and text
+
+        Returns:
+            Mapping[str, Any]: Image tensor and CLIP/T5 tokens
+        """
+        img = self._img_transform(sample["image"])
+        clip_tokens, t5_tokens = self.tokenize(sample["text"])
+        return {
+            "image": img,
+            "clip_tokens": clip_tokens,
+            "t5_tokens": t5_tokens,
+        }
+
+    def tokenize(self, text: str) -> Tuple[Tensor, Tensor]:
+        """
+        Tokenize a string using the CLIP and T5 tokenizers.
+
+        Args:
+            text (str): the string
+
+        Returns:
+            Tuple[Tensor, Tensor]: tuple of (clip_tokens, t5_tokens)
+        """
+        clip_tokens = self._tokenize(text, self._clip_tokenizer)
+        t5_tokens = self._tokenize(text, self._t5_tokenizer)
+        return clip_tokens, t5_tokens
+
+    def _tokenize(self, text, tokenizer):
+        tensor = torch.full(
+            (tokenizer.max_seq_len,),
+            tokenizer.pad_id,
+            dtype=torch.int,
+        )
+        tokens = tokenizer.encode(text)
+        tensor[: len(tokens)] = torch.tensor(tokens)
+        return tensor
+
+
+class _FluxImgNormalize:
+    def __call__(self, x):
+        return (x * 2.0) - 1.0

--- a/torchtune/models/flux/_util.py
+++ b/torchtune/models/flux/_util.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from torchtune.models.flux._flow_model import FluxFlowModel
+
+PATCH_HEIGHT, PATCH_WIDTH = 2, 2
+POSITION_DIM = 3
+
+
+def predict_noise(
+    model: FluxFlowModel,
+    latents: Tensor,
+    clip_encodings: Tensor,
+    t5_encodings: Tensor,
+    timesteps: Tensor,
+    guidance: Optional[Tensor] = None,
+) -> Tensor:
+    """
+    Use Flux's flow-matching model to predict the noise in image latents.
+
+    Args:
+        model (FluxFlowModel): The Flux flow model.
+        latents (Tensor): Image encodings from the Flux autoencoder.
+            Shape: [bsz, 16, latent height, latent width]
+        clip_encodings (Tensor): CLIP text encodings.
+            Shape: [bsz, 768]
+        t5_encodings (Tensor): T5 text encodings.
+            Shape: [bsz, sequence length, 256 or 512]
+        timesteps (Tensor): The amount of noise (0 to 1).
+            Shape: [bsz]
+        guidance (Optional[Tensor]): The guidance value (1.5 to 4) if guidance-enabled model.
+            Shape: [bsz]
+            Default: None
+
+    Returns:
+        Tensor: The noise prediction.
+            Shape: [bsz, 16, latent height, latent width]
+    """
+    bsz, _, latent_height, latent_width = latents.shape
+
+    # Create positional encodings
+    latent_pos_enc = create_position_encoding_for_latents(
+        bsz, latent_height, latent_width
+    )
+    text_pos_enc = torch.zeros(bsz, t5_encodings.shape[1], POSITION_DIM)
+
+    # Convert latent into a sequence of patches
+    latents = pack_latents(latents)
+
+    # Predict noise
+    latent_noise_pred = model(
+        img=latents,
+        img_ids=latent_pos_enc.to(latents),
+        txt=t5_encodings.to(latents),
+        txt_ids=text_pos_enc.to(latents),
+        y=clip_encodings.to(latents),
+        timesteps=timesteps.to(latents),
+        guidance=guidance.to(latents) if guidance is not None else None,
+    )
+
+    # Convert sequence of patches to latent shape
+    latent_noise_pred = unpack_latents(latent_noise_pred, latent_height, latent_width)
+
+    return latent_noise_pred
+
+
+def create_position_encoding_for_latents(
+    bsz: int, latent_height: int, latent_width: int
+) -> Tensor:
+    """
+    Create the packed latents' position encodings for the Flux flow model.
+
+    Args:
+        bsz (int): The batch size.
+        latent_height (int): The height of the latent.
+        latent_width (int): The width of the latent.
+
+    Returns:
+        Tensor: The position encodings.
+            Shape: [bsz, (latent_height // PATCH_HEIGHT) * (latent_width // PATCH_WIDTH), POSITION_DIM)
+    """
+    height = latent_height // PATCH_HEIGHT
+    width = latent_width // PATCH_WIDTH
+
+    position_encoding = torch.zeros(height, width, POSITION_DIM)
+
+    row_indices = torch.arange(height)
+    position_encoding[:, :, 1] = row_indices.unsqueeze(1)
+
+    col_indices = torch.arange(width)
+    position_encoding[:, :, 2] = col_indices.unsqueeze(0)
+
+    # Flatten and repeat for the full batch
+    # [height, width, 3] -> [bsz, height * width, 3]
+    position_encoding = position_encoding.view(1, height * width, POSITION_DIM)
+    position_encoding = position_encoding.repeat(bsz, 1, 1)
+
+    return position_encoding
+
+
+def pack_latents(x: Tensor) -> Tensor:
+    """
+    Rearrange latents from an image-like format into a sequence of patches.
+
+    Equivalent to `einops.rearrange("b c (h ph) (w pw) -> b (h w) (c ph pw)")`.
+
+    Args:
+        x (Tensor): The unpacked latents.
+            Shape: [bsz, ch, latent height, latent width]
+
+    Returns:
+        Tensor: The packed latents.
+            Shape: (bsz, (latent_height // ph) * (latent_width // pw), ch * ph * pw)
+    """
+    b, c, latent_height, latent_width = x.shape
+    h = latent_height // PATCH_HEIGHT
+    w = latent_width // PATCH_WIDTH
+
+    # [b, c, h*ph, w*ph] -> [b, c, h, w, ph, pw]
+    x = x.unfold(2, PATCH_HEIGHT, PATCH_HEIGHT).unfold(3, PATCH_WIDTH, PATCH_WIDTH)
+
+    # [b, c, h, w, ph, PW] -> [b, h, w, c, ph, PW]
+    x = x.permute(0, 2, 3, 1, 4, 5)
+
+    # [b, h, w, c, ph, PW] -> [b, h*w, c*ph*PW]
+    return x.reshape(b, h * w, c * PATCH_HEIGHT * PATCH_WIDTH)
+
+
+def unpack_latents(x: Tensor, latent_height: int, latent_width: int) -> Tensor:
+    """
+    Rearrange latents from a sequence of patches into an image-like format.
+
+    Equivalent to `einops.rearrange("b (h w) (c ph pw) -> b c (h ph) (w pw)")`.
+
+    Args:
+        x (Tensor): The packed latents.
+            Shape: (bsz, (latent_height // ph) * (latent_width // pw), ch * ph * pw)
+        latent_height (int): The height of the unpacked latents.
+        latent_width (int): The width of the unpacked latents.
+
+    Returns:
+        Tensor: The unpacked latents.
+            Shape: [bsz, ch, latent height, latent width]
+    """
+    b, _, c_ph_pw = x.shape
+    h = latent_height // PATCH_HEIGHT
+    w = latent_width // PATCH_WIDTH
+    c = c_ph_pw // (PATCH_HEIGHT * PATCH_WIDTH)
+
+    # [b, h*w, c*ph*pw] -> [b, h, w, c, ph, pw]
+    x = x.reshape(b, h, w, c, PATCH_HEIGHT, PATCH_WIDTH)
+
+    # [b, h, w, c, ph, pw] -> [b, c, h, ph, w, pw]
+    x = x.permute(0, 3, 1, 4, 2, 5)
+
+    # [b, c, h, ph, w, pw] -> [b, c, h*ph, w*pw]
+    return x.reshape(b, c, h * PATCH_HEIGHT, w * PATCH_WIDTH)

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -718,8 +718,8 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     dim=self._config["hidden_size"],
                     head_dim=self._config.get("head_dim", None),
                 )
-            elif self._model_type == ModelType.FLUX_FLOW:
-                pass
+            elif self._model_type == ModelType.FLUX:
+                pass  # the torchtune Flux model state dict is identical to the huggingface one
             else:
                 state_dict[training.MODEL_KEY] = convert_weights.tune_to_hf(
                     state_dict[training.MODEL_KEY],

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -611,7 +611,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             converted_state_dict[training.MODEL_KEY] = flux_ae_hf_to_tune(
                 merged_state_dict,
             )
-        elif self._model_type == ModelType.FLUX_FLOW:
+        elif self._model_type == ModelType.FLUX:
             converted_state_dict[training.MODEL_KEY] = merged_state_dict
         else:
             converted_state_dict[training.MODEL_KEY] = convert_weights.hf_to_tune(

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -94,7 +94,7 @@ class ModelType(Enum):
         CLIP_TEXT (str): CLIP text encoder. See :func:`~torchtune.models.clip.clip_text_encoder_large`
         T5_ENCODER (str): T5 text encoder. See :func:`~torchtune.models.t5.t5_v1_1_xxl_encoder`
         FLUX_AUTOENCODER (str): Flux autoencoder. See :func:`~torchtune.models.flux.flux_1_autoencoder`
-        FLUX_FLOW (str): Flux flow model. See :func:`~torchtune.models.flux.flux_1_dev_flow_model`
+        FLUX (str): Main Flux model. See :func:`~torchtune.models.flux.flux_1_dev_flow_model`
 
     Example:
         >>> # Usage in a checkpointer class
@@ -117,7 +117,7 @@ class ModelType(Enum):
     CLIP_TEXT: str = "clip_text"
     T5_ENCODER: str = "t5_encoder"
     FLUX_AUTOENCODER: str = "flux_autoencoder"
-    FLUX_FLOW: str = "flux_flow"
+    FLUX: str = "flux"
 
 
 class FormattedCheckpointFiles:

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -93,6 +93,8 @@ class ModelType(Enum):
         QWEN2 (str): Qwen2 family of models. See :func:`~torchtune.models.qwen2.qwen2`
         CLIP_TEXT (str): CLIP text encoder. See :func:`~torchtune.models.clip.clip_text_encoder_large`
         T5_ENCODER (str): T5 text encoder. See :func:`~torchtune.models.t5.t5_v1_1_xxl_encoder`
+        FLUX_AUTOENCODER (str): Flux autoencoder. See :func:`~torchtune.models.flux.flux_1_autoencoder`
+        FLUX_FLOW (str): Flux flow model. See :func:`~torchtune.models.flux.flux_1_dev_flow_model`
 
     Example:
         >>> # Usage in a checkpointer class
@@ -114,6 +116,8 @@ class ModelType(Enum):
     QWEN2: str = "qwen2"
     CLIP_TEXT: str = "clip_text"
     T5_ENCODER: str = "t5_encoder"
+    FLUX_AUTOENCODER: str = "flux_autoencoder"
+    FLUX_FLOW: str = "flux_flow"
 
 
 class FormattedCheckpointFiles:


### PR DESCRIPTION
#### Context
This adds a text-to-image dataset class, as well as a Flux transform that converts generic text-to-image data to Flux-specific data.

The text-to-image dataset class also has the optional ability to yield a row ID along with the text and image data. This will be used to preprocess the dataset before Flux finetuning.

The Flux transform also exposes a public function just for tokenizing text. This will be used by the Flux finetuning recipe to tokenize the prompts used to sample images from the model during training.

#### Changelog
* Text-to-image dataset class and builder
* Flux transform
* Unit test for the dataset class
* Unit test for the Flux transform

#### Test plan
Manual testing
- [x] created a local dataset of labeled images and finetuned Flux on the dataset 

Checklist
- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`