### PR TITLE
added `tie_word_embeddings` to llama3_2 models

### DIFF
--- a/torchtune/models/llama3_2/_component_builders.py
+++ b/torchtune/models/llama3_2/_component_builders.py
@@ -52,6 +52,7 @@ def llama3_2(
     intermediate_dim: Optional[int] = None,
     norm_eps: float = 1e-5,
     scale_factor: int = 32,
+    tie_word_embeddings: bool = True,
 ) -> TransformerDecoder:
     """
     Build the decoder associated with the Llama3.2 model. This includes:
@@ -78,6 +79,7 @@ def llama3_2(
             this is computed using :func:`~torchtune.modules.scale_hidden_dim_for_mlp`
         norm_eps (float): epsilon in RMS norms.
         scale_factor (int): scaling factor for RoPE. Default: 32
+        tie_word_embeddings (bool): whether the model's input and output word embeddings should be tied.
 
     Returns:
         TransformerDecoder: Instantiation of Llama3.2 model.
@@ -112,7 +114,11 @@ def llama3_2(
         layers.append(layer)
 
     tok_embeddings = nn.Embedding(vocab_size, embed_dim)
-    output_proj = TiedLinear(tok_embeddings)
+    if tie_word_embeddings:
+        output_proj = TiedLinear(tok_embeddings)
+    else:
+        output_proj = nn.Linear(embed_dim, vocab_size, bias=False)
+
     return TransformerDecoder(
         tok_embeddings=tok_embeddings,
         layers=layers,
@@ -161,6 +167,7 @@ def lora_llama3_2(
     use_dora: bool = False,
     # Quantization args
     quantize_base: bool = False,
+    tie_word_embeddings: bool = True,
 ) -> TransformerDecoder:
     """
     Return a version of Llama3.2 (an instance of :func:`~torchtune.modules.TransformerDecoder`)
@@ -197,6 +204,7 @@ def lora_llama3_2(
         quantize_base: (bool): Whether to quantize base model weights or not. Only applied to base
             weights within linear layers LoRA is applied to. The final output linear projection is not
             supported for quantization currently.
+        tie_word_embeddings (bool): whether the model's input and output word embeddings should be tied.
 
     Returns:
         TransformerDecoder: Instantiation of Llama3.2 model with LoRA applied to
@@ -254,7 +262,11 @@ def lora_llama3_2(
             "apply_lora_to_output is currently not supporting in llama3.2 1b and 3b,"
             "as the projection layer weights are tied to the embeddings"
         )
-    output_proj = TiedLinear(tok_embeddings)
+    if tie_word_embeddings:
+        output_proj = TiedLinear(tok_embeddings)
+    else:
+        output_proj = nn.Linear(embed_dim, vocab_size, bias=False)
+        
     model = TransformerDecoder(
         tok_embeddings=tok_embeddings,
         layers=layers,

--- a/torchtune/models/llama3_2/_model_builders.py
+++ b/torchtune/models/llama3_2/_model_builders.py
@@ -16,10 +16,15 @@ Model builders build specific instantiations using component builders. For examp
 the llama3_2_1b model builder uses the llama3_2 component builder to create the
 Llama3.2 1B model.
 """
-def llama3_2_1b() -> TransformerDecoder:
+def llama3_2_1b(
+    tie_word_embeddings: bool = True,
+) -> TransformerDecoder:
     """
     Builder for creating a Llama3.2 model initialized w/ the default 1b parameter values.
     
+    Args:
+        tie_word_embeddings (bool): whether the model's input and output word embeddings should be tied.
+
     Returns:
         TransformerDecoder: Instantiation of Llama3.2 1B model
     """
@@ -35,10 +40,16 @@ def llama3_2_1b() -> TransformerDecoder:
         norm_eps=1e-5,
         rope_base=500_000,
         scale_factor=32,
+        tie_word_embeddings=tie_word_embeddings,
     )
-def llama3_2_3b() -> TransformerDecoder:
+def llama3_2_3b(
+    tie_word_embeddings: bool = True,
+) -> TransformerDecoder:
     """
     Builder for creating a Llama3.2 model initialized w/ the default 3b parameter values.
+
+    Args:
+        tie_word_embeddings (bool): whether the model's input and output word embeddings should be tied.
 
     Returns:
         TransformerDecoder: Instantiation of Llama3.2 3B model
@@ -55,6 +66,7 @@ def llama3_2_3b() -> TransformerDecoder:
         norm_eps=1e-5,
         rope_base=500_000,
         scale_factor=32,
+        tie_word_embeddings=tie_word_embeddings,
     )
 def lora_llama3_2_1b(
     lora_attn_modules: List[LORA_ATTN_MODULES],

--- a/torchtune/models/llama3_2/_model_builders.py
+++ b/torchtune/models/llama3_2/_model_builders.py
@@ -87,6 +87,7 @@ def lora_llama3_2_1b(
         use_dora (bool): Decompose the LoRA weight into magnitude and direction, as
             introduced in "DoRA: Weight-Decomposed Low-Rank Adaptation" (https://arxiv.org/abs/2402.09353).
         quantize_base (bool): Whether to quantize base model weights
+        tie_word_embeddings (bool): whether the model's input and output word embeddings should be tied.
 
     Returns:
         TransformerDecoder: Instantiation of Llama3.2 1B model with LoRA applied
@@ -144,6 +145,7 @@ def lora_llama3_2_3b(
         use_dora (bool): Decompose the LoRA weight into magnitude and direction, as
             introduced in "DoRA: Weight-Decomposed Low-Rank Adaptation" (https://arxiv.org/abs/2402.09353).
         quantize_base (bool): Whether to quantize base model weights
+        tie_word_embeddings (bool): whether the model's input and output word embeddings should be tied.
 
     Returns:
         TransformerDecoder: Instantiation of Llama3.2 3B model with LoRA applied

--- a/torchtune/models/llama3_2/_model_builders.py
+++ b/torchtune/models/llama3_2/_model_builders.py
@@ -65,6 +65,7 @@ def lora_llama3_2_1b(
     lora_dropout: float = 0.0,
     use_dora: bool = False,
     quantize_base: bool = False,
+    tie_word_embeddings: bool = True,
 ) -> TransformerDecoder:
     """
     Builder for creating a Llama3.2 1B model with LoRA enabled.
@@ -110,6 +111,7 @@ def lora_llama3_2_1b(
         lora_dropout=lora_dropout,
         use_dora=use_dora,
         quantize_base=quantize_base,
+        tie_word_embeddings=tie_word_embeddings,
     )
 def lora_llama3_2_3b(
     lora_attn_modules: List[LORA_ATTN_MODULES],
@@ -120,6 +122,7 @@ def lora_llama3_2_3b(
     lora_dropout: float = 0.0,
     use_dora: bool = False,
     quantize_base: bool = False,
+    tie_word_embeddings: bool = True,
 ) -> TransformerDecoder:
     """
     Builder for creating a Llama3.2 3B model with LoRA enabled.
@@ -166,6 +169,7 @@ def lora_llama3_2_3b(
         lora_dropout=lora_dropout,
         use_dora=use_dora,
         quantize_base=quantize_base,
+        tie_word_embeddings=tie_word_embeddings,
     )
 qlora_llama3_2_1b = partial(lora_llama3_2_1b, quantize_base=True)
 qlora_llama3_2_1b.__doc__ = """


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

https://github.com/pytorch/torchtune/issues/2237

#### Changelog
What are the changes made in this PR?
* added `tie_word_embeddings` to llama3_2 models. It resolved the errors during model loading. However, the generated models are still not working properly yet. Need more investigation. 

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
