### PR TITLE
Update to proper EOS ids for Qwen2 and Qwen2.5

### DIFF
--- a/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
+++ b/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
@@ -59,7 +59,7 @@ class TestQwenTokenizer:
                            1506, 416, 114, 128, 1429, 182, 253, 82, 120, 163, 330, 105, 262, 13, 223, 1791, 155, 1551,
                            171, 1951, 628, 296, 64, 237, 886, 1390, 130, 883, 1678, 447, 306, 279, 113, 11, 215, 785,
                            215, 1951, 628, 378, 101, 66, 72, 593, 98, 984, 208, 1580, 167, 510, 737, 318, 1278, 13,
-                           2000] # noqa
+                           2002] # noqa
         # fmt: on
 
         expected_mask = [True] * 67 + [False] * 121
@@ -69,8 +69,9 @@ class TestQwenTokenizer:
         formatted_messages = tokenizer.decode(tokens)
         expected_formatted_messages = (
             f"<|im_start|>user\n{messages[0].text_content}<|im_end|>\n"
-            f"<|im_start|>assistant\n{messages[1].text_content}<|endoftext|>"
+            f"<|im_start|>assistant\n{messages[1].text_content}<|im_end|>"
         )
+
         assert expected_formatted_messages == formatted_messages
 
     def test_tokenize_messages_gt_max_seq_len(self, messages):

--- a/tests/torchtune/models/qwen2_5/test_tokenizer.py
+++ b/tests/torchtune/models/qwen2_5/test_tokenizer.py
@@ -29,7 +29,7 @@ class TestQwen2_5Tokenizer:  # noqa: N801
         expected_tokens = [
             151644, 82, 88, 479, 94, 56, 119, 230, 98, 374, 494, 1318, 249, 13, 151645, 94, 151644, 273, 105, 94,
             38, 229, 362, 98, 1695, 310, 1305, 165, 128, 432, 43, 44, 82, 13, 151645, 94, 151644, 397, 251, 249, 94,
-            151643,
+            151645,
         ] # noqa
         # fmt: on
 
@@ -39,7 +39,7 @@ class TestQwen2_5Tokenizer:  # noqa: N801
             "<|im_start|>user\n"
             "Give me a short introduction to LLMs.<|im_end|>\n"
             "<|im_start|>assistant\n"
-            "<|endoftext|>"
+            "<|im_end|>"
         )
         _test_tokenize_messages(
             tokenizer,
@@ -62,7 +62,7 @@ class TestQwen2_5Tokenizer:  # noqa: N801
             151644, 82, 88, 479, 94, 64, 151645, 94, 151644, 273, 105, 94, 65, 151645, 94, 151644, 397, 251, 249,
             94, 151657, 94, 83, 269, 107, 330, 94, 151658, 151645, 94, 151644, 273, 105, 94, 27, 83, 1364,
             62, 237, 79, 102, 182, 29, 94, 83, 269, 706, 102, 182, 94, 1932, 83, 1364, 62, 237, 79, 102,
-            182, 29, 151645, 94, 151644, 397, 251, 249, 94, 151643,
+            182, 29, 151645, 94, 151644, 397, 251, 249, 94, 151645,
         ] # noqa
         # fmt: on
 
@@ -80,7 +80,7 @@ class TestQwen2_5Tokenizer:  # noqa: N801
             "test response\n"
             "</tool_response><|im_end|>\n"
             "<|im_start|>assistant\n"
-            "<|endoftext|>"
+            "<|im_end|>"
         )
         _test_tokenize_messages(
             tokenizer,

--- a/torchtune/models/qwen2/_tokenizer.py
+++ b/torchtune/models/qwen2/_tokenizer.py
@@ -125,9 +125,9 @@ class Qwen2Tokenizer(ModelTokenizer):
         *,
         prompt_template: Optional[PromptTemplate] = None,
         errors: str = "replace",
-        unk_token: Optional[str] = ENDOFTEXT,
+        unk_token: Optional[str] = None,
         bos_token: Optional[str] = None,
-        eos_token: str = ENDOFTEXT,
+        eos_token: str = IM_END,
         pad_token: Optional[str] = ENDOFTEXT,
         bpe_cache_size: int = DEFAULT_QWEN2_TOKENIZER_BPE_CACHE_SIZE,
     ):
@@ -160,7 +160,7 @@ class Qwen2Tokenizer(ModelTokenizer):
         self.pad_id = None if pad_token is None else self.special_tokens[pad_token]
         self.im_start_id = self.special_tokens[IM_START]
         self.im_end_id = self.special_tokens[IM_END]
-        self.stop_tokens = [self.eos_id, self.im_end_id]
+        self.stop_tokens = [self.eos_id, self.pad_id]
 
         # Pattern for special tokens.
         self._pattern_split_special_tokens = re.compile(
@@ -168,7 +168,6 @@ class Qwen2Tokenizer(ModelTokenizer):
         )
 
         self.max_seq_len = max_seq_len
-
         self.prompt_template = prompt_template
 
     def _bpe_without_cache(self, token):

--- a/torchtune/models/qwen2_5/_tokenizer.py
+++ b/torchtune/models/qwen2_5/_tokenizer.py
@@ -92,9 +92,9 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
         *,
         prompt_template: Optional[PromptTemplate] = None,
         errors: str = "replace",
-        unk_token: Optional[str] = ENDOFTEXT,
+        unk_token: Optional[str] = None,
         bos_token: Optional[str] = None,
-        eos_token: str = ENDOFTEXT,
+        eos_token: str = IM_END,
         pad_token: Optional[str] = ENDOFTEXT,
         bpe_cache_size: int = DEFAULT_QWEN2_TOKENIZER_BPE_CACHE_SIZE,
     ):

--- a/torchtune/models/qwen2_5/_tokenizer.py
+++ b/torchtune/models/qwen2_5/_tokenizer.py
@@ -9,6 +9,7 @@ from torchtune.data import ChatMLTemplate, Message, PromptTemplate, truncate
 from torchtune.models.qwen2._tokenizer import (
     DEFAULT_QWEN2_TOKENIZER_BPE_CACHE_SIZE,
     ENDOFTEXT,
+    IM_END,
     QWEN2_SPECIAL_TOKENS,
     Qwen2Tokenizer,
 )


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

As detailed in #2337, the ending token for Qwen2 and Qwen2.5 should actually be "<|im_end|>", not "<|endoftext|>". This fixes that and updates tests accordingly.

[Qwen2 tokenizer source](https://huggingface.co/Qwen/Qwen2-7B-Instruct/blob/main/tokenizer_config.json)
[Qwen2.5 tokenizer source](https://huggingface.co/Qwen/Qwen2.5-14B-Instruct/blob/main/tokenizer_config.json)

#### Changelog
What are the changes made in this PR?
* Change eos token id to be the token id for "<|im_end|>"
* Set UNK id to null b/c that's the same way it is in HF code
* Update tests

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
