### PR TITLE
Add max-autotune try/except if flex attn breaks

### DIFF
--- a/torchtune/modules/attention_utils.py
+++ b/torchtune/modules/attention_utils.py
@@ -30,6 +30,7 @@ if _SUPPORTS_FLEX_ATTENTION:
         # If user's torch version is <torch-2.7.0.dev20250205, compiling may fail.
         # using max-autotune fixes this issue. Context: https://github.com/pytorch/torchtune/issues/2113
         # TODO: deprecate me once 2.7 becomes stable.
+        _log.info("Compiling flex_attention failed. Retrying with mode='max-autotune'.")
         flex_attention_compiled = torch.compile(
             torch.compile(flex_attention, dynamic=False, mode="max-autotune")
         )

--- a/torchtune/modules/attention_utils.py
+++ b/torchtune/modules/attention_utils.py
@@ -22,7 +22,17 @@ if _SUPPORTS_FLEX_ATTENTION:
         flex_attention,
     )
 
-    flex_attention_compiled = torch.compile(flex_attention, dynamic=False)
+    try:
+        flex_attention_compiled = torch.compile(
+            torch.compile(flex_attention, dynamic=False)
+        )
+    except:
+        # If user's torch version is <torch-2.7.0.dev20250205, compiling may fail.
+        # using max-autotune fixes this issue. Context: https://github.com/pytorch/torchtune/issues/2113
+        # TODO: deprecate me once 2.7 becomes stable.
+        flex_attention_compiled = torch.compile(
+            torch.compile(flex_attention, dynamic=False, mode="max-autotune")
+        )
 
     # We cannot do nested compile, but flex attention only has perf benefits
     # when compiled. To insulate it from the compiler, we wrap it with


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Context: https://github.com/pytorch/torchtune/issues/2113
It doesnt break on nighttlies, but may break on 2.6 under some scenarios.

#### Changelog
Add try/except, so we dont disrupt normal workflows. If it breaks during compilation, then max-autotune kicks in. It looks ugly in the logs, and takes ~35s in the test i ran
![image](https://github.com/user-attachments/assets/82acde54-f824-43b4-b234-2caf38370872)


#### Test plan
Tested with 2.6 and 2.7, also with the repro mentioned in #2113

```
tune run full_finetune_single_device --config llama3_2/1B_full_single_device dataset.packed=True tokenizer.max_seq_len=512 dataset.split=train[:5%]
```
