### PR TITLE
Implements MLFlowLogger

### DIFF
--- a/docs/source/api_ref_training.rst
+++ b/docs/source/api_ref_training.rst
@@ -102,6 +102,7 @@ Various logging utilities.
     metric_logging.TensorBoardLogger
     metric_logging.StdoutLogger
     metric_logging.DiskLogger
+    metric_logging.MLFlowLogger
 
 .. _perf_profiling_label:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ tune = "torchtune._cli.tune:main"
 dev = [
     "bitsandbytes>=0.43.0",
     "comet_ml>=3.44.2",
+    "mlflow",
     "pre-commit",
     "pytest==7.4.0",
     "pytest-cov",

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -48,12 +48,30 @@ def save_config(config: DictConfig) -> Path:
         log.warning(f"Error saving config.\nError: \n{e}.")
 
 
-def flatten_dict(d, parent_key="", sep="."):
+def flatten_dict(d: Dict[str, Any], sep: str = ".", parent_key: str = ""):
+    """Recursively flattens a nested dictionary into one level of key-value pairs.
+
+    Args:
+        d (Dict[str, Any]): Any dictionary to flatten
+        sep (str): Desired separator for flattening nested keys
+        parent_key (str): Key prefix for children (nested keys), containing parent key
+            names
+
+    Example:
+        >>> flatten_dict({"foo": {"bar": "baz"}, "qux"; "quux"}, parent_key="--")
+        {"foo--bar": "baz", "qux", "quux"}
+
+    Returns:
+        Flattened dictionary
+
+    Note:
+        Does not unnest dictionaries within list values (i.e. {"foo": [{"bar": "baz}]}})
+    """
     items = []
     for k, v in d.items():
         new_key = f"{parent_key}{sep}{k}" if parent_key else k
         if isinstance(v, dict):
-            items.extend(flatten_dict(v, new_key, sep=sep).items())
+            items.extend(flatten_dict(v, sep=sep, parent_key=new_key).items())
         else:
             items.append((new_key, v))
     return dict(items)

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -530,11 +530,9 @@ class MLFlowLogger(MetricLoggerInterface):
 
         self._mlflow = mlflow
 
-        self._tracking_uri = tracking_uri or os.getenv("MLFLOW_TRACKING_URI", None)
-        self._experiment_name = experiment_name or os.getenv(
-            "MLFLOW_EXPERIMENT_NAME", None
-        )
-        self._run_id = run_id or os.getenv("MLFLOW_RUN_ID", None)
+        self._tracking_uri = tracking_uri or os.getenv("MLFLOW_TRACKING_URI")
+        self._experiment_name = experiment_name or os.getenv("MLFLOW_EXPERIMENT_NAME")
+        self._run_id = run_id or os.getenv("MLFLOW_RUN_ID")
 
         if self.rank == 0:
             if not self._mlflow.is_tracking_uri_set():

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -483,7 +483,7 @@ class CometLogger(MetricLoggerInterface):
 
 
 class MLFlowLogger(MetricLoggerInterface):
-    """Logger for use w/ MLFlow.
+    """Logger for use w/ MLFlow (https://mlflow.org/).
 
     Args:
         experiment_name (Optional[str]): MLFlow experiment name. If not specified, will
@@ -497,7 +497,7 @@ class MLFlowLogger(MetricLoggerInterface):
             to MLFLOW_RUN_ID environment variable if set, or a new run will be created.
 
     Example:
-        >>> logger = MLFlowLogger(experiment_name="my_experiment", run_name="run1", log_dir="./mlruns")
+        >>> logger = MLFlowLogger(experiment_name="my_experiment", run_name="run1")
         >>> logger.log("accuracy", 0.95, step=1)
         >>> logger.log_dict({"loss": 0.1, "accuracy": 0.95}, step=1)
         >>> logger.log_config(config)

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -482,49 +482,6 @@ class CometLogger(MetricLoggerInterface):
         self.close()
 
 
-class MetricLoggerInterface(Protocol):
-    """Abstract metric logger."""
-
-    def log(
-        self,
-        name: str,
-        data: Scalar,
-        step: int,
-    ) -> None:
-        """Log scalar data.
-
-        Args:
-            name (str): tag name used to group scalars
-            data (Scalar): scalar data to log
-            step (int): step value to record
-        """
-        pass
-
-    def log_config(self, config: DictConfig) -> None:
-        """Logs the config as file
-
-        Args:
-            config (DictConfig): config to log
-        """
-        pass
-
-    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
-        """Log multiple scalar values.
-
-        Args:
-            payload (Mapping[str, Scalar]): dictionary of tag name and scalar value
-            step (int): step value to record
-        """
-        pass
-
-    def close(self) -> None:
-        """
-        Close log resource, flushing if necessary.
-        Logs should not be written after `close` is called.
-        """
-        pass
-
-
 class MLFlowLogger(MetricLoggerInterface):
     """Logger for use w/ MLFlow.
 

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -48,24 +48,23 @@ def save_config(config: DictConfig) -> Path:
         log.warning(f"Error saving config.\nError: \n{e}.")
 
 
-def flatten_dict(d: Dict[str, Any], sep: str = ".", parent_key: str = ""):
+def flatten_dict(d: Dict[str, Any], *, sep: str = ".", parent_key: str = ""):
     """Recursively flattens a nested dictionary into one level of key-value pairs.
 
     Args:
-        d (Dict[str, Any]): Any dictionary to flatten
-        sep (str): Desired separator for flattening nested keys
-        parent_key (str): Key prefix for children (nested keys), containing parent key
-            names
+        d (Dict[str, Any]): Any dictionary to flatten.
+        sep (str, optional): Desired separator for flattening nested keys. Defaults to ".".
+        parent_key (str, optional): Key prefix for children (nested keys), containing parent key names. Defaults to "".
 
     Example:
-        >>> flatten_dict({"foo": {"bar": "baz"}, "qux"; "quux"}, parent_key="--")
-        {"foo--bar": "baz", "qux", "quux"}
+        >>> flatten_dict({"foo": {"bar": "baz"}, "qux": "quux"}, sep="--")
+        {"foo--bar": "baz", "qux": "quux"}
 
     Returns:
-        Flattened dictionary
+        Dict[str, Any]: Flattened dictionary.
 
     Note:
-        Does not unnest dictionaries within list values (i.e. {"foo": [{"bar": "baz}]}})
+        Does not unnest dictionaries within list values (i.e., {"foo": [{"bar": "baz"}]}).
     """
     items = []
     for k, v in d.items():

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -48,6 +48,17 @@ def save_config(config: DictConfig) -> Path:
         log.warning(f"Error saving config.\nError: \n{e}.")
 
 
+def flatten_dict(d, parent_key="", sep="."):
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
 class MetricLoggerInterface(Protocol):
     """Abstract metric logger."""
 
@@ -469,3 +480,159 @@ class CometLogger(MetricLoggerInterface):
 
     def __del__(self) -> None:
         self.close()
+
+
+class MetricLoggerInterface(Protocol):
+    """Abstract metric logger."""
+
+    def log(
+        self,
+        name: str,
+        data: Scalar,
+        step: int,
+    ) -> None:
+        """Log scalar data.
+
+        Args:
+            name (str): tag name used to group scalars
+            data (Scalar): scalar data to log
+            step (int): step value to record
+        """
+        pass
+
+    def log_config(self, config: DictConfig) -> None:
+        """Logs the config as file
+
+        Args:
+            config (DictConfig): config to log
+        """
+        pass
+
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
+        """Log multiple scalar values.
+
+        Args:
+            payload (Mapping[str, Scalar]): dictionary of tag name and scalar value
+            step (int): step value to record
+        """
+        pass
+
+    def close(self) -> None:
+        """
+        Close log resource, flushing if necessary.
+        Logs should not be written after `close` is called.
+        """
+        pass
+
+
+class MLFlowLogger(MetricLoggerInterface):
+    """Logger for use w/ MLFlow.
+
+    Args:
+        experiment_name (Optional[str]): MLFlow experiment name. If not specified, will
+            default to MLFLOW_EXPERIMENT_NAME environment variable if set, or default.
+        tracking_uri (Optional[str]): MLFlow tracking uri. If not specified, will default
+            to MLFLOW_TRACKING_URI environment variable if set, or default.
+        run_id (Optional[str]): MLFlow run name. If not specified, will default
+            to mlflow-generated HRID. Unused if run_id is specified or MLFLOW_RUN_ID
+            environment variable is found.
+        run_name (Optional[str]): MLFlow run ID. If not specified, will default
+            to MLFLOW_RUN_ID environment variable if set, or a new run will be created.
+
+    Example:
+        >>> logger = MLFlowLogger(experiment_name="my_experiment", run_name="run1", log_dir="./mlruns")
+        >>> logger.log("accuracy", 0.95, step=1)
+        >>> logger.log_dict({"loss": 0.1, "accuracy": 0.95}, step=1)
+        >>> logger.log_config(config)
+        >>> logger.close()
+
+    Raises:
+        ImportError: If ``mlflow`` package is not installed.
+
+    Note:
+        This logger requires the mlflow package to be installed.
+        You can install it with `pip install mlflow`.
+    """
+
+    def __init__(
+        self,
+        experiment_name: Optional[str] = None,
+        tracking_uri: Optional[str] = None,
+        run_id: Optional[str] = None,
+        run_name: Optional[str] = None,
+    ):
+        try:
+            import mlflow
+        except ImportError as e:
+            raise ImportError(
+                "``mlflow`` package not found. Please install mlflow using `pip install mlflow` to use MLFlowLogger."
+                "Alternatively, use the ``StdoutLogger``, which can be specified by setting metric_logger_type='stdout'."
+            ) from e
+
+        _, self.rank = get_world_size_and_rank()
+
+        self._mlflow = mlflow
+
+        self._tracking_uri = tracking_uri or os.getenv("MLFLOW_TRACKING_URI", None)
+        self._experiment_name = experiment_name or os.getenv(
+            "MLFLOW_EXPERIMENT_NAME", None
+        )
+        self._run_id = run_id or os.getenv("MLFLOW_RUN_ID", None)
+
+        if self.rank == 0:
+            if not self._mlflow.is_tracking_uri_set():
+                if self._tracking_uri:
+                    self._mlflow.set_tracking_uri(self._tracking_uri)
+
+            if self._mlflow.active_run() is None or self._nested_run or self._run_id:
+                if self._experiment_name:
+                    # Use of set_experiment() ensure that Experiment is created if not exists
+                    self._mlflow.set_experiment(self._experiment_name)
+                run = self._mlflow.start_run(run_name=run_name)
+                self._run_id = run.info.run_id
+
+    def log_config(self, config: DictConfig) -> None:
+        """Saves the config locally and also logs the config to mlflow. The config is
+        stored in the same directory as the checkpoint.
+
+        Args:
+            config (DictConfig): config to log
+        """
+        if self._mlflow.active_run():
+            resolved = OmegaConf.to_container(config, resolve=True)
+
+            # mlflow's params must be flat key-value pairs
+            config_as_params = flatten_dict(resolved)
+            self._mlflow.log_params(config_as_params, run_id=self._run_id)
+
+            output_config_fname = save_config(config)
+
+            # this avoids break if config's output_dir is an absolute path
+            artifact_path = str(output_config_fname.parent).lstrip("/")
+
+            self._mlflow.log_artifact(
+                output_config_fname,
+                artifact_path=artifact_path,
+                run_id=self._run_id,
+            )
+
+    def log(self, name: str, data: Scalar, step: int) -> None:
+        if self._mlflow.active_run():
+            self._mlflow.log_metric(name, data, step=step, run_id=self._run_id)
+
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
+        if self._mlflow.active_run():
+            self._mlflow.log_metrics(payload, step=step, run_id=self._run_id)
+
+    def close(self) -> None:
+        """
+        Ends the MLflow run.
+        After calling close, no further logging should be performed.
+        """
+        if self.rank == 0 and self._mlflow.active_run():
+            self._mlflow.end_run()
+
+    def __del__(self) -> None:
+        # Ensure the MLflow run is closed when the logger is deleted.
+        if hasattr(self, "_mlflow") and self._mlflow.active_run():
+            self._mlflow.end_run()

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -554,11 +554,11 @@ class MLFlowLogger(MetricLoggerInterface):
 
         if self.rank == 0:
             if not self._mlflow.is_tracking_uri_set():
-                if self._tracking_uri:
+                if self._tracking_uri is not None:
                     self._mlflow.set_tracking_uri(self._tracking_uri)
 
             if self._mlflow.active_run() is None or self._nested_run or self._run_id:
-                if self._experiment_name:
+                if self._experiment_name is not None:
                     # Use of set_experiment() ensure that Experiment is created if not exists
                     self._mlflow.set_experiment(self._experiment_name)
                 run = self._mlflow.start_run(run_name=run_name)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
Implements a basic MLFlowLogger in-line with the functionality of the other loggers.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings

----------

Note the MLFlowLogger's init was heavily inspired by the HF trainer's [MLflowCallback](https://github.com/huggingface/transformers/blob/v4.48.2/src/transformers/integrations/integration_utils.py#L1229). In-line with the other loggers, key identifiers (experiment name, run ID) can be overridden, but are often set in MLFlow via environment variables. 

Fixes https://github.com/pytorch/torchtune/issues/2211, interest shown in https://github.com/pytorch/torchtune/discussions/2103

#### Images

Logging the config shows, nested under the same path as the config output directory (this looks like it aligns to other loggers, but it's a bit ugly - do we want to keep it or should we always log in the artifact root as `torchtune_config.yaml`?)

<img width="1617" alt="image" src="https://github.com/user-attachments/assets/2dbfccf1-eefb-4b80-95ce-1a90dbbb7c4f" />

Parameters and metrics show in the run overview, with nested parameters period-separated (e.g. `profiler.profile_memory`)

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/bbfedb51-b055-4dad-99d5-c500b3d514ab" />

Metrics also display over-time in the Model Metrics tab according to the logging steps

<img width="1705" alt="image" src="https://github.com/user-attachments/assets/ffe27df4-d940-4eaa-8741-4ec489fcdc01" />