### PR TITLE
Refactor load_image to return torch.Tensor instead of PIL.Image

### DIFF
--- a/tests/torchtune/data/test_data_utils.py
+++ b/tests/torchtune/data/test_data_utils.py
@@ -122,7 +122,7 @@ def test_load_image(monkeypatch, tmp_path):
     assert image.size() == (3, 403, 580)
 
     # Test that a ValueError is raised when the image path is invalid
-    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
+    with pytest.raises(ValueError, match="Failed to load local image as torch.Tensor"):
         load_image("invalid_path")
 
     # Test a temporary file with invalid image data
@@ -131,16 +131,16 @@ def test_load_image(monkeypatch, tmp_path):
         f.write("Invalid image data")
 
     # Test that a ValueError is raised when the image data is invalid
-    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
+    with pytest.raises(ValueError, match="Failed to load local image as torch.Tensor"):
         load_image(str(image_path))
 
     # Test that a ValueError is raised when there is an HTTP error
     # Mock the urlopen function to raise an exception
     def mock_urlopen(url):
-        raise Exception("Failed to load image")
+        raise Exception("Failed to load remote image as torch.Tensor")
 
     monkeypatch.setattr("urllib.request.urlopen", mock_urlopen)
-    with pytest.raises(ValueError, match="Failed to load image"):
+    with pytest.raises(ValueError, match="Failed to load remote image as torch.Tensor"):
         load_image("http://example.com/test_image.jpg")
 
     # Test that a ValueError is raised when there is an IO error
@@ -149,7 +149,7 @@ def test_load_image(monkeypatch, tmp_path):
     with open(image_path, "w") as f:
         f.write("Test data")
     os.chmod(image_path, 0o000)  # Remove read permissions
-    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
+    with pytest.raises(ValueError, match="Failed to load local image as torch.Tensor"):
         load_image(str(image_path))
     os.chmod(image_path, 0o644)  # Restore read permissions
 
@@ -158,5 +158,5 @@ def test_load_image(monkeypatch, tmp_path):
     image_path = tmp_path / "test_image.jpg"
     with open(image_path, "wb") as f:
         f.write(b"Invalid image data")
-    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
+    with pytest.raises(ValueError, match="Failed to load local image as torch.Tensor"):
         load_image(str(image_path))

--- a/tests/torchtune/data/test_data_utils.py
+++ b/tests/torchtune/data/test_data_utils.py
@@ -7,6 +7,7 @@
 import os
 
 import pytest
+import torch
 from PIL import Image
 
 from tests.common import ASSETS
@@ -107,8 +108,8 @@ def test_load_image(monkeypatch, tmp_path):
 
     # Test loading from local file
     image = load_image(tmp_image)
-    assert isinstance(image, Image.Image)
-    assert image.size == (580, 403)
+    assert isinstance(image, torch.Tensor)
+    assert image.size() == (3, 403, 580)
 
     # Test loading from remote file
     # Mock the urlopen function to return a BytesIO object
@@ -117,11 +118,11 @@ def test_load_image(monkeypatch, tmp_path):
 
     monkeypatch.setattr("urllib.request.urlopen", mock_urlopen)
     image = load_image("http://example.com/test_image.jpg")
-    assert isinstance(image, Image.Image)
-    assert image.size == (580, 403)
+    assert isinstance(image, torch.Tensor)
+    assert image.size() == (3, 403, 580)
 
     # Test that a ValueError is raised when the image path is invalid
-    with pytest.raises(ValueError, match="Failed to open image as PIL.Image"):
+    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
         load_image("invalid_path")
 
     # Test a temporary file with invalid image data
@@ -130,7 +131,7 @@ def test_load_image(monkeypatch, tmp_path):
         f.write("Invalid image data")
 
     # Test that a ValueError is raised when the image data is invalid
-    with pytest.raises(ValueError, match="Failed to open image as PIL.Image"):
+    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
         load_image(str(image_path))
 
     # Test that a ValueError is raised when there is an HTTP error
@@ -148,7 +149,7 @@ def test_load_image(monkeypatch, tmp_path):
     with open(image_path, "w") as f:
         f.write("Test data")
     os.chmod(image_path, 0o000)  # Remove read permissions
-    with pytest.raises(ValueError, match="Failed to open image as PIL.Image"):
+    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
         load_image(str(image_path))
     os.chmod(image_path, 0o644)  # Restore read permissions
 
@@ -157,5 +158,5 @@ def test_load_image(monkeypatch, tmp_path):
     image_path = tmp_path / "test_image.jpg"
     with open(image_path, "wb") as f:
         f.write(b"Invalid image data")
-    with pytest.raises(ValueError, match="Failed to open image as PIL.Image"):
+    with pytest.raises(ValueError, match="Failed to open image as torch.Tensor"):
         load_image(str(image_path))

--- a/tests/torchtune/datasets/multimodal/test_vqa_dataset.py
+++ b/tests/torchtune/datasets/multimodal/test_vqa_dataset.py
@@ -5,10 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-from PIL.PngImagePlugin import PngImageFile
+
+import torch
 from tests.common import ASSETS
 from tests.test_utils import DummyTokenizer
-
 from torchtune.datasets.multimodal import vqa_dataset
 
 
@@ -46,7 +46,7 @@ class TestMultimodalInstructDataset:
             )
             assert prompt == expected_tokens[i]
             assert label == expected_labels[i]
-            assert isinstance(image[0], PngImageFile)
+            assert isinstance(image[0], torch.Tensor)
 
     def test_dataset_fails_with_packed(self, tokenizer):
         with pytest.raises(

--- a/tests/torchtune/models/clip/test_clip_image_transform.py
+++ b/tests/torchtune/models/clip/test_clip_image_transform.py
@@ -31,6 +31,7 @@ class TestCLIPImageTransform:
         [
             {
                 "image_size": (100, 400, 3),
+                "image_type": "PIL.Image",
                 "expected_shape": torch.Size([2, 3, 224, 224]),
                 "resize_to_max_canvas": False,
                 "expected_tile_means": [0.2230, 0.1763],
@@ -40,6 +41,7 @@ class TestCLIPImageTransform:
             },
             {
                 "image_size": (1000, 300, 3),
+                "image_type": "PIL.Image",
                 "expected_shape": torch.Size([4, 3, 224, 224]),
                 "resize_to_max_canvas": True,
                 "expected_tile_means": [0.5007, 0.4995, 0.5003, 0.1651],
@@ -49,6 +51,7 @@ class TestCLIPImageTransform:
             },
             {
                 "image_size": (200, 200, 3),
+                "image_type": "PIL.Image",
                 "expected_shape": torch.Size([4, 3, 224, 224]),
                 "resize_to_max_canvas": True,
                 "expected_tile_means": [0.5012, 0.5020, 0.5011, 0.4991],
@@ -59,6 +62,48 @@ class TestCLIPImageTransform:
             },
             {
                 "image_size": (600, 200, 3),
+                "image_type": "torch.Tensor",
+                "expected_shape": torch.Size([3, 3, 224, 224]),
+                "resize_to_max_canvas": False,
+                "expected_tile_means": [0.4473, 0.4469, 0.3032],
+                "expected_tile_max": [1.0, 1.0, 1.0],
+                "expected_tile_min": [0.0, 0.0, 0.0],
+                "expected_aspect_ratio": [3, 1],
+            },
+            {
+                "image_size": (100, 400, 3),
+                "image_type": "torch.Tensor",
+                "expected_shape": torch.Size([2, 3, 224, 224]),
+                "resize_to_max_canvas": False,
+                "expected_tile_means": [0.2230, 0.1763],
+                "expected_tile_max": [1.0, 1.0],
+                "expected_tile_min": [0.0, 0.0],
+                "expected_aspect_ratio": [1, 2],
+            },
+            {
+                "image_size": (1000, 300, 3),
+                "image_type": "torch.Tensor",
+                "expected_shape": torch.Size([4, 3, 224, 224]),
+                "resize_to_max_canvas": True,
+                "expected_tile_means": [0.5007, 0.4995, 0.5003, 0.1651],
+                "expected_tile_max": [0.9705, 0.9694, 0.9521, 0.9314],
+                "expected_tile_min": [0.0353, 0.0435, 0.0528, 0.0],
+                "expected_aspect_ratio": [4, 1],
+            },
+            {
+                "image_size": (200, 200, 3),
+                "image_type": "torch.Tensor",
+                "expected_shape": torch.Size([4, 3, 224, 224]),
+                "resize_to_max_canvas": True,
+                "expected_tile_means": [0.5012, 0.5020, 0.5011, 0.4991],
+                "expected_tile_max": [0.9922, 0.9926, 0.9970, 0.9908],
+                "expected_tile_min": [0.0056, 0.0069, 0.0059, 0.0033],
+                "expected_aspect_ratio": [2, 2],
+                "pad_tiles": 1,
+            },
+            {
+                "image_size": (600, 200, 3),
+                "image_type": "torch.Tensor",
                 "expected_shape": torch.Size([3, 3, 224, 224]),
                 "resize_to_max_canvas": False,
                 "expected_tile_means": [0.4473, 0.4469, 0.3032],
@@ -99,7 +144,10 @@ class TestCLIPImageTransform:
             .reshape(image_size)
             .astype(np.uint8)
         )
-        image = PIL.Image.fromarray(image)
+        if params["image_type"] == "PIL.Image":
+            image = PIL.Image.fromarray(image)
+        elif params["image_type"] == "torch.Tensor":
+            image = torch.from_numpy(image).permute(2, 0, 1)
 
         # Apply the transformation
         output = image_transform({"image": image})

--- a/torchtune/data/_utils.py
+++ b/torchtune/data/_utils.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, TypeVar, Union
 from urllib import request
 
+import torch
+import torchvision
 from datasets import load_dataset
 from datasets.distributed import split_dataset_by_node
 from torch.utils.data import default_collate, DistributedSampler
@@ -44,9 +46,9 @@ def truncate(
     return tokens_truncated
 
 
-def load_image(image_loc: Union[Path, str]) -> "PIL.Image.Image":
+def load_image(image_loc: Union[Path, str]) -> "torch.Tensor":
     """
-    Convenience method to load an image in PIL format from a local file path or remote source.
+    Convenience method to load an image in torch.Tensor format from a local file path or remote source.
 
     Args:
         image_loc (Union[Path, str]): Local file path or remote source pointing to the image
@@ -59,7 +61,7 @@ def load_image(image_loc: Union[Path, str]) -> "PIL.Image.Image":
     Raises:
         ValueError:
             If the image cannot be loaded from remote source, **or**
-            if the image cannot be opened as a :class:`~PIL.Image.Image`.
+            if the image cannot be opened as a :class:`~torch.Tensor`.
 
     Examples:
         >>> # Load from remote source
@@ -69,25 +71,24 @@ def load_image(image_loc: Union[Path, str]) -> "PIL.Image.Image":
         >>> image = load_image(Path("/home/user/bird.jpg"))
 
     Returns:
-        PIL.Image.Image: The loaded image.
+        torch.Tensor: The loaded image.
     """
-    # Hackily import PIL to avoid burdensome import in the main module
-    # TODO: Fix this
-    from PIL import Image
-
     # If pointing to remote source, try to load to local
     if isinstance(image_loc, str) and image_loc.startswith("http"):
         try:
-            image_loc = request.urlopen(image_loc)
+            image_loc = request.urlopen(image_loc).read()
+            image = torchvision.io.decode_image(
+                torch.frombuffer(image_loc, dtype=torch.uint8)
+            )
         except Exception as e:
-            raise ValueError(f"Failed to load image from {image_loc}") from e
+            raise ValueError("Failed to load image as torch.Tensor") from e
 
-    # Open the local image as a PIL image
-    try:
-        image = Image.open(image_loc)
-    except Exception as e:
-        raise ValueError(f"Failed to open image as PIL Image from {image_loc}") from e
-
+    # Open the local image as a Tensor image
+    else:
+        try:
+            image = torchvision.io.decode_image(image_loc)
+        except Exception as e:
+            raise ValueError("Failed to open image as torch.Tensor") from e
     return image
 
 

--- a/torchtune/data/_utils.py
+++ b/torchtune/data/_utils.py
@@ -78,7 +78,8 @@ def load_image(image_loc: Union[Path, str]) -> torch.Tensor:
         try:
             image_loc = request.urlopen(image_loc).read()
             image = torchvision.io.decode_image(
-                torch.frombuffer(image_loc, dtype=torch.uint8)
+                torch.frombuffer(image_loc, dtype=torch.uint8),
+                mode="RGB",
             )
         except Exception as e:
             raise ValueError("Failed to load remote image as torch.Tensor") from e
@@ -86,7 +87,7 @@ def load_image(image_loc: Union[Path, str]) -> torch.Tensor:
     # Open the local image as a Tensor image
     else:
         try:
-            image = torchvision.io.decode_image(image_loc)
+            image = torchvision.io.decode_image(image_loc, mode="RGB")
         except Exception as e:
             raise ValueError("Failed to load local image as torch.Tensor") from e
     return image

--- a/torchtune/data/_utils.py
+++ b/torchtune/data/_utils.py
@@ -46,7 +46,7 @@ def truncate(
     return tokens_truncated
 
 
-def load_image(image_loc: Union[Path, str]) -> "torch.Tensor":
+def load_image(image_loc: Union[Path, str]) -> torch.Tensor:
     """
     Convenience method to load an image in torch.Tensor format from a local file path or remote source.
 
@@ -81,14 +81,14 @@ def load_image(image_loc: Union[Path, str]) -> "torch.Tensor":
                 torch.frombuffer(image_loc, dtype=torch.uint8)
             )
         except Exception as e:
-            raise ValueError("Failed to load image as torch.Tensor") from e
+            raise ValueError("Failed to load remote image as torch.Tensor") from e
 
     # Open the local image as a Tensor image
     else:
         try:
             image = torchvision.io.decode_image(image_loc)
         except Exception as e:
-            raise ValueError("Failed to open image as torch.Tensor") from e
+            raise ValueError("Failed to load local image as torch.Tensor") from e
     return image
 
 

--- a/torchtune/models/clip/_transform.py
+++ b/torchtune/models/clip/_transform.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple, Union
 
 import torch
 import torchvision
@@ -156,10 +156,12 @@ class CLIPImageTransform:
                 "aspect_ratio" field.
         """
         image = sample["image"]
-        assert isinstance(image, Image.Image), "Input image must be a PIL image."
+        assert isinstance(
+            image, Union[Image.Image, torch.Tensor]
+        ), "Input image must be a PIL image or a torch.Tensor."
 
         # Make image torch.tensor((3, H, W), dtype=dtype), 0<=values<=1
-        if image.mode != "RGB":
+        if isinstance(image, Image.Image) and image.mode != "RGB":
             image = image.convert("RGB")
         image = F.to_image(image)
         image = F.to_dtype(image, dtype=self.dtype, scale=True)

--- a/torchtune/models/clip/_transform.py
+++ b/torchtune/models/clip/_transform.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, List, Mapping, Optional, Tuple, Union
+from typing import Any, List, Mapping, Optional, Tuple
 
 import torch
 import torchvision
@@ -157,7 +157,7 @@ class CLIPImageTransform:
         """
         image = sample["image"]
         assert isinstance(
-            image, Union[Image.Image, torch.Tensor]
+            image, (Image.Image, torch.Tensor)
         ), "Input image must be a PIL image or a torch.Tensor."
 
         # Make image torch.tensor((3, H, W), dtype=dtype), 0<=values<=1

--- a/torchtune/models/clip/inference/_transform.py
+++ b/torchtune/models/clip/inference/_transform.py
@@ -257,7 +257,7 @@ class CLIPImageTransform:
     ) -> Mapping[str, Any]:
 
         assert isinstance(
-            image, Union[Image.Image, torch.Tensor]
+            image, (Image.Image, torch.Tensor)
         ), "Input image must be a PIL image or torch.Tensor."
 
         # Make image torch.tensor((3, H, W), dtype='float32'), 0<=values<=1.

--- a/torchtune/models/clip/inference/_transform.py
+++ b/torchtune/models/clip/inference/_transform.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple, Union
 
 import torch
 import torchvision
@@ -252,9 +252,13 @@ class CLIPImageTransform:
             antialias=self.antialias,
         )
 
-    def __call__(self, *, image: Image.Image, **kwargs) -> Mapping[str, Any]:
+    def __call__(
+        self, *, image: Union[Image.Image, torch.Tensor], **kwargs
+    ) -> Mapping[str, Any]:
 
-        assert isinstance(image, Image.Image), "Input image must be a PIL image."
+        assert isinstance(
+            image, Union[Image.Image, torch.Tensor]
+        ), "Input image must be a PIL image or torch.Tensor."
 
         # Make image torch.tensor((3, H, W), dtype='float32'), 0<=values<=1.
         image_tensor = F.to_dtype(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [X] other (refactor)

Please link to any issues this PR addresses. #2303 

#### Changelog
What are the changes made in this PR?
* Updated `load_image` to return `torch.Tensor` instead of `PIL.Image`
* Updated `CLIPImageTransform` to support both `torch.Tensor` and `PIL.Image`
* Added 4x new tests for `CLIPImageTransform` with `torch.Tensor` input

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [X] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [X] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [X] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [X] I have added an example to docs or docstrings
