### PR TITLE
feat: Added cfg.cudnn_deterministic_mode flag

### DIFF
--- a/recipes/dev/early_exit_finetune_distributed.py
+++ b/recipes/dev/early_exit_finetune_distributed.py
@@ -234,7 +234,7 @@ class EarlyExitFinetuneRecipeDistributed(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/dev/early_exit_finetune_distributed.py
+++ b/recipes/dev/early_exit_finetune_distributed.py
@@ -233,7 +233,9 @@ class EarlyExitFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/dev/early_exit_finetune_distributed.py
+++ b/recipes/dev/early_exit_finetune_distributed.py
@@ -233,7 +233,7 @@ class EarlyExitFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/dev/generate_v2.py
+++ b/recipes/dev/generate_v2.py
@@ -78,7 +78,9 @@ class InferenceRecipe:
         self._device = utils.get_device(device=cfg.device)
         self._dtype = training.get_dtype(dtype=cfg.dtype, device=self._device)
         self._logger = utils.get_logger(cfg.log_level)
-        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
+        )
 
     def setup(self, cfg: DictConfig) -> None:
         """Setup the model and transforms."""

--- a/recipes/dev/generate_v2.py
+++ b/recipes/dev/generate_v2.py
@@ -78,7 +78,7 @@ class InferenceRecipe:
         self._device = utils.get_device(device=cfg.device)
         self._dtype = training.get_dtype(dtype=cfg.dtype, device=self._device)
         self._logger = utils.get_logger(cfg.log_level)
-        training.set_seed(seed=cfg.seed)
+        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
 
     def setup(self, cfg: DictConfig) -> None:
         """Setup the model and transforms."""

--- a/recipes/dev/generate_v2_distributed.py
+++ b/recipes/dev/generate_v2_distributed.py
@@ -87,7 +87,7 @@ class InferenceRecipe:
         dist.init_process_group(backend="nccl")
         _, rank = utils.get_world_size_and_rank()
         self._is_rank_zero = rank == 0
-        training.set_seed(seed=cfg.seed)
+        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
 
     def setup(self, cfg: DictConfig) -> None:
         """Setup the model and transforms."""

--- a/recipes/dev/generate_v2_distributed.py
+++ b/recipes/dev/generate_v2_distributed.py
@@ -87,7 +87,9 @@ class InferenceRecipe:
         dist.init_process_group(backend="nccl")
         _, rank = utils.get_world_size_and_rank()
         self._is_rank_zero = rank == 0
-        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
+        )
 
     def setup(self, cfg: DictConfig) -> None:
         """Setup the model and transforms."""

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -451,7 +451,9 @@ class EleutherEvalRecipe(EvalRecipeInterface):
         self.device = utils.get_device(device=cfg.device)
         self.dtype = training.get_dtype(dtype=cfg.dtype, device=self.device)
         self.logger = utils.get_logger(cfg.get("log_level", "info"))
-        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
+        )
 
         # Eval specific variables
         self.limit = cfg.limit

--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -451,7 +451,7 @@ class EleutherEvalRecipe(EvalRecipeInterface):
         self.device = utils.get_device(device=cfg.device)
         self.dtype = training.get_dtype(dtype=cfg.dtype, device=self.device)
         self.logger = utils.get_logger(cfg.get("log_level", "info"))
-        training.set_seed(seed=cfg.seed)
+        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
 
         # Eval specific variables
         self.limit = cfg.limit

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -181,7 +181,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -180,7 +180,9 @@ class FullDPORecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -180,7 +180,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -199,7 +199,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -198,7 +198,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -198,7 +198,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -184,7 +184,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -185,7 +185,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -184,7 +184,9 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/generate.py
+++ b/recipes/generate.py
@@ -40,7 +40,7 @@ class InferenceRecipe:
         self._quantizer = config.instantiate(cfg.quantizer)
         self._quantization_mode = training.get_quantizer_mode(self._quantizer)
 
-        training.set_seed(seed=cfg.seed)
+        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
 
     def setup(self, cfg: DictConfig) -> None:
         checkpointer = config.instantiate(cfg.checkpointer)

--- a/recipes/generate.py
+++ b/recipes/generate.py
@@ -40,7 +40,9 @@ class InferenceRecipe:
         self._quantizer = config.instantiate(cfg.quantizer)
         self._quantization_mode = training.get_quantizer_mode(self._quantizer)
 
-        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
+        )
 
     def setup(self, cfg: DictConfig) -> None:
         checkpointer = config.instantiate(cfg.checkpointer)

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -130,7 +130,9 @@ class KDRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -130,7 +130,7 @@ class KDRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -131,7 +131,7 @@ class KDRecipeDistributed(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -128,7 +128,9 @@ class KDRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -128,7 +128,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -129,7 +129,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -173,7 +173,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -172,7 +172,9 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -172,7 +172,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -129,7 +129,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -130,7 +130,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -129,7 +129,9 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -152,7 +152,9 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -153,7 +153,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -152,7 +152,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_finetune_distributed_multi_dataset.py
+++ b/recipes/lora_finetune_distributed_multi_dataset.py
@@ -155,7 +155,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_finetune_distributed_multi_dataset.py
+++ b/recipes/lora_finetune_distributed_multi_dataset.py
@@ -156,7 +156,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/lora_finetune_distributed_multi_dataset.py
+++ b/recipes/lora_finetune_distributed_multi_dataset.py
@@ -155,7 +155,9 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -145,7 +145,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -144,7 +144,9 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -144,7 +144,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -133,7 +133,7 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         # manually setting up a generator for the recipe
         self._rng = torch.Generator(self._device).manual_seed(self.seed)
         self._total_steps = 0

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -133,7 +133,9 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         # manually setting up a generator for the recipe
         self._rng = torch.Generator(self._device).manual_seed(self.seed)
         self._total_steps = 0

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -134,7 +134,7 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         # manually setting up a generator for the recipe
         self._rng = torch.Generator(self._device).manual_seed(self.seed)

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -202,7 +202,7 @@ class QATRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -202,7 +202,9 @@ class QATRecipeDistributed(FTRecipeInterface):
 
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -203,7 +203,7 @@ class QATRecipeDistributed(FTRecipeInterface):
         # These are public properties which are updated by the checkpoint loader
         # when ``resume_from_checkpoint`` is `True` or validated in tests
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -175,7 +175,7 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
         self.seed = training.set_seed(
-            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
         )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -174,7 +174,9 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None)
+        )
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -174,7 +174,7 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # These attributes constitute the recipe state and are updated by ``load_checkpoint``
         # when ``resume_from_checkpoint`` is ``True``
-        self.seed = training.set_seed(seed=cfg.seed)
+        self.seed = training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
         self.epochs_run = 0
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch

--- a/recipes/quantize.py
+++ b/recipes/quantize.py
@@ -50,7 +50,7 @@ class QuantizationRecipe:
         self._dtype = training.get_dtype(dtype=cfg.dtype, device=self._device)
         self._quantizer = config.instantiate(cfg.quantizer)
         self._quantization_mode = training.get_quantizer_mode(self._quantizer)
-        training.set_seed(seed=cfg.seed)
+        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
 
     def load_checkpoint(self, checkpointer_cfg: DictConfig) -> Dict[str, Any]:
         self._checkpointer = config.instantiate(checkpointer_cfg)

--- a/recipes/quantize.py
+++ b/recipes/quantize.py
@@ -50,7 +50,9 @@ class QuantizationRecipe:
         self._dtype = training.get_dtype(dtype=cfg.dtype, device=self._device)
         self._quantizer = config.instantiate(cfg.quantizer)
         self._quantization_mode = training.get_quantizer_mode(self._quantizer)
-        training.set_seed(seed=cfg.seed, debug_mode=cfg.get("deterministic_mode", None))
+        training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
+        )
 
     def load_checkpoint(self, checkpointer_cfg: DictConfig) -> Dict[str, Any]:
         self._checkpointer = config.instantiate(checkpointer_cfg)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [x] fix a bug -> closes #2335
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog

`cfg.deterministic_mode` added for reproducibility

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings 
