### PR TITLE
Renamed parallelize_plan to tensor_parallel_plan

### DIFF
--- a/recipes/configs/llama3/70B_full.yaml
+++ b/recipes/configs/llama3/70B_full.yaml
@@ -21,7 +21,7 @@ output_dir: /tmp/torchtune/llama3_70B/full # /tmp may be deleted by your system.
 
 # Parallelism
 tensor_parallel_dim: 1
-parallelize_plan:
+tensor_parallel_plan:
   _component_: torchtune.models.llama3.base_llama_tp_plan
 
 # Tokenizer

--- a/recipes/configs/llama3/70B_generation_distributed.yaml
+++ b/recipes/configs/llama3/70B_generation_distributed.yaml
@@ -13,7 +13,7 @@ output_dir: ./
 model:
   _component_: torchtune.models.llama3.llama3_70b
 
-parallelize_plan:
+tensor_parallel_plan:
   _component_: torchtune.models.llama3.base_llama_tp_plan
 
 # Transform arguments

--- a/recipes/configs/llama3_1/70B_full.yaml
+++ b/recipes/configs/llama3_1/70B_full.yaml
@@ -20,7 +20,7 @@ output_dir: /tmp/torchtune/llama3_1_70B/full # /tmp may be deleted by your syste
 
 # Parallelism
 tensor_parallel_dim: 1
-parallelize_plan:
+tensor_parallel_plan:
   _component_: torchtune.models.llama3.base_llama_tp_plan
 
 # Tokenizer

--- a/recipes/configs/llama3_1/70B_generation_distributed.yaml
+++ b/recipes/configs/llama3_1/70B_generation_distributed.yaml
@@ -13,7 +13,7 @@ output_dir: ./
 model:
   _component_: torchtune.models.llama3_1.llama3_1_70b
 
-parallelize_plan:
+tensor_parallel_plan:
   _component_: torchtune.models.llama3.base_llama_tp_plan
 
 # Transform arguments

--- a/recipes/configs/llama3_3/70B_full.yaml
+++ b/recipes/configs/llama3_3/70B_full.yaml
@@ -20,7 +20,7 @@ output_dir: /tmp/torchtune/llama3_3_70B/full # /tmp may be deleted by your syste
 
 # Parallelism
 tensor_parallel_dim: 1
-parallelize_plan:
+tensor_parallel_plan:
   _component_: torchtune.models.llama3.base_llama_tp_plan
 
 # Tokenizer

--- a/recipes/configs/llama3_3/70B_generation_distributed.yaml
+++ b/recipes/configs/llama3_3/70B_generation_distributed.yaml
@@ -13,7 +13,7 @@ output_dir: ./
 model:
   _component_: torchtune.models.llama3_3.llama3_3_70b
 
-parallelize_plan:
+tensor_parallel_plan:
   _component_: torchtune.models.llama3.base_llama_tp_plan
 
 # Transform arguments

--- a/recipes/dev/generate_v2_distributed.py
+++ b/recipes/dev/generate_v2_distributed.py
@@ -111,7 +111,7 @@ class InferenceRecipe:
         parallelize_module(
             model,
             tp_device_mesh,
-            parallelize_plan=config.instantiate(cfg.parallelize_plan),
+            parallelize_plan=config.instantiate(cfg.tensor_parallel_plan),
         )
 
         with training.set_default_dtype(self._dtype), self._device:

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -145,11 +145,13 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         # Initialize distributed variables
         self.world_size, self.rank = utils.get_world_size_and_rank()
         self._is_rank_zero = self.rank == 0
-        self.parallelize_plan = config.instantiate(cfg.get("parallelize_plan", None))
+        self.tensor_parallel_plan = config.instantiate(
+            cfg.get("tensor_parallel_plan", None)
+        )
         self.tensor_parallel_dim = cfg.get("tensor_parallel_dim", 1)
-        if self.tensor_parallel_dim > 1 and self.parallelize_plan is None:
+        if self.tensor_parallel_dim > 1 and self.tensor_parallel_plan is None:
             raise ValueError(
-                "Parallelism plan need to be provided when tensor parallel is enabled."
+                "Tensor Parallel plan needs to be provided when tensor parallel is enabled."
             )
         if self.world_size % self.tensor_parallel_dim != 0:
             raise ValueError(
@@ -549,7 +551,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             parallelize_module(
                 model,
                 device_mesh["tp"],
-                parallelize_plan=self.parallelize_plan,
+                parallelize_plan=self.tensor_parallel_plan,
             )
 
         # We currently have two versions of activation checkpointing in this recipe

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -156,7 +156,7 @@ class TestFullFinetuneDistributedRecipe:
         tokenizer_path = Path(TOKENIZER_PATHS[model_type])
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
-        parallelize_plan = "torchtune.models.llama3.base_llama_tp_plan"
+        tp_plan = "torchtune.models.llama3.base_llama_tp_plan"
 
         # Config file needed for model conversion.
         write_hf_ckpt_config(ckpt_dir)
@@ -175,7 +175,7 @@ class TestFullFinetuneDistributedRecipe:
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
             tensor_parallel_dim={tensor_parallel_dim} \
-            parallelize_plan._component_={parallelize_plan} \
+            tensor_parallel_plan._component_={tp_plan} \
             metric_logger.filename={log_file} \
         """.split()
         model_config = MODEL_TEST_CONFIGS[model_type]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

Renamed `parallelize_plan` to disambiguate it from fsdp parallelization. New name is `tensor_parallel_plan`. This PR doesn't add changes to the docs as currently the docs have no reference to TP. Should that be added with this PR too?

#### Changelog
What are the changes made in this PR?
* parallelize_plan -> tensor_parallel_plan everywhere

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
