### PR TITLE
check if log_dir is not none

### DIFF
--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -243,7 +243,7 @@ class WandBLogger(MetricLoggerInterface):
         self.log_dir = kwargs.pop("dir", log_dir)
 
         # create log_dir if missing
-        if self.log_dir and not os.path.exists(self.log_dir):
+        if self.log_dir is not None and not os.path.exists(self.log_dir):
             os.makedirs(self.log_dir)
 
         _, self.rank = get_world_size_and_rank()

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -243,7 +243,7 @@ class WandBLogger(MetricLoggerInterface):
         self.log_dir = kwargs.pop("dir", log_dir)
 
         # create log_dir if missing
-        if not os.path.exists(self.log_dir):
+        if self.log_dir and not os.path.exists(self.log_dir):
             os.makedirs(self.log_dir)
 
         _, self.rank = get_world_size_and_rank()


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

if log_dir was not passed ,it would crash. This makes log_dir optonal


#### Test plan

```
tune run full_finetune_single_device --config llama3_2/1B_full_single_device dataset.packed=True tokenizer.max_seq_len=512 dataset.split=train[:5%] metric_logger=torchtune.training.metric_logging.WandBLogger ~metric_logger.log_dir
```

Before this change:
```
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

After this change:
It works!