### PR TITLE
Fix optimizer_in_backward at loading opt_state_dict in distributed recipes

### DIFF
--- a/recipes/dev/early_exit_finetune_distributed.py
+++ b/recipes/dev/early_exit_finetune_distributed.py
@@ -610,7 +610,7 @@ class EarlyExitFinetuneRecipeDistributed(FTRecipeInterface):
                 for param in opt_state_dict.keys():
                     try:
                         training.load_from_full_optimizer_state_dict(
-                            self._optim_ckpt_wrapper.state_dict()[param],
+                            self._optim_ckpt_wrapper.optim_map[param],
                             opt_state_dict[param],
                             self._device,
                         )

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -619,7 +619,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                     try:
                         training.load_from_full_optimizer_state_dict(
                             self._model,
-                            self._optim_ckpt_wrapper.state_dict()[param],
+                            self._optim_ckpt_wrapper.optim_map[param],
                             opt_state_dict[param],
                             self._device,
                         )

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -654,7 +654,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     try:
                         training.load_from_full_optimizer_state_dict(
                             self._model,
-                            self._optim_ckpt_wrapper.state_dict()[param],
+                            self._optim_ckpt_wrapper.optim_map[param],
                             opt_state_dict[param],
                             self._device,
                         )

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -564,7 +564,7 @@ class QATRecipeDistributed(FTRecipeInterface):
                     try:
                         training.load_from_full_optimizer_state_dict(
                             self._model,
-                            self._optim_ckpt_wrapper.state_dict()[param],
+                            self._optim_ckpt_wrapper.optim_map[param],
                             opt_state_dict[param],
                             self._device,
                         )

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -352,10 +352,10 @@ class TestFullFinetuneDistributedRecipe:
         cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config
 
         if not optim_in_bwd:
-            cmd_1.append("clip_grad_norm=100")
-            cmd_1.append("optimizer_in_bwd=False")
+            cmd_2.append("clip_grad_norm=100")
+            cmd_2.append("optimizer_in_bwd=False")
         else:
-            cmd_1.append("optimizer_in_bwd=True")
+            cmd_2.append("optimizer_in_bwd=True")
 
         monkeypatch.setattr(sys, "argv", cmd_2)
         runpy.run_path(TUNE_PATH, run_name="__main__")

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -194,8 +194,6 @@ class TestFullFinetuneDistributedRecipe:
         runpy.run_path(TUNE_PATH, run_name="__main__")
         loss_values = get_loss_values_from_metric_logger(log_file)
         expected_loss_values = self._fetch_expected_loss_values_multi_rank(model_type)
-        print("loss_values:", loss_values)
-        print("expected_loss_values:", expected_loss_values)
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-4, atol=1e-4
         )
@@ -268,7 +266,7 @@ class TestFullFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps, optim_in_bwd",
         [
-            ("llama3/8B_full", "llama3", "tune", 4, 1, True),
+            ("llama3/8B_full", "llama3", "tune", 1, 4, False),
         ],
     )
     @gpu_test(gpu_count=2)
@@ -308,7 +306,7 @@ class TestFullFinetuneDistributedRecipe:
             checkpointer.model_type={model_type.upper()} \
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
-            optimizer_in_bwd={optim_in_bwd} \
+            clip_grad_norm=100 \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS[model_type]
@@ -340,7 +338,7 @@ class TestFullFinetuneDistributedRecipe:
             tokenizer.prompt_template=null \
             resume_from_checkpoint=True \
             metric_logger.filename={log_file} \
-            optimizer_in_bwd={optim_in_bwd} \
+            clip_grad_norm=100 \
         """.split()
 
         cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -267,8 +267,6 @@ class TestFullFinetuneDistributedRecipe:
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps, optim_in_bwd",
         [
             ("llama3/8B_full", "llama3", "tune", 1, 4, False),
-        ],
-        [
             ("llama3/8B_full", "llama3", "tune", 4, 1, True),
         ],
     )
@@ -309,9 +307,16 @@ class TestFullFinetuneDistributedRecipe:
             checkpointer.model_type={model_type.upper()} \
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
-            clip_grad_norm=f"{'100' if not optim_in_bwd else 'null'}" \
-            optimizer_in_bwd={optim_in_bwd} \
         """.split()
+
+        # "optimizer_in_bwd=True" would free gradient info before clip_grad, causing
+        # wrong grad_norm, so we only test one of them each time. But loss values
+        # should be the same.
+        if not optim_in_bwd:
+            cmd_1.append("clip_grad_norm=100")
+            cmd_1.append("optimizer_in_bwd=False")
+        else:
+            cmd_1.append("optimizer_in_bwd=True")
 
         model_config = MODEL_TEST_CONFIGS[model_type]
         cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
@@ -341,12 +346,16 @@ class TestFullFinetuneDistributedRecipe:
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
             resume_from_checkpoint=True \
-            metric_logger.filename={log_file} \
-            clip_grad_norm=f"{'100' if not optim_in_bwd else 'null'}" \
-            optimizer_in_bwd={optim_in_bwd} \
+            metric_logger.filename={log_file}
         """.split()
 
         cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config
+
+        if not optim_in_bwd:
+            cmd_1.append("clip_grad_norm=100")
+            cmd_1.append("optimizer_in_bwd=False")
+        else:
+            cmd_1.append("optimizer_in_bwd=True")
 
         monkeypatch.setattr(sys, "argv", cmd_2)
         runpy.run_path(TUNE_PATH, run_name="__main__")

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -194,6 +194,8 @@ class TestFullFinetuneDistributedRecipe:
         runpy.run_path(TUNE_PATH, run_name="__main__")
         loss_values = get_loss_values_from_metric_logger(log_file)
         expected_loss_values = self._fetch_expected_loss_values_multi_rank(model_type)
+        print("loss_values:", loss_values)
+        print("expected_loss_values:", expected_loss_values)
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-4, atol=1e-4
         )
@@ -266,7 +268,7 @@ class TestFullFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps, optim_in_bwd",
         [
-            ("llama3/8B_full", "llama3", "tune", 1, 4, False),
+            ("llama3/8B_full", "llama3", "tune", 4, 1, True),
         ],
     )
     @gpu_test(gpu_count=2)
@@ -306,7 +308,7 @@ class TestFullFinetuneDistributedRecipe:
             checkpointer.model_type={model_type.upper()} \
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
-            clip_grad_norm=100 \
+            optimizer_in_bwd={optim_in_bwd} \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS[model_type]
@@ -338,7 +340,7 @@ class TestFullFinetuneDistributedRecipe:
             tokenizer.prompt_template=null \
             resume_from_checkpoint=True \
             metric_logger.filename={log_file} \
-            clip_grad_norm=100 \
+            optimizer_in_bwd={optim_in_bwd} \
         """.split()
 
         cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -268,6 +268,9 @@ class TestFullFinetuneDistributedRecipe:
         [
             ("llama3/8B_full", "llama3", "tune", 1, 4, False),
         ],
+        [
+            ("llama3/8B_full", "llama3", "tune", 4, 1, True),
+        ],
     )
     @gpu_test(gpu_count=2)
     def test_training_state_on_resume(
@@ -306,7 +309,8 @@ class TestFullFinetuneDistributedRecipe:
             checkpointer.model_type={model_type.upper()} \
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \
-            clip_grad_norm=100 \
+            clip_grad_norm=f"{'100' if not optim_in_bwd else 'null'}" \
+            optimizer_in_bwd={optim_in_bwd} \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS[model_type]
@@ -338,7 +342,8 @@ class TestFullFinetuneDistributedRecipe:
             tokenizer.prompt_template=null \
             resume_from_checkpoint=True \
             metric_logger.filename={log_file} \
-            clip_grad_norm=100 \
+            clip_grad_norm=f"{'100' if not optim_in_bwd else 'null'}" \
+            optimizer_in_bwd={optim_in_bwd} \
         """.split()
 
         cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -137,7 +137,11 @@ class TestFullFinetuneSingleDeviceRecipe:
         )
 
     @pytest.mark.integration_test
-    def test_training_state_on_resume(self, tmpdir, monkeypatch):
+    @pytest.mark.parametrize(
+        "optimizer_in_bwd",
+        [True, False],
+    )
+    def test_training_state_on_resume(self, tmpdir, monkeypatch, optimizer_in_bwd):
         """Test whether the recipe state is correctly updated on resume. Since this
         is model agnostic, we should run this on the small model only. The test
         consists of three stages:
@@ -169,6 +173,7 @@ class TestFullFinetuneSingleDeviceRecipe:
             checkpointer.model_type=LLAMA2 \
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
+            optimizer_in_bwd={optimizer_in_bwd} \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama2"]
@@ -200,6 +205,7 @@ class TestFullFinetuneSingleDeviceRecipe:
             tokenizer.prompt_template=null \
             resume_from_checkpoint=True \
             metric_logger.filename={log_file} \
+            optimizer_in_bwd={optimizer_in_bwd} \
         """.split()
 
         cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
Fix the issue here: https://github.com/pytorch/torchtune/issues/2360
Switch the second input at load_from_full_optimizer_state_dict **from state_dict to optimizer** after API inputs changed at https://github.com/pytorch/torchtune/pull/2138 


#### Test plan
- [x] run unit tests via `pytest tests`
`pytest -m integration_test tests/recipes/test_full_finetune_distributed.py`

With failure at `test_loss_2d_parallel[llama3/8B_full-llama3-tune-4-1-True-4]` when test locally, failure happens not only on this PR
