### PR TITLE
Added Scalable Softmax module

### DIFF
--- a/docs/source/api_ref_modules.rst
+++ b/docs/source/api_ref_modules.rst
@@ -110,6 +110,7 @@ These are utilities that are common to and can be used by all modules.
    common_utils.local_kv_cache
    common_utils.disable_kv_cache
    common_utils.delete_kv_caches
+   common_utils.ScalableSoftmax
 
 
 Vision Transforms

--- a/torchtune/modules/__init__.py
+++ b/torchtune/modules/__init__.py
@@ -11,6 +11,7 @@ from .common_utils import (
     disable_kv_cache,
     local_kv_cache,
     reparametrize_as_dtype_state_dict_post_hook,
+    ScalableSoftmax,
 )
 from .feed_forward import FeedForward  # noqa
 from .kv_cache import KVCache  # noqa
@@ -57,4 +58,5 @@ __all__ = [
     "disable_kv_cache",
     "LayerDropout",
     "prepare_layer_dropout",
+    "ScalableSoftmax",
 ]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?

This PR introduces a Scalable Softmax module that enhances the length generalization of transformer models both pre-and-post training by decreasing attention fading as shown in this [paper](https://arxiv.org/html/2501.19399v1). 

Files changed: 
- docs/source/api_ref_modules.rst
- tests/torchtune/modules/test_common_utils.py
- torchtune/modules/__init__.py
- torchtune/modules/common_utils.py


#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x] I have added an example to docs or docstrings
