### PR TITLE
Add support for ``StatefulDataLoader``

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ authors = [
 ]
 keywords = ["pytorch", "finetuning", "llm"]
 dependencies = [
+    # Stable torchdata (no nightly support)
+    "torchdata",
 
     # Hugging Face integrations
     "datasets",
@@ -33,7 +35,6 @@ dependencies = [
 
     # Multimodal
     "Pillow>=9.4.0",
-
 ]
 dynamic = ["version"]
 

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -770,10 +770,8 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
                 # Check if we should stop training for this epoch
                 if (
-                    self.max_steps_per_epoch is not None
-                    and (idx + 1 // self._gradient_accumulation_steps)
-                    == self.max_steps_per_epoch
-                ):
+                    (idx + 1) // self._gradient_accumulation_steps
+                ) == self.max_steps_per_epoch:
                     break
 
             self.epochs_run += 1

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -554,11 +554,11 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         batch_size: int,
         collate_fn: str,
         dataloader_state_dict: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[DistributedSampler, DataLoader]:
+    ) -> StatefulDataLoader:
         """
-        All data related setup happens here. Currently this recipe only supports the
-        DistributedSamplers with Map-style Datasets which fit into memory. Other samplers,
-        iterable datasets and streaming datasets are not supported.
+        All data related setup happens here. This recipe currently supports only
+        map-style datasets. If a state_dict is provided (meaning we are resuming a training run),
+        it is loaded into the dataloader.
         """
         if isinstance(cfg_dataset, ListConfig):
             datasets = [

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -580,7 +580,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             shuffle=shuffle,
-            num_workers=8,  # Set to a reasonable default
             collate_fn=(
                 partial(
                     collate_fn,

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -7,7 +7,7 @@
 import sys
 import time
 from functools import partial
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Union
 from warnings import warn
 
 import torch
@@ -604,13 +604,16 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         ckpt_dict = {training.MODEL_KEY: self._model.state_dict()}
         # if training is in-progress, checkpoint the optimizer state as well
         if epoch + 1 < self.total_epochs:
+            dataloader_sd = self._dataloader.state_dict()
+            # Hardcode _iterator_finished to True to avoid issues with resuming from a checkpoint
+            dataloader_sd["_iterator_finished"] = True
             ckpt_dict.update(
                 {
                     training.SEED_KEY: self.seed,
                     training.EPOCHS_KEY: self.epochs_run,
                     training.TOTAL_EPOCHS_KEY: self.total_epochs,
                     training.MAX_STEPS_KEY: self.max_steps_per_epoch,
-                    training.DATALOADER_KEY: self._dataloader.state_dict(),
+                    training.DATALOADER_KEY: dataloader_sd,
                 }
             )
             if not self._optimizer_in_bwd:

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -15,7 +15,7 @@ from omegaconf import DictConfig, ListConfig
 
 from torch import nn
 from torch.optim import Optimizer
-from torchdata import StatefulDataLoader
+from torchdata.stateful_dataloader import StatefulDataLoader
 
 from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
@@ -580,6 +580,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             dataset=ds,
             batch_size=batch_size,
             shuffle=shuffle,
+            num_workers=8,  # Set to a reasonable default
             collate_fn=(
                 partial(
                     collate_fn,

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -56,8 +56,8 @@ class TestFullFinetuneSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama2": [10.5130, 10.5215, 10.5764, 10.5046],
-            "llama3": [11.9839, 11.9684, 11.9596, 11.9366],
+            "llama2": [10.5219, 10.5292, 10.5475, 10.5195],
+            "llama3": [11.9611, 11.9432, 11.9326, 11.9807],
         }
 
         return loss_values_map[model_type]

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -56,7 +56,7 @@ class TestFullFinetuneSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama2": [10.5201, 10.5217, 10.4945, 10.5136],
+            "llama2": [10.5130, 10.5215, 10.5764, 10.5046],
             "llama3": [11.9839, 11.9684, 11.9596, 11.9366],
         }
 

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -153,7 +153,7 @@ class TestFullFinetuneSingleDeviceRecipe:
         ckpt = "llama2_hf"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
-        log_file = gen_log_file_name(tmpdir)
+        first_log_file = gen_log_file_name(tmpdir, suffix="first")
 
         # Config file needed for model conversion.
         # Create a second copy for training resume
@@ -173,6 +173,7 @@ class TestFullFinetuneSingleDeviceRecipe:
             checkpointer.model_type=LLAMA2 \
             tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
+            metric_logger.filename={first_log_file} \
             optimizer_in_bwd={optimizer_in_bwd} \
         """.split()
 
@@ -183,7 +184,15 @@ class TestFullFinetuneSingleDeviceRecipe:
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
+        # Sanity check that the loss values are expected for the initial run
+        expected_loss_values = self._fetch_expected_loss_values("llama2")
+        loss_values = get_loss_values_from_metric_logger(first_log_file)
+        torch.testing.assert_close(
+            loss_values, expected_loss_values, rtol=1e-4, atol=1e-4
+        )
+
         # Resume training
+        log_file = gen_log_file_name(tmpdir, suffix="resume")
         epoch_folder = get_largest_iter_folder(tmpdir)
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         suffix = ".safetensors"

--- a/torchtune/training/__init__.py
+++ b/torchtune/training/__init__.py
@@ -40,6 +40,7 @@ from torchtune.training.checkpointing import (
     ADAPTER_CONFIG,
     ADAPTER_KEY,
     Checkpointer,
+    DATALOADER_KEY,
     DistributedCheckpointer,
     EPOCHS_KEY,
     FormattedCheckpointFiles,
@@ -137,4 +138,5 @@ __all__ = [
     "FormattedCheckpointFiles",
     "scale_grads",
     "disable_dropout",
+    "DATALOADER_KEY",
 ]

--- a/torchtune/training/checkpointing/__init__.py
+++ b/torchtune/training/checkpointing/__init__.py
@@ -14,6 +14,7 @@ from torchtune.training.checkpointing._checkpointer import (
 from torchtune.training.checkpointing._utils import (
     ADAPTER_CONFIG,
     ADAPTER_KEY,
+    DATALOADER_KEY,
     EPOCHS_KEY,
     FormattedCheckpointFiles,
     get_largest_iter_folder,
@@ -55,4 +56,5 @@ __all__ = [
     "STEPS_KEY",
     "TOTAL_EPOCHS_KEY",
     "FormattedCheckpointFiles",
+    "DATALOADER_KEY",
 ]

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -71,6 +71,9 @@ STEPS_KEY = "steps_run"
 # rng state for ensuring correct training resuming in PPO
 RNG_KEY = "rng_state"
 
+# key used for dataloader state
+DATALOADER_KEY = "dataloader"
+
 
 class ModelType(Enum):
     """ModelType is used by the checkpointer to distinguish between different model architectures.


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

This PR adds support for the `StatefulDataLoader` class from the PyTorch library torchdata.

**FAQs**
1. **Why?** This is necessary for resuming from checkpoints mid-epoch - a feature set we will need to support for step-based checkpointing.
2. **Only full finetune single device?** Yeah, this is more to see how we'll integrate this as a POC and make sure that the tests can pass. Once this is merged, I'll add support for the rest of the recipes. 
3. **Hardcoding iterator_finished?** Yeah, we'll change this when we _actually_ move to step-based checkpointing, but right now we expect to save on the epoch boundaries so if the epoch is cut short, then we expect that the dataloader will restart its shuffling and data provided as if the iterator has finished going through all the samples. Huge, huge thanks to @ramanishsingh for helping me debug this last issue.
4. **You removed the sampler?!!** The `StatefulDataLoader` creates a batched random sampler of it's own so there's no need for us to be creating a new one in this context. Less code means my life is easier.
5. **WTH, you removed the check for max_steps is None. Won't that break?** Nope, Python is dumb. Check it:
```
>>> 1 == None
False
>>> 0 == None
False
>>> 5 == None
False
>>> 1000000000000000 == None
False
```

#### Changelog
What are the changes made in this PR?
* Import `StatefulDataloader` and replace it's usage in the `_setup_data` method
* Checkpoint the dataloader state dict
* Load the dataloader state dict if we are trying to resume from the checkpoint
* Update tests to match (yes the numbers changed b/c we are using a new random state - it's fine)

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
