### PR TITLE
Ensuring `max_seq_len` is set in PPO recipe when using kv-cacheing

### DIFF
--- a/recipes/configs/mistral/7B_full_ppo_low_memory.yaml
+++ b/recipes/configs/mistral/7B_full_ppo_low_memory.yaml
@@ -30,7 +30,7 @@ output_dir: /tmp/torchtune/mistral_7B/full_ppo_low_memory # /tmp may be deleted 
 tokenizer:
   _component_: torchtune.models.mistral.mistral_tokenizer
   path: /tmp/Mistral-7B-Instruct-v0.2/tokenizer.model
-  max_seq_len: null
+  max_seq_len: 512
 
 # Dataset
 dataset:

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -234,6 +234,11 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # setup a context manager for enabling KV-cacheing during
         # trajectory generation if enabled in the config
+        if self.enable_kv_cache and self._tokenizer.max_seq_len is None:
+            raise ValueError(
+                "`tokenizer.max_seq_len` is required when `enable_kv_cache` is `True`. "
+                "Please set `max_seq_len` in tokenizer config."
+            )
         self.cache_ctx_manager = lambda enable_kv_cache: (
             local_kv_cache(
                 self._policy_model,


### PR DESCRIPTION
Bug was raised in #2064.

`tokenizer.max_seq_len=512` was the config I used in #2066 - see [this wandb run](https://wandb.ai/salman-mohammadi/ppo_v2/runs/1rccy2yp/overview) for evidence of success.

Additionally, we ensure `tokenizer.max_seq_len` has been configured if KV-cacheing is enabled,  as otherwise we cannot infer the correct shapes for the `KVCache`s.