### PR TITLE
Padding bug in GRPO

### DIFF
--- a/recipes/dev/grpo_full_finetune_distributed.py
+++ b/recipes/dev/grpo_full_finetune_distributed.py
@@ -887,7 +887,9 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
                         traj.query_responses, max_p_plus_l, 1, dim=1
                     ),
                     logprobs=self._pad_tensor(traj.logprobs, max_l, -1e9, dim=1),
-                    ref_logprobs=self._pad_tensor(traj.ref_logprobs, max_l, -1e9, dim=1),
+                    ref_logprobs=self._pad_tensor(
+                        traj.ref_logprobs, max_l, -1e9, dim=1
+                    ),
                     rewards=traj.rewards,
                     successes=traj.successes,
                     advantages=traj.advantages,

--- a/recipes/dev/grpo_full_finetune_distributed.py
+++ b/recipes/dev/grpo_full_finetune_distributed.py
@@ -822,14 +822,15 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
 
         pad_idx variable might be confusing, so here is the brief explanation of what is happening.
 
-        This value is used to find the position in the padding list where the padding for the right side of the specified dimension should go.
-        The formula consists of the 3 key points:
+        This value is used to find the position in the padding list where the padding for
+        the right side of the specified dimension should go. The formula consists of the 3 key points:
 
-        1. Each dimension has two padding values: one for the left side and one for the right side. Hence, for a tensor with N dimensions, the padding list will have 2 * N elements.
+        1. Each dimension has two padding values: one for the left side and one for the right side.
+        Hence, for a tensor with N dimensions, the padding list will have 2 * N elements.
 
         2. The dimensions in the padding list are organized from the last dimension of the tensor towards the first.
-        To determine which pair (or position within that pair) corresponds to the given dimension dim, we need to calculate its offset in this reversed order.
-        Considering the first point we get the following expression:
+        To determine which pair (or position within that pair) corresponds to the given dimension dim,
+        we need to calculate its offset in this reversed order. Considering the first point we get the following expression:
 
         2 * (tensor.ndim - dim)
 

--- a/recipes/dev/grpo_full_finetune_distributed.py
+++ b/recipes/dev/grpo_full_finetune_distributed.py
@@ -820,6 +820,23 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
         Pads the end of the specified dimension with the given value until the dimension reaches the target size.
         We need this to ensure, that trajectories are padded to the same size, and we will not get errors on torch.cat.
 
+        pad_idx variable might be confusing, so here is the brief explanation of what is happening.
+
+        This value is used to find the position in the padding list where the padding for the right side of the specified dimension should go.
+        The formula consists of the 3 key points:
+
+        1. Each dimension has two padding values: one for the left side and one for the right side. Hence, for a tensor with N dimensions, the padding list will have 2 * N elements.
+
+        2. The dimensions in the padding list are organized from the last dimension of the tensor towards the first.
+        To determine which pair (or position within that pair) corresponds to the given dimension dim, we need to calculate its offset in this reversed order.
+        Considering the first point we get the following expression:
+
+        2 * (tensor.ndim - dim)
+
+        3. To get the index for the right direction padding we subtract 1:
+
+        2 * (tensor.ndim - dim) - 1
+
         Args:
             tensor (torch.Tensor): Tensor related to the trajectory
             target_dim (int): Target size after padding

--- a/recipes/dev/grpo_full_finetune_distributed.py
+++ b/recipes/dev/grpo_full_finetune_distributed.py
@@ -814,11 +814,16 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
         )
 
     def _pad_tensor(
-        self, tensor: torch.Tensor, target_dim: int, pad_value: float, dim: int = 1, pad_right: bool = True
+        self,
+        tensor: torch.Tensor,
+        target_dim: int,
+        pad_value: float,
+        dim: int = 1,
+        pad_right: bool = True,
     ) -> torch.Tensor:
         """
         Pads the specified dimension of a tensor with a given value up to the target size, either on the right or left side.
-    
+
         Args:
             tensor (torch.Tensor): Input tensor to pad.
             target_dim (int): Desired size of the specified dimension after padding.
@@ -826,10 +831,10 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
             dim (int): Dimension to pad. Default: 1.
             pad_right (bool): If True, pads on the right side; if False, pads on the left side.
                 Default: True
-    
+
         Returns:
             torch.Tensor: Padded tensor.
-    
+
         Example:
             >>> tensor = torch.tensor([[1, 2], [3, 4]])
             >>> padded_right = _pad_tensor(tensor, target_dim=3, pad_value=0, dim=1, pad_right=True)
@@ -844,22 +849,22 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
         pad_size = target_dim - tensor.shape[dim]
         if pad_size <= 0:
             return tensor
-    
+
         # Padding list is [left_N, right_N, ..., left_1, right_1], a pair for each dim;
         # right padding for dim is at 2*(N - dim) - 1
         # left padding for dim is at 2*(N - dim) - 2
         pad_idx_right = 2 * (tensor.ndim - dim) - 1
         pad_idx_left = 2 * (tensor.ndim - dim) - 2
-    
+
         # Initialize padding list for left/right for each dim, therefore (2 * tensor.ndim) numbers
         padding_list = [0] * (2 * tensor.ndim)
-    
+
         # Set new pad_size for the specified dim
         if pad_right:
             padding_list[pad_idx_right] = pad_size
         else:
             padding_list[pad_idx_left] = pad_size
-    
+
         return torch.nn.functional.pad(tensor, padding_list, value=pad_value)
 
     def generate_trajectory_batched(
@@ -895,7 +900,7 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
         # Determine maximum lengths for padding, necessary when concatenating.
         max_total_length = max(t.query_responses.shape[1] for t in trajectories)
         max_response_length = max(t.logprobs.shape[1] for t in trajectories)
-    
+
         padded_trajectories = []
         for traj in trajectories:
             # Pad masks along two dimensions (assuming 3D tensor)
@@ -905,7 +910,7 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
                 0,
                 dim=1,
             )
-    
+
             padded_trajectories.append(
                 GRPOTrajectory(
                     query_responses=self._pad_tensor(
@@ -930,7 +935,7 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
                     seq_lens=traj.seq_lens,
                 )
             )
-    
+
         return GRPOTrajectory(*map(torch.cat, zip(*padded_trajectories)))
 
     def grpo_step(

--- a/torchtune/dev/grpo/rewards.py
+++ b/torchtune/dev/grpo/rewards.py
@@ -5,14 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import re
-from typing import Tuple
+from typing import Dict
 
 import torch
 
 from torchtune.modules.transforms.tokenizers import ModelTokenizer
 
 
-def extract_tags(text: str) -> Tuple[str, str]:
+def extract_tags(text: str) -> Dict:
     """
     Parse XML-like tags from text. Returns a dictionary with keys 'think' and 'answer'.
     The values are lists of strings, with each string being the content of a tag.
@@ -23,7 +23,14 @@ def extract_tags(text: str) -> Tuple[str, str]:
     answer_match = re.search(answer_pattern, text, re.DOTALL)
     cot = think_match.group(1).strip() if think_match else ""
     potential_answer = answer_match.group(1).strip() if answer_match else ""
-    return cot, potential_answer
+    return {
+        "think": [
+            cot,
+        ],
+        "answer": [
+            potential_answer,
+        ],
+    }
 
 
 def shaped_correctness_reward(answer: str, completion: str) -> tuple[float, float]:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Fix a bug described in #2421 

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings

I still need to verify that everything is correct, but here is a fix reproduction code:

```
import torch
from typing import NamedTuple, List

class GRPOTrajectory(NamedTuple):
    query_responses: torch.Tensor  # [BxG, P+L]
    logprobs: torch.Tensor         # [BxG, L]
    ref_logprobs: torch.Tensor     # [BxG, L]
    rewards: torch.Tensor          # [BxG]
    successes: torch.Tensor
    advantages: torch.Tensor       # [BxG]
    masks: torch.Tensor            # [BxG, P+L, P+L]  
    position_ids: torch.Tensor     # [BxG, P+L]
    response_padding_masks: torch.Tensor  # [BxG, L]
    seq_lens: torch.Tensor

trajectory1 = GRPOTrajectory(
    query_responses=torch.randint(0, 100, (16, 512)),
    logprobs=torch.randn(16, 512),
    ref_logprobs=torch.randn(16, 512),
    rewards=torch.randn(16),
    successes=torch.randn(16),
    advantages=torch.randn(16),
    masks=torch.ones(16, 512, 512, dtype=torch.bool),  
    position_ids=torch.arange(512).expand(16, -1),
    response_padding_masks=torch.ones(16, 512, dtype=torch.bool),
    seq_lens=torch.full((16,), 512)
)

trajectory2 = GRPOTrajectory(
    query_responses=torch.randint(0, 100, (16, 600)),
    logprobs=torch.randn(16, 300),
    ref_logprobs=torch.randn(16, 300),
    rewards=torch.randn(16),
    successes=torch.randn(16),
    advantages=torch.randn(16),
    masks=torch.ones(16, 300, 300, dtype=torch.bool), 
    position_ids=torch.arange(300).expand(16, -1),
    response_padding_masks=torch.ones(16, 300, dtype=torch.bool),
    seq_lens=torch.full((16,), 300)
)
trajectory3 = GRPOTrajectory(
    query_responses=torch.randint(0, 100, (16, 600)),
    logprobs=torch.randn(16, 300),
    ref_logprobs=torch.randn(16, 24),
    rewards=torch.randn(16),
    successes=torch.randn(16),
    advantages=torch.randn(16),
    masks=torch.ones(16, 300, 300, dtype=torch.bool),  
    position_ids=torch.arange(300).expand(16, -1),
    response_padding_masks=torch.ones(16, 300, dtype=torch.bool),
    seq_lens=torch.full((16,), 300)
)

trajectories = [trajectory1, trajectory2, trajectory3]

def _pad_tensor(tensor: torch.Tensor, target_dim: int, pad_value: float, dim: int = 1) -> torch.Tensor:
    pad_size = target_dim - tensor.shape[dim]
    if pad_size <= 0:
        return tensor
    
    pad = [0] * (2 * tensor.ndim)
    pad[-2*(dim+1)] = 0     
    pad[-2*(dim+1)+1] = pad_size
    return torch.nn.functional.pad(tensor, pad, value=pad_value)

max_p_plus_l = max(t.query_responses.shape[1] for t in trajectories)
max_l = max(t.logprobs.shape[1] for t in trajectories)

padded_trajectories = []
for traj in trajectories:
    padded_masks = _pad_tensor(
        _pad_tensor(traj.masks, max_p_plus_l, 0, dim=2),  # Pad width
        max_p_plus_l, 
        0, 
        dim=1 
    )
    
    padded_trajectories.append(GRPOTrajectory(
        query_responses=_pad_tensor(traj.query_responses, max_p_plus_l, 1, dim=1),
        logprobs=_pad_tensor(traj.logprobs, max_l, 1.0, dim=1),
        ref_logprobs=_pad_tensor(traj.ref_logprobs, max_l, 1.0, dim=1),
        rewards=traj.rewards,
        successes=traj.successes,
        advantages=traj.advantages,
        masks=padded_masks,
        position_ids=_pad_tensor(traj.position_ids, max_p_plus_l, 0, dim=1),
        response_padding_masks=_pad_tensor(traj.response_padding_masks, max_l, False, dim=1),
        seq_lens=traj.seq_lens
    ))


concatenated = GRPOTrajectory(*map(torch.cat, zip(*padded_trajectories)))
print(concatenated.query_responses.shape)
```