### PR TITLE
Custom DPO losses support

### DIFF
--- a/docs/source/recipes/dpo.rst
+++ b/docs/source/recipes/dpo.rst
@@ -62,7 +62,9 @@ To use any of these, simply use the ``loss`` config entry or flag through the :r
 Also, you can pass your custom loss in our recipe. Note that its `forward` method should align with the following signature:
 
 .. code-block:: python
-  def forward(self, policy_inputs: ChosenRejectedOutputs, reference_inputs: ChosenRejectedOutputs) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+    def forward(self, policy_inputs: ChosenRejectedOutputs, reference_inputs: ChosenRejectedOutputs) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        ...
 
 Here, `ChosenRejectedOutputs` is a dataclass obtained from `concatenated_forward``:
 

--- a/docs/source/recipes/dpo.rst
+++ b/docs/source/recipes/dpo.rst
@@ -75,7 +75,7 @@ Here, `ChosenRejectedOutputs` is a dataclass obtained from `concatenated_forward
       chosen_logits: torch.Tensor
       rejected_logits: torch.Tensor
 
-If this is not sufficient and you need to compute additional values from the logits, you can modify `concatenated_forward directly`. To do this, use `tune cp`` to copy the desired recipe, and don’t forget to use your own dataclass!
+If this is not sufficient and you need to compute additional values from the logits, you can modify `concatenated_forward` directly. To do this, use `tune cp` to copy the desired recipe, and don’t forget to use your own dataclass!
 
 Refer to the TRL library for reference implementations of the desired losses. In particular, you may find useful loss calculations in trainers.
 

--- a/docs/source/recipes/dpo.rst
+++ b/docs/source/recipes/dpo.rst
@@ -59,6 +59,26 @@ To use any of these, simply use the ``loss`` config entry or flag through the :r
     loss=torchtune.modules.loss.RSOLoss \
     gamma=0.5
 
+Also, you can pass your custom loss in our recipe. Note that its `forward` method should align with the following signature:
+
+.. code-block:: python
+  def forward(self, policy_inputs: ChosenRejectedOutputs, reference_inputs: ChosenRejectedOutputs) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+Here, `ChosenRejectedOutputs` is a dataclass obtained from `concatenated_forward``:
+
+.. code-block:: python
+
+  @dataclass
+  class ChosenRejectedOutputs:
+      chosen_logps: torch.Tensor
+      rejected_logps: torch.Tensor
+      chosen_logits: torch.Tensor
+      rejected_logits: torch.Tensor
+
+If this is not sufficient and you need to compute additional values from the logits, you can modify `concatenated_forward directly`. To do this, use `tune cp`` to copy the desired recipe, and don’t forget to use your own dataclass!
+
+Refer to the TRL library for reference implementations of the desired losses. In particular, you may find useful loss calculations in trainers.
+
 For a deeper understanding of the different levers you can pull when using this recipe,
 see our documentation for the different PEFT training paradigms we support:
 

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -20,6 +20,7 @@ from torchtune import config, modules, rlhf, training, utils
 from torchtune.data import CROSS_ENTROPY_IGNORE_IDX, padded_collate_dpo
 from torchtune.datasets import ConcatDataset
 from torchtune.recipe_interfaces import FTRecipeInterface
+from torchtune.rlhf import ChosenRejectedOutputs
 from torchtune.training import disable_dropout, DummyProfiler, PROFILER_KEY
 from torchtune.training.lr_schedulers import get_lr
 from torchtune.utils import get_world_size_and_rank
@@ -797,7 +798,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
         model: nn.Module,
         batch: Tuple[torch.Tensor, torch.Tensor],
         activations_handling: Optional[bool] = True,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> ChosenRejectedOutputs:
         """
         Run forward pass of the model with chosen and rejected samples concatenated.
 
@@ -806,7 +807,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
             batch (Tuple[torch.Tensor, torch.Tensor]): Tuple of input_ids and labels.
 
         Returns:
-            Tuple of chosen log probs, rejected log probs, chosen logits, rejected logits.
+            Dataclass of chosen log probs, rejected log probs, chosen logits, rejected logits.
         """
         concatenated_input_ids, concatenated_labels = batch
         concatenated_input_ids = concatenated_input_ids.to(self._device)
@@ -836,7 +837,9 @@ class FullDPORecipeDistributed(FTRecipeInterface):
         chosen_logits = all_logits[:len_chosen]
         rejected_logits = all_logits[len_chosen:]
 
-        return (chosen_log_probs, rejected_log_probs, chosen_logits, rejected_logits)
+        return ChosenRejectedOutputs(
+            chosen_log_probs, rejected_log_probs, chosen_logits, rejected_logits
+        )
 
     def train(self) -> None:
         """
@@ -884,36 +887,29 @@ class FullDPORecipeDistributed(FTRecipeInterface):
 
                 # batch is input_ids, labels
                 num_tokens += torch.tensor(batch[0].numel())
-                (
-                    policy_chosen_log_probs,
-                    policy_rejected_log_probs,
-                    policy_chosen_logits,
-                    policy_rejected_logits,
-                ) = self.concatenated_forward(self._model, batch)
+                policy_chosen_rejected_outputs = self.concatenated_forward(
+                    self._model, batch
+                )
 
-                policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
-                policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
+                policy_chosen_logits_mean = (
+                    policy_chosen_rejected_outputs.chosen_logits.detach().mean()
+                )
+                policy_rejected_logits_mean = (
+                    policy_chosen_rejected_outputs.rejected_logits.detach().mean()
+                )
 
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
                 del policy_chosen_logits, policy_rejected_logits
 
                 with torch.no_grad():
-                    (
-                        reference_chosen_log_probs,
-                        reference_rejected_log_probs,
-                        reference_chosen_logits,
-                        reference_rejected_logits,
-                    ) = self.concatenated_forward(
+                    reference_chosen_rejected_outputs = self.concatenated_forward(
                         self._ref_model, batch, activations_handling=False
                     )
 
                 del reference_chosen_logits, reference_rejected_logits
 
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
-                    policy_chosen_log_probs,
-                    policy_rejected_log_probs,
-                    reference_chosen_log_probs,
-                    reference_rejected_log_probs,
+                    policy_chosen_rejected_outputs, reference_chosen_rejected_outputs
                 )
                 reward_accuracies = (chosen_rewards > rejected_rewards).float()
 
@@ -936,10 +932,12 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                     scaling_factor * reward_accuracies.mean()
                 )
                 running_metrics["log_probs/chosen"] += (
-                    scaling_factor * policy_chosen_log_probs.detach().mean()
+                    scaling_factor
+                    * policy_chosen_rejected_outputs.chosen_logps.detach().mean()
                 )
                 running_metrics["log_probs/rejected"] += (
-                    scaling_factor * policy_rejected_log_probs.detach().mean()
+                    scaling_factor
+                    * policy_chosen_rejected_outputs.rejected_logps.detach().mean()
                 )
                 running_metrics["logits/chosen"] += (
                     scaling_factor * policy_chosen_logits_mean

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -899,14 +899,20 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                 )
 
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
-                del policy_chosen_rejected_outputs.chosen_logits, policy_chosen_rejected_outputs.rejected_logits
+                del (
+                    policy_chosen_rejected_outputs.chosen_logits,
+                    policy_chosen_rejected_outputs.rejected_logits,
+                )
 
                 with torch.no_grad():
                     reference_chosen_rejected_outputs = self.concatenated_forward(
                         self._ref_model, batch, activations_handling=False
                     )
 
-                del reference_chosen_rejected_outputs.chosen_logits, reference_chosen_rejected_outputs.rejected_logits
+                del (
+                    reference_chosen_rejected_outputs.chosen_logits,
+                    reference_chosen_rejected_outputs.rejected_logits,
+                )
 
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_rejected_outputs, reference_chosen_rejected_outputs

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -899,14 +899,14 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                 )
 
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
-                del policy_chosen_logits, policy_rejected_logits
+                del policy_chosen_rejected_outputs.chosen_logits, policy_chosen_rejected_outputs.rejected_logits
 
                 with torch.no_grad():
                     reference_chosen_rejected_outputs = self.concatenated_forward(
                         self._ref_model, batch, activations_handling=False
                     )
 
-                del reference_chosen_logits, reference_rejected_logits
+                del reference_chosen_rejected_outputs.chosen_logits, reference_chosen_rejected_outputs.rejected_logits
 
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_rejected_outputs, reference_chosen_rejected_outputs

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -697,11 +697,11 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     self._model, batch
                 )
 
-                policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
-                policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
+                policy_chosen_logits_mean = policy_chosen_rejected_outputs.chosen_logits.detach().mean()
+                policy_rejected_logits_mean = policy_chosen_rejected_outputs.rejected_logits.detach().mean()
 
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
-                del policy_chosen_logits, policy_rejected_logits
+                del policy_chosen_rejected_outputs.chosen_logits, policy_chosen_rejected_outputs.rejected_logits
 
                 with torch.no_grad(), disable_adapter(self._model):
                     reference_chosen_rejected_outputs = self.concatenated_forward(

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -697,11 +697,18 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     self._model, batch
                 )
 
-                policy_chosen_logits_mean = policy_chosen_rejected_outputs.chosen_logits.detach().mean()
-                policy_rejected_logits_mean = policy_chosen_rejected_outputs.rejected_logits.detach().mean()
+                policy_chosen_logits_mean = (
+                    policy_chosen_rejected_outputs.chosen_logits.detach().mean()
+                )
+                policy_rejected_logits_mean = (
+                    policy_chosen_rejected_outputs.rejected_logits.detach().mean()
+                )
 
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
-                del policy_chosen_rejected_outputs.chosen_logits, policy_chosen_rejected_outputs.rejected_logits
+                del (
+                    policy_chosen_rejected_outputs.chosen_logits,
+                    policy_chosen_rejected_outputs.rejected_logits,
+                )
 
                 with torch.no_grad(), disable_adapter(self._model):
                     reference_chosen_rejected_outputs = self.concatenated_forward(

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -33,6 +33,7 @@ from torchtune.modules.peft import (
     validate_missing_and_unexpected_for_lora,
 )
 from torchtune.recipe_interfaces import FTRecipeInterface
+from torchtune.rlhf import ChosenRejectedOutputs
 from tqdm import tqdm
 
 log = utils.get_logger("DEBUG")
@@ -614,7 +615,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
 
     def concatenated_forward(
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> ChosenRejectedOutputs:
         """
         Run forward pass of the model with chosen and rejected samples concatenated.
 
@@ -623,7 +624,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             batch (Tuple[torch.Tensor, torch.Tensor]): Tuple of input_ids and labels.
 
         Returns:
-            Tuple of chosen log probs, rejected log probs, chosen logits, rejected logits.
+            Dataclass of chosen log probs, rejected log probs, chosen logits, rejected logits.
         """
         concatenated_input_ids, concatenated_labels = batch
         concatenated_input_ids = concatenated_input_ids.to(self._device)
@@ -643,7 +644,9 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         chosen_logits = all_logits[:len_chosen]
         rejected_logits = all_logits[len_chosen:]
 
-        return (chosen_log_probs, rejected_log_probs, chosen_logits, rejected_logits)
+        return ChosenRejectedOutputs(
+            chosen_log_probs, rejected_log_probs, chosen_logits, rejected_logits
+        )
 
     def train(self) -> None:
         """
@@ -690,12 +693,9 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 # batch is input_ids, labels
                 num_tokens += torch.tensor(batch[0].numel())
 
-                (
-                    policy_chosen_log_probs,
-                    policy_rejected_log_probs,
-                    policy_chosen_logits,
-                    policy_rejected_logits,
-                ) = self.concatenated_forward(self._model, batch)
+                policy_chosen_rejected_outputs = self.concatenated_forward(
+                    self._model, batch
+                )
 
                 policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
                 policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
@@ -704,17 +704,12 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 del policy_chosen_logits, policy_rejected_logits
 
                 with torch.no_grad(), disable_adapter(self._model):
-                    (
-                        reference_chosen_log_probs,
-                        reference_rejected_log_probs,
-                        _,
-                        _,
-                    ) = self.concatenated_forward(self._model, batch)
+                    reference_chosen_rejected_outputs = self.concatenated_forward(
+                        self._model, batch
+                    )
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
-                    policy_chosen_log_probs,
-                    policy_rejected_log_probs,
-                    reference_chosen_log_probs,
-                    reference_rejected_log_probs,
+                    policy_chosen_rejected_outputs,
+                    reference_chosen_rejected_outputs,
                 )
                 reward_accuracies = (chosen_rewards > rejected_rewards).float()
 
@@ -737,10 +732,12 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     scaling_factor * reward_accuracies.mean()
                 )
                 running_metrics["log_probs/chosen"] += (
-                    scaling_factor * policy_chosen_log_probs.detach().mean()
+                    scaling_factor
+                    * policy_chosen_rejected_outputs.chosen_logps.detach().mean()
                 )
                 running_metrics["log_probs/rejected"] += (
-                    scaling_factor * policy_rejected_log_probs.detach().mean()
+                    scaling_factor
+                    * policy_chosen_rejected_outputs.rejected_logps.detach().mean()
                 )
                 running_metrics["logits/chosen"] += (
                     scaling_factor * policy_chosen_logits_mean

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -539,8 +539,6 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                 policy_chosen_rejected_outputs = self.concatenated_forward(
                     self._model, batch
                 )
-                
-                print("forwared")
 
                 policy_chosen_logits_mean = policy_chosen_rejected_outputs.chosen_logits.detach().mean()
                 policy_rejected_logits_mean = policy_chosen_rejected_outputs.rejected_logits.detach().mean()

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -540,11 +540,18 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                     self._model, batch
                 )
 
-                policy_chosen_logits_mean = policy_chosen_rejected_outputs.chosen_logits.detach().mean()
-                policy_rejected_logits_mean = policy_chosen_rejected_outputs.rejected_logits.detach().mean()
+                policy_chosen_logits_mean = (
+                    policy_chosen_rejected_outputs.chosen_logits.detach().mean()
+                )
+                policy_rejected_logits_mean = (
+                    policy_chosen_rejected_outputs.rejected_logits.detach().mean()
+                )
 
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
-                del policy_chosen_rejected_outputs.chosen_logits, policy_chosen_rejected_outputs.rejected_logits
+                del (
+                    policy_chosen_rejected_outputs.chosen_logits,
+                    policy_chosen_rejected_outputs.rejected_logits,
+                )
 
                 with torch.no_grad(), disable_adapter(self._model):
                     reference_chosen_rejected_outputs = self.concatenated_forward(

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -539,12 +539,14 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                 policy_chosen_rejected_outputs = self.concatenated_forward(
                     self._model, batch
                 )
+                
+                print("forwared")
 
-                policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
-                policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
+                policy_chosen_logits_mean = policy_chosen_rejected_outputs.chosen_logits.detach().mean()
+                policy_rejected_logits_mean = policy_chosen_rejected_outputs.rejected_logits.detach().mean()
 
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
-                del policy_chosen_logits, policy_rejected_logits
+                del policy_chosen_rejected_outputs.chosen_logits, policy_chosen_rejected_outputs.rejected_logits
 
                 with torch.no_grad(), disable_adapter(self._model):
                     reference_chosen_rejected_outputs = self.concatenated_forward(

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -30,6 +30,7 @@ from torchtune.modules.peft import (
     validate_missing_and_unexpected_for_lora,
 )
 from torchtune.recipe_interfaces import FTRecipeInterface
+from torchtune.rlhf import ChosenRejectedOutputs
 
 from tqdm import tqdm
 
@@ -472,7 +473,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
 
     def concatenated_forward(
         self, model: nn.Module, batch: Tuple[torch.Tensor, torch.Tensor]
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> ChosenRejectedOutputs:
         """
         Run forward pass of the model with chosen and rejected samples concatenated.
 
@@ -481,7 +482,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             batch (Tuple[torch.Tensor, torch.Tensor]): Tuple of input_ids and labels.
 
         Returns:
-            Tuple of chosen log probs, rejected log probs, chosen logits, rejected logits.
+            Dataclass of chosen log probs, rejected log probs, chosen logits, rejected logits.
         """
         concatenated_input_ids, concatenated_labels = batch
         concatenated_input_ids = concatenated_input_ids.to(self._device)
@@ -501,7 +502,9 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         chosen_logits = all_logits[:len_chosen]
         rejected_logits = all_logits[len_chosen:]
 
-        return (chosen_log_probs, rejected_log_probs, chosen_logits, rejected_logits)
+        return ChosenRejectedOutputs(
+            chosen_log_probs, rejected_log_probs, chosen_logits, rejected_logits
+        )
 
     def train(self) -> None:
         """
@@ -533,12 +536,9 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
 
                 # batch is input_ids, labels
                 num_tokens += batch[0].numel()
-                (
-                    policy_chosen_log_probs,
-                    policy_rejected_log_probs,
-                    policy_chosen_logits,
-                    policy_rejected_logits,
-                ) = self.concatenated_forward(self._model, batch)
+                policy_chosen_rejected_outputs = self.concatenated_forward(
+                    self._model, batch
+                )
 
                 policy_chosen_logits_mean = policy_chosen_logits.detach().mean()
                 policy_rejected_logits_mean = policy_rejected_logits.detach().mean()
@@ -547,17 +547,12 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                 del policy_chosen_logits, policy_rejected_logits
 
                 with torch.no_grad(), disable_adapter(self._model):
-                    (
-                        reference_chosen_log_probs,
-                        reference_rejected_log_probs,
-                        _,
-                        _,
-                    ) = self.concatenated_forward(self._model, batch)
+                    reference_chosen_rejected_outputs = self.concatenated_forward(
+                        self._model, batch
+                    )
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
-                    policy_chosen_log_probs,
-                    policy_rejected_log_probs,
-                    reference_chosen_log_probs,
-                    reference_rejected_log_probs,
+                    policy_chosen_rejected_outputs,
+                    reference_chosen_rejected_outputs,
                 )
 
                 loss = loss.mean()
@@ -596,10 +591,10 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                             "rewards/margins": (chosen_rewards - rejected_rewards)
                             .mean()
                             .cpu(),
-                            "log_probs/rejected": policy_rejected_log_probs.detach()
+                            "log_probs/rejected": policy_chosen_rejected_outputs.rejected_logps.detach()
                             .mean()
                             .cpu(),
-                            "log_probs/chosen": policy_chosen_log_probs.detach()
+                            "log_probs/chosen": policy_chosen_rejected_outputs.chosen_logps.detach()
                             .mean()
                             .cpu(),
                             "logits/rejected": policy_rejected_logits_mean.cpu(),

--- a/tests/torchtune/rlhf/loss/test_dpo_loss.py
+++ b/tests/torchtune/rlhf/loss/test_dpo_loss.py
@@ -6,6 +6,7 @@
 
 import pytest
 import torch
+from torchtune.rlhf._types import ChosenRejectedOutputs
 from torchtune.rlhf.loss import DPOLoss, RSOLoss
 
 
@@ -39,11 +40,16 @@ class TestDPOLosses:
         ref_chosen_logprobs = torch.tensor([-0.5, -10.1, -0.1])
         ref_rejected_logprobs = torch.tensor([-0.1, -20.1, -0.1])
 
-        return (
+        return ChosenRejectedOutputs(
             policy_chosen_logprobs,
             policy_rejected_logprobs,
+            torch.tensor(0),
+            torch.tensor(0),
+        ), ChosenRejectedOutputs(
             ref_chosen_logprobs,
             ref_rejected_logprobs,
+            torch.tensor(0),
+            torch.tensor(0),
         )
 
     def test_dpo_loss(self, dpo_loss, loss_inputs):

--- a/torchtune/rlhf/__init__.py
+++ b/torchtune/rlhf/__init__.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from ._types import PPOStats, Trajectory
+from ._types import ChosenRejectedOutputs, PPOStats, Trajectory
 
 from .rewards import (
     estimate_advantages,
@@ -39,4 +39,5 @@ __all__ = [
     "PPOStats",
     "get_batch_log_probs",
     "Trajectory",
+    "ChosenRejectedOutputs",
 ]

--- a/torchtune/rlhf/_types.py
+++ b/torchtune/rlhf/_types.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
 from typing import NamedTuple
 
 import torch
@@ -67,3 +68,23 @@ class PPOStats(NamedTuple):
     ratios: torch.Tensor
     clipfrac: torch.Tensor
     approx_policy_kls: torch.Tensor
+
+
+@dataclass
+class ChosenRejectedOutputs:
+    """
+    Contains `concatenated_forward` outputs.
+
+    Attributes:
+        chosen_logps (torch.Tensor): Log probabilities of the policy/reference model
+            for the chosen responses. Shape: (batch_size)
+        rejected_logps (torch.Tensor): Log probabilities of the policy/reference model
+            for the rejected responses. Shape: (batch_size)
+        chosen_logits (torch.Tensor): logits of the policy/reference model
+        rejected_logits (torch.Tensor): logits of the policy/reference model
+    """
+
+    chosen_logps: torch.Tensor
+    rejected_logps: torch.Tensor
+    chosen_logits: torch.Tensor
+    rejected_logits: torch.Tensor

--- a/torchtune/rlhf/loss/dpo.py
+++ b/torchtune/rlhf/loss/dpo.py
@@ -10,6 +10,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from torchtune.rlhf._types import ChosenRejectedOutputs
+
+from torchtune.utils._logging import deprecated
 
 class DPOLoss(nn.Module):
     """
@@ -46,24 +49,16 @@ class DPOLoss(nn.Module):
 
     def forward(
         self,
-        policy_chosen_logps: torch.Tensor,
-        policy_rejected_logps: torch.Tensor,
-        reference_chosen_logps: torch.Tensor,
-        reference_rejected_logps: torch.Tensor,
+        policy_inputs: ChosenRejectedOutputs,
+        reference_inputs: ChosenRejectedOutputs, 
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the DPO loss for a batch of policy and reference model log probabilities.
 
         Args:
-            policy_chosen_logps (torch.Tensor): Log probabilities of the policy model
-                for the chosen responses. Shape: (batch_size)
-            policy_rejected_logps (torch.Tensor): Log probabilities of the policy model
-                for the rejected responses. Shape: (batch_size)
-            reference_chosen_logps (torch.Tensor): Log probabilities of the reference model
-                for the chosen responses. Shape: (batch_size)
-            reference_rejected_logps (torch.Tensor): Log probabilities of the reference model
-                for the rejected responses. Shape: (batch_size)
-
+            policy_inputs (ChosenRejectedOutputs): Policy log-probs and logits required for the calculation.
+            reference_inputs (ChosenRejectedOutputs): Reference log-probs and logits required for the calculation.
+         
         Returns:
             Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: A tuple of three tensors:
                 - losses: The DPO loss for each example in the batch.
@@ -71,8 +66,8 @@ class DPOLoss(nn.Module):
                 - rejected_rewards: Rewards for the rejected responses.
 
         """
-        pi_logratios = policy_chosen_logps - policy_rejected_logps
-        ref_logratios = reference_chosen_logps - reference_rejected_logps
+        pi_logratios = policy_inputs.chosen_logps - policy_inputs.rejected_logps
+        ref_logratios = reference_inputs.chosen_logps - reference_inputs.rejected_logps
 
         logits = pi_logratios - ref_logratios
 
@@ -85,15 +80,15 @@ class DPOLoss(nn.Module):
         )
 
         chosen_rewards = (
-            self.beta * (policy_chosen_logps - reference_chosen_logps).detach()
+            self.beta * (policy_inputs.chosen_logps - reference_inputs.chosen_logps).detach()
         )
         rejected_rewards = (
-            self.beta * (policy_rejected_logps - reference_rejected_logps).detach()
+            self.beta * (policy_inputs.rejected_logps - reference_inputs.rejected_logps).detach()
         )
 
         return losses, chosen_rewards, rejected_rewards
 
-
+@deprecated(msg="RSOLoss will be deprecated in an upcoming release.")
 class RSOLoss(nn.Module):
     """
     Statistical Rejection Sampling Optimization (RSO) or "hinge" loss module: https://arxiv.org/abs/2309.06657.


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* #2292 

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [X] I have added an example to docs or docstrings
