### PR TITLE
Add token 128011 to the Llama tokenizer

### DIFF
--- a/torchtune/models/llama3/_tokenizer.py
+++ b/torchtune/models/llama3/_tokenizer.py
@@ -31,7 +31,7 @@ SPECIAL_TOKENS = {
     "<|python_tag|>": 128010,
     "<|image|>": 128256,
     "<|video|>": 128012,
-    "<|reserved_special_token_255|>": 128011,
+    "<|reserved_special_token_244|>": 128011,
 }
 
 NUM_RESERVED_SPECIAL_TOKENS = 256

--- a/torchtune/models/llama3/_tokenizer.py
+++ b/torchtune/models/llama3/_tokenizer.py
@@ -31,6 +31,7 @@ SPECIAL_TOKENS = {
     "<|python_tag|>": 128010,
     "<|image|>": 128256,
     "<|video|>": 128012,
+    "<|reserved_special_token_255|>": 128011,
 }
 
 NUM_RESERVED_SPECIAL_TOKENS = 256

--- a/torchtune/models/llama3/_tokenizer.py
+++ b/torchtune/models/llama3/_tokenizer.py
@@ -34,7 +34,7 @@ SPECIAL_TOKENS = {
     "<|reserved_special_token_244|>": 128011,
 }
 
-NUM_RESERVED_SPECIAL_TOKENS = 256
+NUM_RESERVED_SPECIAL_TOKENS = 257
 
 RESERVED_TOKENS = {
     f"<|reserved_special_token_{2 + i}|>": 128013 + i


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

See issue #2424 

For now I just defined this token as a <|reserved_special_token_244|> for simplicity. The alternative approach is reindexing all special tokens, but this might require some extra attention.

My two concerns about this are:
1. How exactly should we reindex them? Tokens that don't have a specific definition are tokens (128000+) 2, 3, 11, and then 13-255. I don't think there's a coherent way in which we can match up with the HF tokenizer that has 128011 <-> <|reserved_special_token_6|>. Do we just do 128011 as special token 2, and then tokens 128013+i become special tokens 3+i?
2. Are we absolutely sure that this won't break anyone's workflows or trained models? I never actually used special tokens, but the way I understand they could be used, is that someone could define a format, e.g. "Question <|reserved_special_token_0|>cot<|reserved_special_token_1|> <|reserved_special_token_2|>answer<|reserved_special_token_3|>". A model trained on this today would learn to associate <|reserved_special_token_2|> with token 128013. If we reindex it, then <|reserved_special_token_2|> becomes token token 128011, so everything falls apart. But is this how the special tokens are actually used?

The way I see it, defining it as special token 244 won't break anything, because trying to decode token 128011 would have resulted in a crash. Reindexing all special tokens miiiiiiiiiight cause some issues in some weird cases, but I'm very much uncertain.


As a side note - NUM_RESERVED_TOKENS was set to 256, which seems reasonable, it's a nice round number. But in fact there are 257 special tokens: 0-256, inclusive on both ends. This bug canceled itself out with the omission of token 128011, but now I needed to fix this as well.

#### Changelog
What are the changes made in this PR?
* Added token 128011 to the Llama tokenizer