### PR TITLE
Attempt to make the reward function customizable in GRPO

### DIFF
--- a/recipes/configs/dev/3B_full_grpo.yaml
+++ b/recipes/configs/dev/3B_full_grpo.yaml
@@ -38,6 +38,10 @@ dataset:
 seed: null
 shuffle: False
 
+# Reward functions
+reward_fn:
+  _component_: torchtune.dev.grpo.rewards.batch_shaped_correctness_reward
+
 # Model Arguments
 model:
   _component_: torchtune.models.llama3_2.llama3_2_3b

--- a/torchtune/dev/grpo/__init__.py
+++ b/torchtune/dev/grpo/__init__.py
@@ -3,3 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from .rewards import batch_shaped_correctness_reward
+
+DEFAULT_REWARD_FN = batch_shaped_correctness_reward

--- a/torchtune/dev/grpo/rewards.py
+++ b/torchtune/dev/grpo/rewards.py
@@ -72,7 +72,7 @@ def shaped_correctness_reward(answer: str, completion: str) -> tuple[float, floa
 
 def batch_shaped_correctness_reward(
     tokenizer: ModelTokenizer, completions: torch.Tensor, answers: list[str]
-) -> [torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Utility function to apply the shaped reward function to a GRPO-style batch of completions."""
 
     batch_size, grpo_size, *_ = completions.shape


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Attempt to make the reward function customizable in GRPO implementation following issue #2421 

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
