### PR TITLE
Bugfixes: Grad norm scaling in TP

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -842,13 +842,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                                     max_norm=float(self._clip_grad_norm),
                                 )
                             else:
-                                grads = [
-                                    p.grad
-                                    for p in self._model.parameters()
-                                    if p.grad is not None
-                                ]
                                 grad_norm = torch.nn.utils.get_total_norm(
-                                    grads,
+                                    self._model.parameters(),
                                     norm_type=2,
                                     error_if_nonfinite=False,
                                     foreach=True,

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -849,7 +849,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                                     grads,
                                     norm_type=2,
                                     error_if_nonfinite=False,
-                                    foreac=True,
+                                    foreach=True,
                                 )
                         if isinstance(grad_norm, DTensor):
                             grad_norm = grad_norm.full_tensor()

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -843,7 +843,11 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                                 )
                             else:
                                 grad_norm = torch.nn.utils.get_total_norm(
-                                    self._model.parameters(),
+                                    [
+                                        p.grad 
+                                        for p in self._model.parameters()
+                                        if p.grad is not None
+                                    ],
                                     norm_type=2,
                                     error_if_nonfinite=False,
                                     foreach=True,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

[Please link to any issues this PR addresses.](https://github.com/pytorch/torchtune/issues/2420#issuecomment-2682130656)

#### Changelog
* Corrects grad norm scaler to scale with DP size, not world size
* Reports grad norm in both the clipping/no clipping case
* Corrects tokens per GPU count in TP

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
