### PR TITLE
[WIP] Add Llama3.3 tokenizer and update message roles to 'tool' (instead of 'ipython')

### DIFF
--- a/tests/torchtune/data/test_messages.py
+++ b/tests/torchtune/data/test_messages.py
@@ -57,7 +57,7 @@ class TestMessage:
             ValueError,
             match="Only assistant messages can be tool calls. Found role user in message: hello world",
         ):
-            message = Message(role="user", content="hello world", ipython=True)
+            message = Message(role="user", content="hello world", tool=True)
 
         with pytest.raises(
             ValueError,
@@ -66,7 +66,7 @@ class TestMessage:
             message = Message(
                 role="user",
                 content=[{"type": "image", "content": test_image}],
-                ipython=True,
+                tool=True,
             )
 
     def test_from_dict(self):
@@ -74,7 +74,7 @@ class TestMessage:
         assert message.role == "user"
         assert message.content[0]["content"] == "hello world"
         assert not message.masked
-        assert not message.ipython
+        assert not message.tool
         assert message.eot
 
     def test_contains_media(self, text_message, image_message):

--- a/tests/torchtune/models/llama3/test_llama3_tokenizer.py
+++ b/tests/torchtune/models/llama3/test_llama3_tokenizer.py
@@ -113,7 +113,7 @@ class TestLlama3Tokenizer:
                 {"type": "text", "content": "locate_sun(radius=100_000_000)"},
             ],
             masked=False,
-            ipython=True,
+            tool=True,
             eot=False,
         )
 
@@ -125,9 +125,9 @@ class TestLlama3Tokenizer:
         return message, expected_tokens
 
     @pytest.fixture
-    def ipython_message(self):
+    def tool_message(self):
         message = Message(
-            role="ipython",
+            role="tool",
             content=[
                 {"type": "text", "content": '{"content": True}'},
             ],
@@ -234,25 +234,25 @@ class TestLlama3Tokenizer:
         tokenizer,
         user_text_message,
         assistant_tool_message,
-        ipython_message,
+        tool_message,
         assistant_text_message,
     ):
         tool_call_messages = [
             user_text_message[0],
             assistant_tool_message[0],
-            ipython_message[0],
+            tool_message[0],
             assistant_text_message[0],
         ]
         expected_tokens = (
             user_text_message[1]
             + assistant_tool_message[1]
-            + ipython_message[1]
+            + tool_message[1]
             + assistant_text_message[1]
         )
         expected_mask = (
             [True] * len(user_text_message[1])
             + [False] * len(assistant_tool_message[1])
-            + [True] * len(ipython_message[1])
+            + [True] * len(tool_message[1])
             + [False] * (len(assistant_text_message[1]) - 1)
             + [True]
         )

--- a/tests/torchtune/models/qwen2_5/test_tokenizer.py
+++ b/tests/torchtune/models/qwen2_5/test_tokenizer.py
@@ -53,8 +53,8 @@ class TestQwen2_5Tokenizer:  # noqa: N801
         messages = [
             Message(role="system", content="a"),
             Message(role="user", content="b"),
-            Message(role="assistant", content="test call", ipython=True),
-            Message(role="ipython", content="test response"),
+            Message(role="assistant", content="test call", tool=True),
+            Message(role="tool", content="test response"),
             Message(role="assistant", content=""),
         ]
         # fmt: off

--- a/torchtune/data/_prompt_templates.py
+++ b/torchtune/data/_prompt_templates.py
@@ -65,7 +65,7 @@ class PromptTemplate(PromptTemplateInterface):
             "system": ("System: ", "\\n"),
             "user": ("User: ", "\\n"),
             "assistant": ("Assistant: ", "\\n"),
-            "ipython": ("Tool: ", "\\n"),
+            "tool": ("Tool: ", "\\n"),
         }
 
     Once instantiated, you must call the prompt template on a list of messages. It
@@ -74,7 +74,7 @@ class PromptTemplate(PromptTemplateInterface):
     Note:
         Any tags prepended/appended to the assistant message will be included
         in the loss calculation. All other prepend/append tags for other roles
-        (system, user, ipython) are, in most cases, not included in loss. Consider using
+        (system, user, tool) are, in most cases, not included in loss. Consider using
         the append tags for user messages for tags that need to come before the
         assistant message but should not be included in loss. For more custom masking
         and prompt templating, you can create your own class based off the
@@ -123,7 +123,7 @@ class PromptTemplate(PromptTemplateInterface):
                     role=message.role,
                     content=content,
                     masked=message.masked,
-                    ipython=message.ipython,
+                    tool=message.tool,
                     eot=message.eot,
                 ),
             )
@@ -153,7 +153,7 @@ class ChatMLTemplate(PromptTemplateInterface):
         "system": ("<|im_start|>system\n", "<|im_end|>\n"),
         "user": ("<|im_start|>user\n", "<|im_end|>\n"),
         "assistant": ("<|im_start|>assistant\n", "<|im_end|>\n"),
-        "ipython": ("", ""),
+        "tool": ("", ""),
     }
 
     def __call__(
@@ -203,7 +203,7 @@ class ChatMLTemplate(PromptTemplateInterface):
                     role=message.role,
                     content=content,
                     masked=message.masked,
-                    ipython=message.ipython,
+                    tool=message.tool,
                     eot=message.eot,
                 ),
             )

--- a/torchtune/models/llama2/_prompt_template.py
+++ b/torchtune/models/llama2/_prompt_template.py
@@ -29,7 +29,7 @@ class Llama2ChatTemplate(PromptTemplateInterface):
         "system": ("<<SYS>>\n", "\n<</SYS>>\n\n"),
         "user": ("[INST] ", " [/INST] "),
         "assistant": ("", ""),
-        "ipython": ("", ""),
+        "tool": ("", ""),
     }
 
     def __call__(
@@ -75,7 +75,7 @@ class Llama2ChatTemplate(PromptTemplateInterface):
                     role=message.role,
                     content=content,
                     masked=message.masked,
-                    ipython=message.ipython,
+                    tool=message.tool,
                     eot=message.eot,
                 ),
             )

--- a/torchtune/models/llama3/_tokenizer.py
+++ b/torchtune/models/llama3/_tokenizer.py
@@ -203,9 +203,12 @@ class Llama3Tokenizer(ModelTokenizer, Transform):
         """
         Tokenize header start, message role, and header end as list of ids
         """
+        role = message.role.strip()
         return (
             [self.start_header_id]
-            + self.encode(message.role.strip(), add_bos=False, add_eos=False)
+            + self.encode(
+                "ipython" if role == "tool" else role, add_bos=False, add_eos=False
+            )
             + [self.end_header_id]
             + self.encode("\n\n", add_bos=False, add_eos=False)
         )
@@ -231,7 +234,7 @@ class Llama3Tokenizer(ModelTokenizer, Transform):
             else:
                 raise RuntimeError(f"Unsupported message content type: {item['type']}")
 
-        if message.ipython:
+        if message.tool:
             tokenized_body = [self.python_tag] + tokenized_body
 
         return tokenized_body

--- a/torchtune/models/llama3_3/__init__.py
+++ b/torchtune/models/llama3_3/__init__.py
@@ -4,10 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._model_builders import llama3_3_70b, lora_llama3_3_70b, qlora_llama3_3_70b  # noqa
+from ._model_builders import (  # noqa
+    llama3_3_70b,
+    llama3_3_tokenizer,
+    lora_llama3_3_70b,
+    qlora_llama3_3_70b,
+)
+from ._tokenizer import Llama3_3Tokenizer
 
 __all__ = [
     "llama3_3_70b",
     "lora_llama3_3_70b",
     "qlora_llama3_3_70b",
+    "llama3_3_tokenizer",
+    "Llama3_3Tokenizer",
 ]

--- a/torchtune/models/llama3_3/_model_builders.py
+++ b/torchtune/models/llama3_3/_model_builders.py
@@ -3,6 +3,11 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import Optional
+
+from torchtune.models.llama3_3._tokenizer import Llama3_3Tokenizer
+from torchtune.data._prompt_templates import _get_prompt_template, _TemplateType
+from torchtune.modules.transforms.tokenizers import parse_hf_tokenizer_json
 from torchtune.models.llama3_1._model_builders import (
     llama3_1_70b,
     lora_llama3_1_70b,
@@ -35,3 +40,42 @@ Builder for creating a Llama3.3 70B model with QLoRA enabled. Base model weights
 that LoRA is applied to are quantized per the QLoRA paper: https://arxiv.org/abs/2305.14314.
 Please see `lora_llama3_1_70b` for full API arguments.
 """
+
+def llama3_3_tokenizer(
+    path: str,
+    special_tokens_path: Optional[str] = None,
+    max_seq_len: Optional[int] = None,
+    prompt_template: Optional[_TemplateType] = None,
+) -> Llama3_3Tokenizer:
+    """
+    Tokenizer for Llama3.3.
+
+    Args:
+        path (str): path to the tokenizer
+        special_tokens_path (Optional[str]): Path to ``tokenizer.json`` from Hugging Face
+            model files that contains all registered special tokens, or a local json file
+            structured similarly. Default is None to use the canonical Llama3 special tokens.
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
+        prompt_template (Optional[_TemplateType]): optional specified prompt template.
+            If a string, it is assumed to be the dotpath of a :class:`~torchtune.data.PromptTemplateInterface`
+            class. If a dictionary, it is assumed to be a custom prompt template mapping role to the
+            prepend/append tags.
+
+    Returns:
+        Llama3_3Tokenizer: Instantiation of the Llama3.3 tokenizer
+    """
+    special_tokens = (
+        parse_hf_tokenizer_json(special_tokens_path)
+        if special_tokens_path is not None
+        else None
+    )
+    template = (
+        _get_prompt_template(prompt_template) if prompt_template is not None else None
+    )
+    return Llama3_3Tokenizer(
+        path=path,
+        special_tokens=special_tokens,
+        max_seq_len=max_seq_len,
+        prompt_template=template,
+    )

--- a/torchtune/models/llama3_3/_tokenizer.py
+++ b/torchtune/models/llama3_3/_tokenizer.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List
+
+from torchtune.data import Message
+from torchtune.models.llama3 import Llama3Tokenizer
+
+
+class Llama3_3Tokenizer(Llama3Tokenizer):  # noqa: N801
+    """
+    Tokenizer for the Llama3.3 model.
+    """
+
+    def _tokenize_header(self, message: Message) -> List[int]:
+        """
+        Tokenize header start, message role, and header end as list of ids
+        """
+        return (
+            [self.start_header_id]
+            + self.encode(message.role.strip(), add_bos=False, add_eos=False)
+            + [self.end_header_id]
+            + self.encode("\n\n", add_bos=False, add_eos=False)
+        )

--- a/torchtune/models/mistral/_prompt_template.py
+++ b/torchtune/models/mistral/_prompt_template.py
@@ -32,7 +32,7 @@ class MistralChatTemplate(PromptTemplateInterface):
         "system": None,
         "user": ("[INST] ", " [/INST] "),
         "assistant": ("", ""),
-        "ipython": ("", ""),
+        "tool": ("", ""),
     }
 
     def __call__(
@@ -69,7 +69,7 @@ class MistralChatTemplate(PromptTemplateInterface):
                     role=message.role,
                     content=content,
                     masked=message.masked,
-                    ipython=message.ipython,
+                    tool=message.tool,
                     eot=message.eot,
                 ),
             )

--- a/torchtune/models/qwen2/_tokenizer.py
+++ b/torchtune/models/qwen2/_tokenizer.py
@@ -358,7 +358,7 @@ class Qwen2Tokenizer(ModelTokenizer):
             tokens = []
 
             # message header
-            if message.role != "ipython":
+            if message.role != "tool":
                 tokens.append(self.im_start_id)
                 tokens.extend(
                     self.encode(f"{message.role}\n", add_bos=False, add_eos=False)
@@ -380,7 +380,7 @@ class Qwen2Tokenizer(ModelTokenizer):
                     )
 
             # message footer
-            if message.role != "ipython" and (
+            if message.role != "tool" and (
                 message.role != "assistant" or index != len(messages) - 1
             ):
                 tokens.append(self.im_end_id)

--- a/torchtune/models/qwen2_5/_tokenizer.py
+++ b/torchtune/models/qwen2_5/_tokenizer.py
@@ -195,8 +195,8 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
     def _tokenize_header(self, messages, i):
         tokens = []
         message = messages[i]
-        if message.role == "ipython":
-            if i == 0 or messages[i - 1].role != "ipython":
+        if message.role == "tool":
+            if i == 0 or messages[i - 1].role != "tool":
                 # only add the "user" header if this is the first tool response msg
                 self._add_message_start_tokens(tokens, "user")
                 tokens.extend(
@@ -208,7 +208,7 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
                 )
         else:
             self._add_message_start_tokens(tokens, message.role)
-            if message.role == "assistant" and message.ipython:
+            if message.role == "assistant" and message.tool:
                 tokens.append(self.tool_call_start_id)
                 tokens.extend(self.encode("\n", add_bos=False, add_eos=False))
         return tokens
@@ -216,8 +216,8 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
     def _tokenize_footer(self, messages, i):
         tokens = []
         message = messages[i]
-        if message.role == "ipython":
-            if i == len(messages) - 1 or messages[i + 1].role != "ipython":
+        if message.role == "tool":
+            if i == len(messages) - 1 or messages[i + 1].role != "tool":
                 tokens.extend(
                     self.encode("\n</tool_response>", add_bos=False, add_eos=False)
                 )
@@ -227,7 +227,7 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
                     self.encode("\n</tool_response>", add_bos=False, add_eos=False)
                 )
         else:
-            if message.role == "assistant" and message.ipython:
+            if message.role == "assistant" and message.tool:
                 tokens.extend(self.encode("\n", add_bos=False, add_eos=False))
                 tokens.append(self.tool_call_end_id)
             if message.role != "assistant" or i != len(messages) - 1:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses #2371

#### Changelog
What are the changes made in this PR?
- Updated `Role` to use `tool` instead of `ipython`. Also updated all tokenizers and tests to make sure all tests pass
- Updated `Llama3Tokenizer` to continue using `ipython` for backward compatibility
- Created `Llama3_3Tokenizer` that inherits from `Llama3Tokenizer` overriding `_tokenize_header` method

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [X] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [X] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [X] I did not change any public API
- [ ] I have added an example to docs or docstrings

---

I'm not sure whether this is the right approach to handle Llama3 and Llama3.3 tokenizer? Based on my discussion with @pbontrager & @RdoubleA there are two possible ways:
    - Having a single tokenizer, and taking care of tool roles (`ipython` or `tool`) based on the model. This requires us to pass the model detail to the tokenizer.
    - Having two separate tokenizers 

This PR implements the 2nd approach, while its easier to implement it can lead to confusion among users. Looking forward to the discussion.

