### PR TITLE
Enable async checkpointing by default in full_finetune_distributed recipe

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -134,7 +134,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             )
 
         # Set up the backend for distributed training (NCCL, GLOO, etc.)
-        self._enable_async_checkpointing = cfg.get("enable_async_checkpointing", False)
+        self._enable_async_checkpointing = cfg.get("enable_async_checkpointing", True)
         self.fsdp_cpu_offload = cfg.get("fsdp_cpu_offload", False)
         self.distributed_backend = training.get_distributed_backend(
             device_type,

--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -69,7 +69,7 @@ class CheckpointClient:
 
         self._resume_from_checkpoint = self._cfg.get("resume_from_checkpoint", False)
         self._enable_async_checkpointing = self._cfg.get(
-            "enable_async_checkpointing", False
+            "enable_async_checkpointing", True
         )
         self._optimizer_in_bwd = self._cfg.get("optimizer_in_bwd", False)
         self._device = utils.get_device(device=self._cfg.device)
@@ -217,10 +217,10 @@ class CheckpointClient:
                     )
                 else:
                     for param, opt in optimizer.optim_map.items():
-                        optim_state_dict[
-                            param
-                        ] = training.get_full_optimizer_state_dict(
-                            model, opt, self._is_rank_zero, device=self._device
+                        optim_state_dict[param] = (
+                            training.get_full_optimizer_state_dict(
+                                model, opt, self._is_rank_zero, device=self._device
+                            )
                         )
             else:
                 optim_state_dict = optimizer.state_dict()

--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -69,7 +69,7 @@ class CheckpointClient:
 
         self._resume_from_checkpoint = self._cfg.get("resume_from_checkpoint", False)
         self._enable_async_checkpointing = self._cfg.get(
-            "enable_async_checkpointing", True
+            "enable_async_checkpointing", False
         )
         self._optimizer_in_bwd = self._cfg.get("optimizer_in_bwd", False)
         self._device = utils.get_device(device=self._cfg.device)
@@ -217,10 +217,10 @@ class CheckpointClient:
                     )
                 else:
                     for param, opt in optimizer.optim_map.items():
-                        optim_state_dict[param] = (
-                            training.get_full_optimizer_state_dict(
-                                model, opt, self._is_rank_zero, device=self._device
-                            )
+                        optim_state_dict[
+                            param
+                        ] = training.get_full_optimizer_state_dict(
+                            model, opt, self._is_rank_zero, device=self._device
                         )
             else:
                 optim_state_dict = optimizer.state_dict()


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [X] other (expose a pre-existing feature)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Enable async checkpointing by default in full_finetune_distributed recipe

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [X] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [X] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [X] run unit tests via `pytest tests`
- [X] run recipe tests via `pytest tests -m integration_test`
- [X] manually run any new or modified recipes with sufficient proof of correctness
- [X] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [X] I did not change any public API
- [ ] I have added an example to docs or docstrings
