### PR TITLE
Support returning last hidden state

### DIFF
--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -653,6 +653,9 @@ class TransformerDecoder(nn.Module):
                 input_pos=input_pos,
             )
 
+        if len(self.layers) in self.output_hidden_states:
+            hidden.append(h)
+
         # shape: [b, seq_len, out_dim]
         output = self.unembed(h)
 


### PR DESCRIPTION
Currently we don't provide the option to return the final hidden state when a user passes `output_hidden_states` to our transformer class. This PR changes that. The current logic for `output_hidden_states` is that if $i$ is included, we return the state after the $i^{th}$ layer (where $i=0$ corresponds to returning the token embeddings before any layers are run). However, for an $n$-layer transformer this stops at layer $n-1$. Now, if a user includes $n$ in `output_hidden_states`, they will also get the final hidden state back (i.e. before normalization and output projection).