### PR TITLE
Add validation dataset loss to distributed SFT recipies

### DIFF
--- a/recipes/configs/llama3_2/1B_lora_validation.yaml
+++ b/recipes/configs/llama3_2/1B_lora_validation.yaml
@@ -1,0 +1,123 @@
+# Config for multi-device LoRA finetuning in lora_finetune_distributed.py
+# using a Llama3.2 1B Instruct model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download meta-llama/Llama-3.2-1B-Instruct --output-dir /tmp/Llama-3.2-1B-Instruct --ignore-patterns "original/consolidated.00.pth"
+#
+# To launch on 2 devices, run the following command from root:
+#   tune run --nproc_per_node 2 lora_finetune_distributed --config llama3_2/1B_lora
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run --nproc_per_node 2 lora_finetune_distributed --config llama3_2/1B_lora checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works best when the model is being fine-tuned on 2+ GPUs.
+# For single device LoRA finetuning please use 1B_lora_single_device.yaml
+# or 1B_qlora_single_device.yaml
+
+output_dir: /tmp/torchtune/llama3_2_1B/lora # /tmp may be deleted by your system. Change it to your preference.
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Llama-3.2-1B-Instruct/original/tokenizer.model
+  max_seq_len: null
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_2.lora_llama3_2_1b
+  lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  lora_rank: 64  # higher increases accuracy and memory
+  lora_alpha: 128  # usually alpha=2*rank
+  lora_dropout: 0.0
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Llama-3.2-1B-Instruct/
+  checkpoint_files: [
+    model.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: LLAMA3_2
+resume_from_checkpoint: False
+save_adapter_weights_only: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  packed: False  # True increases speed
+seed: null
+shuffle: True
+batch_size: 4
+
+# Validation
+dataset_validation:
+  _component_: torchtune.datasets.alpaca_dataset
+  source: mhenrichsen/alpaca_2k_test
+  split: train
+  packed: False  # True increases speed
+run_val_every_n_steps: 100
+max_validation_batches: -1
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 1  # Use to increase effective batch size
+clip_grad_norm: null
+compile: True  # torch.compile the model + loss, True increases speed + decreases memory
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: True
+
+# Environment
+device: cuda
+dtype: bf16
+enable_activation_checkpointing: False  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/llama3_2/1B_qlora_validation.yaml
+++ b/recipes/configs/llama3_2/1B_qlora_validation.yaml
@@ -17,7 +17,7 @@
 # For single device LoRA finetuning please use 1B_lora_single_device.yaml
 # or 1B_qlora_single_device.yaml
 
-output_dir: /tmp/torchtune/llama3_2_1B/lora # /tmp may be deleted by your system. Change it to your preference.
+output_dir: /tmp/torchtune/llama3_2_1B/qlora # /tmp may be deleted by your system. Change it to your preference.
 
 # Tokenizer
 tokenizer:
@@ -27,7 +27,7 @@ tokenizer:
 
 # Model Arguments
 model:
-  _component_: torchtune.models.llama3_2.lora_llama3_2_1b
+  _component_: torchtune.models.llama3_2.qlora_llama3_2_1b
   lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
   apply_lora_to_mlp: True
   lora_rank: 64  # higher increases accuracy and memory
@@ -85,7 +85,7 @@ compile: True  # torch.compile the model + loss, True increases speed + decrease
 
 # Logging
 metric_logger:
-  _component_: torchtune.training.metric_logging.DiskLogger
+  _component_: torchtune.training.metric_logging.WandBLogger
   log_dir: ${output_dir}/logs
 log_every_n_steps: 1
 log_peak_memory_stats: True

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -750,6 +750,30 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             list(dataloader)
         return dataloader
 
+    def _loss_step(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
+        # Shape [b, s], needed for the loss not the model
+        labels = batch.pop("labels")
+
+        with self.activations_handling_ctx:
+            logits = self._model(**batch)
+
+        # Shift labels to compute loss
+        # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
+        # But this way we dont need to slice the logits. We just add an ignore index to labels.
+        labels = torch.hstack(
+            (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
+        )
+        if not isinstance(logits, list):
+            labels = labels.reshape(-1)
+            logits = logits.reshape(-1, logits.size(-1))
+
+        # Compute loss
+        loss = self._loss_fn(logits, labels)
+        # free logits otherwise it peaks backward memory
+        del logits
+
+        return loss
+
     def validate(self) -> float:
         """
         Run validation loop and return average validation loss.
@@ -774,21 +798,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     batch["labels"] != self._loss_fn.ignore_index
                 ).sum()
 
-                labels = batch.pop("labels")
-
-                with self.activations_handling_ctx:
-                    logits = self._model(**batch)
-
-                # Shift labels to compute loss
-                labels = torch.hstack(
-                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-                )
-                if not isinstance(logits, list):
-                    labels = labels.reshape(-1)
-                    logits = logits.reshape(-1, logits.size(-1))
-
                 # Compute loss
-                val_loss = self._loss_fn(logits, labels) * current_num_tokens
+                val_loss = self._loss_step(batch) * current_num_tokens
 
                 total_val_loss += val_loss
                 total_val_tokens += current_num_tokens
@@ -850,30 +861,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 ).sum()
                 num_tokens += current_num_tokens
 
-                # Shape [b, s], needed for the loss not the model
-                labels = batch.pop("labels")
-
-                with self.activations_handling_ctx:
-                    logits = self._model(**batch)
-
-                # Shift labels to compute loss
-                # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-                # But this way we dont need to slice the logits. We just add an ignore index to labels.
-                labels = torch.hstack(
-                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-                )
-                if not isinstance(logits, list):
-                    labels = labels.reshape(-1)
-                    logits = logits.reshape(-1, logits.size(-1))
-
-                # Compute loss
                 # Loss is normalized by default so we multiply by the number of tokens
                 # This way we can normalize by the total number of tokens if we're accumulating gradients
-                current_loss = self._loss_fn(logits, labels) * current_num_tokens
-
-                # free logits otherwise it peaks backward memory
-                del logits
-
+                current_loss = self._loss_step(batch) * current_num_tokens
                 running_loss += current_loss
 
                 # For optimizer in backward, we need to normalize before calling backward

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -355,6 +355,16 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             collate_fn=collate_name,
         )
 
+        # Setup validation dataloader if validation dataset is provided
+        self._val_sampler, self._val_dataloader = None, None
+        if cfg.get("dataset_validation") is not None:
+            self._val_sampler, self._val_dataloader = self._setup_data(
+                cfg_dataset=cfg.dataset_validation,
+                batch_size=cfg.batch_size,
+                collate_fn=collate_name,
+                shuffle=False,
+            )
+
         # Finally update the recipe state which can only be correctly set after all of the
         # other components have been initialized and updated.
         #
@@ -382,6 +392,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         # Set up profiler, returns DummyProfiler (nullcontext object with no-op `step` method)
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
+
+        # Add validation config parameters
+        self._run_val_every_n_steps = cfg.get("run_val_every_n_steps", None)
+        self._max_validation_batches = cfg.get("max_validation_batches", -1)
 
         # Used to ignore labels for loss computation
         self.ignore_labels_cache = torch.full(
@@ -736,6 +750,63 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             list(dataloader)
         return dataloader
 
+    def validate(self) -> float:
+        """
+        Run validation loop and return average validation loss.
+        """
+        if self._val_dataloader is None:
+            return 0.0
+
+        self._model.eval()
+        total_val_loss = torch.tensor(0.0, device=self._device)
+        total_val_tokens = torch.tensor(0.0, device=self._device)
+
+        with torch.no_grad():
+            for batch_idx, batch in enumerate(self._val_dataloader):
+                if (self._max_validation_batches > 0 and
+                    batch_idx >= self._max_validation_batches):
+                    break
+
+                utils.batch_to_device(batch, self._device)
+
+                # Count tokens excluding padding
+                current_num_tokens = (
+                    batch["labels"] != self._loss_fn.ignore_index
+                ).sum()
+
+                labels = batch.pop("labels")
+
+                with self.activations_handling_ctx:
+                    logits = self._model(**batch)
+
+                # Shift labels to compute loss
+                labels = torch.hstack(
+                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
+                )
+                if not isinstance(logits, list):
+                    labels = labels.reshape(-1)
+                    logits = logits.reshape(-1, logits.size(-1))
+
+                # Compute loss
+                val_loss = self._loss_fn(logits, labels) * current_num_tokens
+
+                total_val_loss += val_loss
+                total_val_tokens += current_num_tokens
+
+        # Aggregate validation metrics across all ranks
+        if torch.distributed.is_initialized():
+            torch.distributed.all_reduce(total_val_loss)
+            torch.distributed.all_reduce(total_val_tokens)
+
+        avg_val_loss = (
+            (total_val_loss / total_val_tokens).item()
+            if total_val_tokens > 0
+            else float('inf')
+        )
+
+        self._model.train()
+        return avg_val_loss
+
     def train(self) -> None:
         """
         The core training loop.
@@ -901,6 +972,18 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     # Note that this is called within gradient accumulation block, hence
                     # will include multiple forward / backward passes if gradient accumulation > 1
                     self._profiler.step()
+
+                    # Run validation after gradient update
+                    if (self._run_val_every_n_steps is not None and
+                        self.global_step % self._run_val_every_n_steps == 0):
+                        pbar.refresh()
+                        val_loss = self.validate()
+                        if self._is_rank_zero:
+                            log.info(f"Validation loss: {val_loss:.4f}")
+                            self._metric_logger.log_dict(
+                                {"val_loss": val_loss},
+                                step=self.global_step,
+                            )
 
                 if (
                     (idx + 1) // self._gradient_accumulation_steps

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -356,9 +356,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         )
 
         # Setup validation dataloader if validation dataset is provided
-        self._val_sampler, self._val_dataloader = None, None
+        self._val_dataloader = None
         if cfg.get("dataset_validation") is not None:
-            self._val_sampler, self._val_dataloader = self._setup_data(
+            self._val_dataloader = self._setup_data(
                 cfg_dataset=cfg.dataset_validation,
                 batch_size=cfg.batch_size,
                 collate_fn=collate_name,
@@ -787,8 +787,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
         with torch.no_grad():
             for batch_idx, batch in enumerate(self._val_dataloader):
-                if (self._max_validation_batches > 0 and
-                    batch_idx >= self._max_validation_batches):
+                if (
+                    self._max_validation_batches > 0
+                    and batch_idx >= self._max_validation_batches
+                ):
                     break
 
                 utils.batch_to_device(batch, self._device)
@@ -812,7 +814,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         avg_val_loss = (
             (total_val_loss / total_val_tokens).item()
             if total_val_tokens > 0
-            else float('inf')
+            else float("inf")
         )
 
         self._model.train()
@@ -964,8 +966,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     self._profiler.step()
 
                     # Run validation after gradient update
-                    if (self._run_val_every_n_steps is not None and
-                        self.global_step % self._run_val_every_n_steps == 0):
+                    if (
+                        self._run_val_every_n_steps is not None
+                        and self.global_step % self._run_val_every_n_steps == 0
+                    ):
                         pbar.refresh()
                         val_loss = self.validate()
                         if self._is_rank_zero:

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -322,9 +322,9 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             ),
         )
 
-        self._val_sampler, self._val_dataloader = None, None
+        self._val_dataloader = None
         if cfg.get("dataset_validation") is not None:
-            self._val_sampler, self._val_dataloader = self._setup_data(
+            self._val_dataloader = self._setup_data(
                 cfg_dataset=cfg.dataset_validation,
                 batch_size=cfg.batch_size,
                 collate_fn=collate_name,
@@ -902,8 +902,10 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     self._profiler.step()
 
                     # Run validation after gradient update
-                    if (self._run_val_every_n_steps is not None and
-                        self.global_step % self._run_val_every_n_steps == 0):
+                    if (
+                        self._run_val_every_n_steps is not None
+                        and self.global_step % self._run_val_every_n_steps == 0
+                    ):
                         pbar.refresh()
                         val_loss = self.validate()
                         if self._is_rank_zero:
@@ -936,8 +938,10 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         with torch.no_grad():
             for batch_idx, batch in enumerate(self._val_dataloader):
-                if (self._max_validation_batches > 0 and
-                    batch_idx >= self._max_validation_batches):
+                if (
+                    self._max_validation_batches > 0
+                    and batch_idx >= self._max_validation_batches
+                ):
                     break
 
                 utils.batch_to_device(batch, self._device)
@@ -946,7 +950,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 current_num_tokens = (
                     batch["labels"] != self._loss_fn.ignore_index
                 ).sum()
-
 
                 labels = batch.pop("labels")
 
@@ -977,7 +980,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         avg_val_loss = (
             (total_val_loss / total_val_tokens).item()
             if total_val_tokens > 0
-            else float('inf')
+            else float("inf")
         )
 
         self._model.train()

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -322,6 +322,15 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             ),
         )
 
+        self._val_sampler, self._val_dataloader = None, None
+        if cfg.get("dataset_validation") is not None:
+            self._val_sampler, self._val_dataloader = self._setup_data(
+                cfg_dataset=cfg.dataset_validation,
+                batch_size=cfg.batch_size,
+                collate_fn=collate_name,
+                shuffle=False,
+            )
+
         # Finally update the recipe state which can only be correctly set after all of the
         # other components have been initialized and updated.
 
@@ -355,6 +364,9 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         self.ignore_labels_cache = torch.full(
             (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
         )
+
+        self._run_val_every_n_steps = cfg.get("run_val_every_n_steps", None)
+        self._max_validation_batches = cfg.get("max_validation_batches", -1)
 
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
@@ -889,6 +901,18 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     # will include multiple forward / backward passes if gradient accumulation > 1
                     self._profiler.step()
 
+                    # Run validation after gradient update
+                    if (self._run_val_every_n_steps is not None and
+                        self.global_step % self._run_val_every_n_steps == 0):
+                        pbar.refresh()
+                        val_loss = self.validate()
+                        if self._is_rank_zero:
+                            log.info(f"Validation loss: {val_loss:.4f}")
+                            self._metric_logger.log_dict(
+                                {"val_loss": val_loss},
+                                step=self.global_step,
+                            )
+
                 if (
                     (idx + 1) // self._gradient_accumulation_steps
                 ) == self.max_steps_per_epoch:
@@ -898,6 +922,66 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             self.save_checkpoint(epoch=curr_epoch)
 
         self._profiler.stop()
+
+    def validate(self) -> float:
+        """
+        Run validation loop and return average validation loss.
+        """
+        if self._val_dataloader is None:
+            return 0.0
+
+        self._model.eval()
+        total_val_loss = torch.tensor(0.0, device=self._device)
+        total_val_tokens = torch.tensor(0.0, device=self._device)
+
+        with torch.no_grad():
+            for batch_idx, batch in enumerate(self._val_dataloader):
+                if (self._max_validation_batches > 0 and
+                    batch_idx >= self._max_validation_batches):
+                    break
+
+                utils.batch_to_device(batch, self._device)
+
+                # Count tokens excluding padding
+                current_num_tokens = (
+                    batch["labels"] != self._loss_fn.ignore_index
+                ).sum()
+
+
+                labels = batch.pop("labels")
+
+                with self.activations_handling_ctx:
+                    logits = self._model(**batch)
+
+                # Shift labels to compute loss
+                labels = torch.hstack(
+                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
+                )
+                if not isinstance(logits, list):
+                    labels = labels.reshape(-1)
+                    logits = logits.reshape(-1, logits.size(-1))
+
+                # Compute loss
+                # Loss is normalized by default so we multiply by the number of tokens
+                # This way we can normalize by the total number of tokens if we're accumulating gradients
+                val_loss = self._loss_fn(logits, labels) * current_num_tokens
+
+                total_val_loss += val_loss
+                total_val_tokens += current_num_tokens
+
+        # Aggregate validation metrics across all ranks
+        if torch.distributed.is_initialized():
+            torch.distributed.all_reduce(total_val_loss)
+            torch.distributed.all_reduce(total_val_tokens)
+
+        avg_val_loss = (
+            (total_val_loss / total_val_tokens).item()
+            if total_val_tokens > 0
+            else float('inf')
+        )
+
+        self._model.train()
+        return avg_val_loss
 
     def cleanup(self) -> None:
         if self._is_rank_zero:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Addresses #1042 / part of the #883 for distributed recipies

#### Changelog
What are the changes made in this PR?
* distributed SFT recipeis (full_finetune_distributed and lora_finetune_distributed) support computing loss on validation dataset (no early stopping)
* example of configuring validation dataset in [recipes/configs/llama3_2/1B_qlora_validation.yaml](recipes/configs/llama3_2/1B_qlora_validation.yaml)

New [configuration](https://github.com/pytorch/torchtune/pull/2238#pullrequestreview-2553490828):
```
dataset_validation: null
run_val_every_n_steps: null
max_validation_batches: -1
```

#### Test plan

As [suggested](https://github.com/pytorch/torchtune/pull/2238/files#r1917299528), I run with  compile + opt_in_bwd + activation ckpt + activation offloading on 2xH100 using [mhenrichsen/alpaca_2k_test](https://huggingface.co/datasets/mhenrichsen/alpaca_2k_test) as a validation dataset.

#### LoRA Distributed

```
pip install -U git+https://github.com/bzz/torchtune.git@validate_distributed

# with validation
tune run --nnodes 1 --nproc_per_node 2 lora_finetune_distributed --config 1B_qlora_validation.yaml \
	compile=True \
	enable_activation_checkpointing=True \
	enable_activation_offloading=True \
	optimizer_in_bwd=True \
	tokenizer.max_seq_len=4096 \
	gradient_accumulation_steps=1 \
	epochs=1 \
	batch_size=16 \
	metric_logger._component_=torchtune.training.metric_logging.WandBLogger \
	output_dir=/tmp/torchtune/llama3_2_1B/qlora_val
```

Without validation
```
tune run --nnodes 1 --nproc_per_node 2 lora_finetune_distributed --config 1B_qlora_validation.yaml \
	run_val_every_n_steps=None \
	compile=True \
	enable_activation_checkpointing=True \
	enable_activation_offloading=True \
	optimizer_in_bwd=True \
	tokenizer.max_seq_len=4096 \
	gradient_accumulation_steps=1 \
	epochs=1 \
	batch_size=16 \
	metric_logger._component_=torchtune.training.metric_logging.WandBLogger \
	output_dir=/tmp/torchtune/llama3_2_1B/qlora
```

<img width="811" alt="Screenshot 2025-03-06 at 08 05 19" src="https://github.com/user-attachments/assets/bb87a934-bb4f-4fbd-994d-e96ad27f789c" />



<details>
<description>llama3_2/1B_qlora_validation.yaml</description>

```
diff recipes/configs/llama3_2/1B_qlora_validation.yaml recipes/configs/llama3_2/1B_lora.yaml

20c20
< output_dir: /tmp/torchtune/llama3_2_1B/qlora # /tmp may be deleted by your system. Change it to your preference.
---
> output_dir: /tmp/torchtune/llama3_2_1B/lora # /tmp may be deleted by your system. Change it to your preference.
30c30
<   _component_: torchtune.models.llama3_2.qlora_llama3_2_1b
---
>   _component_: torchtune.models.llama3_2.lora_llama3_2_1b
57,65d56
< # Validation
< dataset_validation:
<   _component_: torchtune.datasets.alpaca_dataset
<   source: mhenrichsen/alpaca_2k_test
<   split: train
<   packed: False  # True increases speed
< run_val_every_n_steps: 100
< max_validation_batches: -1
<
82c73
< gradient_accumulation_steps: 1  # Use to increase effective batch size
---
> gradient_accumulation_steps: 8  # Use to increase effective batch size
84c75
< compile: True  # torch.compile the model + loss, True increases speed + decreases memory
---
> compile: False  # torch.compile the model + loss, True increases speed + decreases memory
88c79
<   _component_: torchtune.training.metric_logging.WandBLogger
---
>   _component_: torchtune.training.metric_logging.DiskLogger
```
</details>

The difference in throughput is due to both runs using the same 2 GPUs.


#### Full Distributed

```
tune cp llama3_2/1B_full 1B_full_validation

# Validation
dataset_validation:
  _component_: torchtune.datasets.alpaca_dataset
  source: mhenrichsen/alpaca_2k_test
  split: train
run_val_every_n_steps: 100
max_validation_batches: -1

metric_logger:
	_component_: torchtune.training.metric_logging.WandBLogger
```

Validation
```
tune run --nnodes 1 --nproc_per_node 2 \
    full_finetune_distributed --config 1B_full_validation.yaml \
	compile=True \
	enable_activation_checkpointing=True \
	enable_activation_offloading=True \
	optimizer_in_bwd=True \
	tokenizer.max_seq_len=4096 \
	gradient_accumulation_steps=1 \
	epochs=1 \
	batch_size=16 \
	output_dir=/tmp/torchtune/llama3_2_1B/full_dist_val
```

And without
```
tune run --nnodes 1 --nproc_per_node 2 \
    full_finetune_distributed --config 1B_full_validation.yaml \
	run_val_every_n_steps=None \
	compile=True \
	enable_activation_checkpointing=True \
	enable_activation_offloading=True \
	optimizer_in_bwd=True \
	tokenizer.max_seq_len=4096 \
	gradient_accumulation_steps=1 \
	epochs=1 \
	batch_size=16 \
	output_dir=/tmp/torchtune/llama3_2_1B/full_dist
```

<img width="807" alt="Screenshot 2025-03-06 at 11 34 48" src="https://github.com/user-attachments/assets/c446bba8-8acf-4648-8529-0bb5ed40babe" />



- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX

The output is really simplistic and looks like 
```
1|100|Loss: 3.8272886276245117:   6%|████                                                               | 100/1625 [01:05<05:46,  4.41it/s]
INFO:torchtune.utils._logging:Validation loss: 4.8242
1|200|Loss: 1.7956730127334595:  12%|████████▏                                                          | 200/1625 [01:30<05:11,  4.58it/s]
INFO:torchtune.utils._logging:Validation loss: 1.8639
1|300|Loss: 1.4479581117630005:  18%|████████████▎                                                      | 300/1625 [01:52<03:54,  5.66it/s]
INFO:torchtune.utils._logging:Validation loss: 1.7377
1|400|Loss: 1.433119535446167:  25%|████████████████▋                                                   | 400/1625 [02:13<03:51,  5.28it/s]
INFO:torchtune.utils._logging:Validation loss: 1.7247
1|500|Loss: 1.5169874429702759:  31%|████████████████████▌                                              | 500/1625 [02:34<03:13,  5.81it/s]
INFO:torchtune.utils._logging:Validation loss: 1.7714
1|600|Loss: 1.4446262121200562:  37%|████████████████████████▋                                          | 600/1625 [02:55<02:54,  5.89it/s]
INFO:torchtune.utils._logging:Validation loss: 1.7542
1|700|Loss: 1.5118173360824585:  43%|████████████████████████████▊                                      | 700/1625 [03:18<02:54,  5.32it/s]
INFO:torchtune.utils._logging:Validation loss: 1.7290
1|800|Loss: 1.2981687784194946:  49%|████████████████████████████████▉                                  | 800/1625 [03:40<02:09,  6.35it/s]
INFO:torchtune.utils._logging:Validation loss: 1.7309
1|900|Loss: 1.533372163772583:  55%|█████████████████████████████████████▋                              | 900/1625 [04:01<02:22,  5.08it/s]
INFO:torchtune.utils._logging:Validation loss: 1.7264
```

Please if you think it needs to be somehow improved.

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
