### PR TITLE
Reference-free DPO losses in torchtune.

### DIFF
--- a/docs/source/recipes/dpo.rst
+++ b/docs/source/recipes/dpo.rst
@@ -81,6 +81,8 @@ If this is not sufficient and you need to compute additional values from the log
 
 Refer to the TRL library for reference implementations of the desired losses. In particular, you may find useful loss calculations in trainers.
 
+In case, if you don't want to calculate reference values, you can add `reference: False` to the recipe.
+
 For a deeper understanding of the different levers you can pull when using this recipe,
 see our documentation for the different PEFT training paradigms we support:
 

--- a/docs/source/recipes/dpo.rst
+++ b/docs/source/recipes/dpo.rst
@@ -81,7 +81,7 @@ If this is not sufficient and you need to compute additional values from the log
 
 Refer to the TRL library for reference implementations of the desired losses. In particular, you may find useful loss calculations in trainers.
 
-In case, if you don't want to calculate reference values, you can add `reference: False` to the recipe.
+In case, if you don't want to calculate reference values, you can add `is_reference_free: True` to the loss definition in the recipe.
 
 For a deeper understanding of the different levers you can pull when using this recipe,
 see our documentation for the different PEFT training paradigms we support:

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -903,8 +903,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                     policy_chosen_rejected_outputs.chosen_logits,
                     policy_chosen_rejected_outputs.rejected_logits,
                 )
-                
-                
+
                 # Initialize empty outputs as the loss may be reference free.
                 reference_chosen_rejected_outputs = ChosenRejectedOutputs(
                     None,
@@ -912,7 +911,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                     None,
                     None,
                 )
-                
+
                 if not self._loss_fn.is_reference_free:
                     with torch.no_grad():
                         reference_chosen_rejected_outputs = self.concatenated_forward(

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -903,16 +903,26 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                     policy_chosen_rejected_outputs.chosen_logits,
                     policy_chosen_rejected_outputs.rejected_logits,
                 )
-
-                with torch.no_grad():
-                    reference_chosen_rejected_outputs = self.concatenated_forward(
-                        self._ref_model, batch, activations_handling=False
-                    )
-
-                del (
-                    reference_chosen_rejected_outputs.chosen_logits,
-                    reference_chosen_rejected_outputs.rejected_logits,
+                
+                
+                # Initialize empty outputs as the loss may be reference free.
+                reference_chosen_rejected_outputs = ChosenRejectedOutputs(
+                    None,
+                    None,
+                    None,
+                    None,
                 )
+                
+                if not self._loss_fn.is_reference_free:
+                    with torch.no_grad():
+                        reference_chosen_rejected_outputs = self.concatenated_forward(
+                            self._ref_model, batch, activations_handling=False
+                        )
+
+                    del (
+                        reference_chosen_rejected_outputs.chosen_logits,
+                        reference_chosen_rejected_outputs.rejected_logits,
+                    )
 
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_rejected_outputs, reference_chosen_rejected_outputs

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -709,11 +709,21 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     policy_chosen_rejected_outputs.chosen_logits,
                     policy_chosen_rejected_outputs.rejected_logits,
                 )
-
-                with torch.no_grad(), disable_adapter(self._model):
-                    reference_chosen_rejected_outputs = self.concatenated_forward(
-                        self._model, batch
-                    )
+                
+                # Initialize empty outputs as the loss may be reference free.
+                reference_chosen_rejected_outputs = ChosenRejectedOutputs(
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                
+                if not self._loss_fn.is_reference_free:
+                    with torch.no_grad(), disable_adapter(self._model):
+                        reference_chosen_rejected_outputs = self.concatenated_forward(
+                            self._model, batch
+                        )
+                        
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_rejected_outputs,
                     reference_chosen_rejected_outputs,

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -709,7 +709,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     policy_chosen_rejected_outputs.chosen_logits,
                     policy_chosen_rejected_outputs.rejected_logits,
                 )
-                
+
                 # Initialize empty outputs as the loss may be reference free.
                 reference_chosen_rejected_outputs = ChosenRejectedOutputs(
                     None,
@@ -717,13 +717,13 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     None,
                     None,
                 )
-                
+
                 if not self._loss_fn.is_reference_free:
                     with torch.no_grad(), disable_adapter(self._model):
                         reference_chosen_rejected_outputs = self.concatenated_forward(
                             self._model, batch
                         )
-                        
+
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_rejected_outputs,
                     reference_chosen_rejected_outputs,

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -552,11 +552,21 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                     policy_chosen_rejected_outputs.chosen_logits,
                     policy_chosen_rejected_outputs.rejected_logits,
                 )
-
-                with torch.no_grad(), disable_adapter(self._model):
-                    reference_chosen_rejected_outputs = self.concatenated_forward(
-                        self._model, batch
-                    )
+                
+                # Initialize empty outputs as the loss may be reference free.
+                reference_chosen_rejected_outputs = ChosenRejectedOutputs(
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                
+                if not self._loss_fn.is_reference_free:
+                    with torch.no_grad(), disable_adapter(self._model):
+                        reference_chosen_rejected_outputs = self.concatenated_forward(
+                            self._model, batch
+                        )
+                        
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_rejected_outputs,
                     reference_chosen_rejected_outputs,

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -552,7 +552,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                     policy_chosen_rejected_outputs.chosen_logits,
                     policy_chosen_rejected_outputs.rejected_logits,
                 )
-                
+
                 # Initialize empty outputs as the loss may be reference free.
                 reference_chosen_rejected_outputs = ChosenRejectedOutputs(
                     None,
@@ -560,13 +560,13 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                     None,
                     None,
                 )
-                
+
                 if not self._loss_fn.is_reference_free:
                     with torch.no_grad(), disable_adapter(self._model):
                         reference_chosen_rejected_outputs = self.concatenated_forward(
                             self._model, batch
                         )
-                        
+
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_rejected_outputs,
                     reference_chosen_rejected_outputs,

--- a/torchtune/rlhf/loss/dpo.py
+++ b/torchtune/rlhf/loss/dpo.py
@@ -4,16 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple, Optional, TypeVar, Protocol
-
 from dataclasses import dataclass
+from typing import Optional, Protocol, Tuple, TypeVar
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torchtune.utils._logging import deprecated
 
 from torchtune.rlhf._types import ChosenRejectedOutputs
+from torchtune.utils._logging import deprecated
 
 T = TypeVar("T", bound=dataclass)
 
@@ -21,15 +20,19 @@ T = TypeVar("T", bound=dataclass)
 class PreferenceLoss(nn.Module, Protocol):
     @property
     def is_reference_free(self) -> bool:
-       return False
+        return False
 
-    def forward(self, chosen_rejected_policy: T, chosen_rejected_reference: Optional[T], *args, **kwargs) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def forward(
+        self,
+        chosen_rejected_policy: T,
+        chosen_rejected_reference: Optional[T],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
-        Compute the DPO loss for a batch of policy and reference model log probabilities.
+        Compute the PreferenceLoss for a batch of policy and reference model log probabilities.
 
         Args:
-            policy_inputs (T): Policy log-probs and logits required for the calculation.
-            reference_inputs (Optional[T]): Reference log-probs and logits required for the calculation.
+            chosen_rejected_policy (T): Policy log-probs and logits required for the calculation.
+            chosen_rejected_reference (Optional[T]): Reference log-probs and logits required for the calculation.
 
         Returns:
             Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: A tuple of three tensors:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X] add a new feature
- [ ] fix a bug
- [X] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* #1223 #2292 #2081 

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
