### PR TITLE
Fix missing MPS detection in _get_device_type_from_env()

### DIFF
--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -204,8 +204,8 @@ class DeviceSupport(Enum):
     This is a simple enum for compute devices,
     This currently only supports CPU, CUDA, NPU, and XPU.
     The following enumeration defines various device configurations with attributes:
-    1. `device_type` (str): The type of device (e.g., "cpu", "cuda", "npu", "xpu").
-    2. `device_name` (str): A user-friendly name for the device (e.g., "CPU", "GPU", "NPU", "XPU").
+    1. `device_type` (str): The type of device (e.g., "cpu", "cuda", "npu", "xpu", "mps").
+    2. `device_name` (str): A user-friendly name for the device (e.g., "CPU", "GPU", "NPU", "XPU", "MPS").
     3. `communication_backend` (str): Specifies the backend used for communication on this device
     (e.g., "gloo", "nccl", "hccl", "ccl").
     """
@@ -214,6 +214,7 @@ class DeviceSupport(Enum):
     CUDA = ("cuda", "GPU", "nccl")
     NPU = ("npu", "NPU", "hccl")
     XPU = ("xpu", "XPU", "ccl")
+    MPS = ("mps", "MPS", "gloo")
 
     def __init__(
         self,

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -153,7 +153,7 @@ def get_device(device: Optional[str] = None) -> torch.device:
     If CUDA-like is available and being used, this function also sets the CUDA-like device.
 
     Args:
-        device (Optional[str]): The name of the device to use, e.g. "cuda" or "cpu" or "npu" or "xpu" or "mps".
+        device (Optional[str]): The name of the device to use, one of "cuda", "cpu", "npu", "xpu", or "mps".
 
     Example:
         >>> device = get_device("cuda")

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -153,7 +153,7 @@ def get_device(device: Optional[str] = None) -> torch.device:
     If CUDA-like is available and being used, this function also sets the CUDA-like device.
 
     Args:
-        device (Optional[str]): The name of the device to use, e.g. "cuda" or "cpu" or "npu" or "xpu".
+        device (Optional[str]): The name of the device to use, e.g. "cuda" or "cpu" or "npu" or "xpu" or "mps".
 
     Example:
         >>> device = get_device("cuda")
@@ -166,7 +166,7 @@ def get_device(device: Optional[str] = None) -> torch.device:
     if device is None:
         device = _get_device_type_from_env()
     device = torch.device(device)
-    if device.type in ["cuda", "npu", "xpu"]:
+    if device.type in ["cuda", "npu", "xpu", "mps"]:
         device = _setup_device(device)
     _validate_device_from_env(device)
     return device
@@ -237,7 +237,7 @@ class DeviceSupport(Enum):
 def get_device_support() -> DeviceSupport:
     """function that gets the DeviceSupport with compute devices based on the current machine.
 
-    This currently only supports CPU, CUDA, NPU, XPU.
+    This currently only supports CPU, CUDA, NPU, XPU, and MPS.
 
     Returns:
         device_support: DeviceSupport

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -93,7 +93,7 @@ def _setup_device(device: torch.device) -> torch.device:
 def _get_device_type_from_env() -> str:
     """Function that gets the torch.device based on the current machine.
 
-    This currently only supports CPU, CUDA, NPU.
+    This currently only supports CPU, CUDA, NPU, XPU, and MPS.
 
     Returns:
         device
@@ -104,6 +104,8 @@ def _get_device_type_from_env() -> str:
         device = "npu"
     elif torch.xpu.is_available():
         device = "xpu"
+    elif torch.mps.is_available():
+        device = "mps"
     else:
         device = "cpu"
     return device


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
`_get_device_type_from_env` appropriately detects MPS.

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
