### PR TITLE
Add missing `--output_dir` to config download commands

### DIFF
--- a/recipes/configs/gemma/2B_full.yaml
+++ b/recipes/configs/gemma/2B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --output-dir /tmp/gemma-2b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma/2B_full

--- a/recipes/configs/gemma/2B_full.yaml
+++ b/recipes/configs/gemma/2B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN>
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma/2B_full

--- a/recipes/configs/gemma/2B_lora.yaml
+++ b/recipes/configs/gemma/2B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN>
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma/2B_lora

--- a/recipes/configs/gemma/2B_lora.yaml
+++ b/recipes/configs/gemma/2B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --output-dir /tmp/gemma-2b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma/2B_lora

--- a/recipes/configs/gemma/2B_lora_single_device.yaml
+++ b/recipes/configs/gemma/2B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --output-dir /tmp/gemma-2b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/2B_lora_single_device

--- a/recipes/configs/gemma/2B_lora_single_device.yaml
+++ b/recipes/configs/gemma/2B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/2B_lora_single_device

--- a/recipes/configs/gemma/2B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/2B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN>
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/2B_qlora_single_device

--- a/recipes/configs/gemma/2B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/2B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2b
+#   tune download google/gemma-2b --ignore-patterns "gemma-2b.gguf" --output-dir /tmp/gemma-2b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/2B_qlora_single_device

--- a/recipes/configs/gemma/7B_full.yaml
+++ b/recipes/configs/gemma/7B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --output-dir /tmp/gemma-7b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma/7B_full

--- a/recipes/configs/gemma/7B_full.yaml
+++ b/recipes/configs/gemma/7B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma/7B_full

--- a/recipes/configs/gemma/7B_lora.yaml
+++ b/recipes/configs/gemma/7B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --output-dir /tmp/gemma-7b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma/7B_lora

--- a/recipes/configs/gemma/7B_lora.yaml
+++ b/recipes/configs/gemma/7B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN>
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma/7B_lora

--- a/recipes/configs/gemma/7B_lora_single_device.yaml
+++ b/recipes/configs/gemma/7B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run (torchtune does not use gguf so you can ignore it to save time and space):
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/7B_lora_single_device

--- a/recipes/configs/gemma/7B_lora_single_device.yaml
+++ b/recipes/configs/gemma/7B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run (torchtune does not use gguf so you can ignore it to save time and space):
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --output-dir /tmp/gemma-7b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/7B_lora_single_device

--- a/recipes/configs/gemma/7B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/7B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --output-dir /tmp/gemma-7b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/7B_qlora_single_device

--- a/recipes/configs/gemma/7B_qlora_single_device.yaml
+++ b/recipes/configs/gemma/7B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN>
+#   tune download google/gemma-7b --ignore-patterns "gemma-7b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-7b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma/7B_qlora_single_device

--- a/recipes/configs/gemma2/27B_full.yaml
+++ b/recipes/configs/gemma2/27B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf" --output-dir /tmp/gemma-2-27b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma2/27B_full

--- a/recipes/configs/gemma2/27B_full.yaml
+++ b/recipes/configs/gemma2/27B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma2/27B_full

--- a/recipes/configs/gemma2/27B_lora.yaml
+++ b/recipes/configs/gemma2/27B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma2/27B_lora

--- a/recipes/configs/gemma2/27B_lora.yaml
+++ b/recipes/configs/gemma2/27B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf" --output-dir /tmp/gemma-2-27b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma2/27B_lora

--- a/recipes/configs/gemma2/27B_lora_single_device.yaml
+++ b/recipes/configs/gemma2/27B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run (torchtune does not use gguf so you can ignore it to save time and space):
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf" --output-dir /tmp/gemma-2-27b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/27B_lora_single_device

--- a/recipes/configs/gemma2/27B_lora_single_device.yaml
+++ b/recipes/configs/gemma2/27B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run (torchtune does not use gguf so you can ignore it to save time and space):
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf" --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/27B_lora_single_device

--- a/recipes/configs/gemma2/27B_qlora_single_device.yaml
+++ b/recipes/configs/gemma2/27B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf" --output-dir /tmp/gemma-2-27b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/27B_qlora_single_device

--- a/recipes/configs/gemma2/27B_qlora_single_device.yaml
+++ b/recipes/configs/gemma2/27B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-27b --ignore-patterns "gemma-2-27b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-27b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/27B_qlora_single_device

--- a/recipes/configs/gemma2/2B_full.yaml
+++ b/recipes/configs/gemma2/2B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma2/2B_full

--- a/recipes/configs/gemma2/2B_full.yaml
+++ b/recipes/configs/gemma2/2B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf" --output-dir /tmp/gemma-2-2b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma2/2B_full

--- a/recipes/configs/gemma2/2B_lora.yaml
+++ b/recipes/configs/gemma2/2B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf" --output-dir /tmp/gemma-2-2b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma2/2B_lora

--- a/recipes/configs/gemma2/2B_lora.yaml
+++ b/recipes/configs/gemma2/2B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma2/2B_lora

--- a/recipes/configs/gemma2/2B_lora_single_device.yaml
+++ b/recipes/configs/gemma2/2B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf" --output-dir /tmp/gemma-2-2b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/2B_lora_single_device

--- a/recipes/configs/gemma2/2B_lora_single_device.yaml
+++ b/recipes/configs/gemma2/2B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/2B_lora_single_device

--- a/recipes/configs/gemma2/2B_qlora_single_device.yaml
+++ b/recipes/configs/gemma2/2B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf" --output-dir /tmp/gemma-2-2b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/2B_qlora_single_device

--- a/recipes/configs/gemma2/2B_qlora_single_device.yaml
+++ b/recipes/configs/gemma2/2B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-2b --ignore-patterns "gemma-2-2b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-2b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/2B_qlora_single_device

--- a/recipes/configs/gemma2/9B_full.yaml
+++ b/recipes/configs/gemma2/9B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma2/9B_full

--- a/recipes/configs/gemma2/9B_full.yaml
+++ b/recipes/configs/gemma2/9B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf" --output-dir /tmp/gemma-2-9b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config gemma2/9B_full

--- a/recipes/configs/gemma2/9B_lora.yaml
+++ b/recipes/configs/gemma2/9B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf" --output-dir /tmp/gemma-2-9b --hf-token <HF_TOKEN>
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma2/9B_lora

--- a/recipes/configs/gemma2/9B_lora.yaml
+++ b/recipes/configs/gemma2/9B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
 #
 # To launch on 4 devices, run the following command from root:
 #   tune run --nnodes 1 --nproc_per_node 4 lora_finetune_distributed --config gemma2/9B_lora

--- a/recipes/configs/gemma2/9B_lora_single_device.yaml
+++ b/recipes/configs/gemma2/9B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run (torchtune does not use gguf so you can ignore it to save time and space):
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf" --output-dir /tmp/gemma-2-9b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/9B_lora_single_device

--- a/recipes/configs/gemma2/9B_lora_single_device.yaml
+++ b/recipes/configs/gemma2/9B_lora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run (torchtune does not use gguf so you can ignore it to save time and space):
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/9B_lora_single_device

--- a/recipes/configs/gemma2/9B_qlora_single_device.yaml
+++ b/recipes/configs/gemma2/9B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN>
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/9B_qlora_single_device

--- a/recipes/configs/gemma2/9B_qlora_single_device.yaml
+++ b/recipes/configs/gemma2/9B_qlora_single_device.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf"  --hf-token <HF_TOKEN> --output-dir /tmp/gemma-2-9b
+#   tune download google/gemma-2-9b --ignore-patterns "gemma-2-9b.gguf" --output-dir /tmp/gemma-2-9b --hf-token <HF_TOKEN>
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config gemma2/9B_qlora_single_device

--- a/recipes/configs/llama3_1/405B_qlora.yaml
+++ b/recipes/configs/llama3_1/405B_qlora.yaml
@@ -7,7 +7,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Meta-Llama-3.1-405B-Instruct --ignore-patterns "original/consolidated*" --hf-token <HF_TOKEN> --output-dir /tmp/Meta-Llama-3.1-405B-Instruct
+#   tune download meta-llama/Meta-Llama-3.1-405B-Instruct --ignore-patterns "original/consolidated*" --output-dir /tmp/Meta-Llama-3.1-405B-Instruct --hf-token <HF_TOKEN>
 #
 # This config needs 8 GPUs to run
 #   # tune run --nproc_per_node 8 lora_finetune_distributed --config llama3_1/405B_qlora

--- a/recipes/configs/llama3_1/405B_qlora.yaml
+++ b/recipes/configs/llama3_1/405B_qlora.yaml
@@ -7,7 +7,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Meta-Llama-3.1-405B-Instruct --ignore-patterns "original/consolidated*" --hf-token <HF_TOKEN>
+#   tune download meta-llama/Meta-Llama-3.1-405B-Instruct --ignore-patterns "original/consolidated*" --hf-token <HF_TOKEN> --output-dir /tmp/Meta-Llama-3.1-405B-Instruct
 #
 # This config needs 8 GPUs to run
 #   # tune run --nproc_per_node 8 lora_finetune_distributed --config llama3_1/405B_qlora

--- a/recipes/configs/llama3_3/70B_full.yaml
+++ b/recipes/configs/llama3_3/70B_full.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*"
+#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*" --output-dir /tmp/Llama-3.3-70B-Instruct
 #
 # To launch on 8 devices, run the following command from root:
 #   tune run --nproc_per_node 8 full_finetune_distributed --config llama3_3/70B_full

--- a/recipes/configs/llama3_3/70B_generation_distributed.yaml
+++ b/recipes/configs/llama3_3/70B_generation_distributed.yaml
@@ -2,7 +2,7 @@
 # using a Llama3.1 70B Instruct model
 #
 # This config assumes that you've run the following command before launching:
-#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*" --hf-token <HF_TOKEN>
+#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*" --hf-token <HF_TOKEN> --output-dir /tmp/Llama-3.3-70B-Instruct
 #
 # To launch, run the following command from root torchtune directory:
 #    tune run --nproc_per_node 8 dev/generate_v2_distributed --config llama3_3/70B_generation_distributed

--- a/recipes/configs/llama3_3/70B_generation_distributed.yaml
+++ b/recipes/configs/llama3_3/70B_generation_distributed.yaml
@@ -2,7 +2,7 @@
 # using a Llama3.1 70B Instruct model
 #
 # This config assumes that you've run the following command before launching:
-#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*" --hf-token <HF_TOKEN> --output-dir /tmp/Llama-3.3-70B-Instruct
+#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*" --output-dir /tmp/Llama-3.3-70B-Instruct --hf-token <HF_TOKEN>
 #
 # To launch, run the following command from root torchtune directory:
 #    tune run --nproc_per_node 8 dev/generate_v2_distributed --config llama3_3/70B_generation_distributed

--- a/recipes/configs/llama3_3/70B_lora.yaml
+++ b/recipes/configs/llama3_3/70B_lora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*"
+#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*" --output-dir /tmp/Llama-3.3-70B-Instruct
 #
 # This config needs 8 GPUs to run
 #   tune run --nproc_per_node 8 lora_finetune_distributed --config llama3_3/70B_lora

--- a/recipes/configs/llama3_3/70B_qlora.yaml
+++ b/recipes/configs/llama3_3/70B_qlora.yaml
@@ -3,7 +3,7 @@
 #
 # This config assumes that you've run the following command before launching
 # this run:
-#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*"
+#   tune download meta-llama/Llama-3.3-70B-Instruct --ignore-patterns "original/consolidated*" --output-dir /tmp/Llama-3.3-70B-Instruct
 #
 # This config needs 8 GPUs to run
 #   tune run --nproc_per_node 8 lora_finetune_distributed --config llama3_3/70B_lora

--- a/recipes/configs/qwen2_5/0.5B_full.yaml
+++ b/recipes/configs/qwen2_5/0.5B_full.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 0.5B model
 #
 # This config assumes that you've run the following command before launching:
-#   tune download Qwen/Qwen2.5-0.5B-Instruct
+#   tune download Qwen/Qwen2.5-0.5B-Instruct --output-dir /tmp/Qwen2.5-0.5B-Instruct
 #
 # To launch on 2 devices, run the following command from root:
 #   tune run --nproc_per_node 2 full_finetune_distributed --config qwen2_5/0.5B_full

--- a/recipes/configs/qwen2_5/0.5B_full_single_device.yaml
+++ b/recipes/configs/qwen2_5/0.5B_full_single_device.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 0.5B
 #
 # This config assumes that you've run the following command before launching:
-#   tune download Qwen/Qwen2.5-0.5B-Instruct
+#   tune download Qwen/Qwen2.5-0.5B-Instruct --output-dir /tmp/Qwen2.5-0.5B-Instruct
 #
 # To launch on a single device, run the following command from root:
 #   tune run full_finetune_single_device --config qwen2_5/0.5B_full_single_device

--- a/recipes/configs/qwen2_5/0.5B_lora.yaml
+++ b/recipes/configs/qwen2_5/0.5B_lora.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 0.5B model
 #
 # This config assumes that you've run the following command before launching:
-#   tune download Qwen/Qwen2.5-0.5B-Instruct
+#   tune download Qwen/Qwen2.5-0.5B-Instruct --output-dir /tmp/Qwen2.5-0.5B-Instruct
 #
 # To launch on 2 devices, run the following command from root:
 #   tune run --nproc_per_node 2 lora_finetune_distributed --config qwen2_5/0.5B_lora

--- a/recipes/configs/qwen2_5/0.5B_lora_single_device.yaml
+++ b/recipes/configs/qwen2_5/0.5B_lora_single_device.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 0.5B model
 #
 # This config assumes that you've run the following command before launching
-#   tune download Qwen/Qwen2.5-0.5B-Instruct
+#   tune download Qwen/Qwen2.5-0.5B-Instruct --output-dir /tmp/Qwen2.5-0.5B-Instruct
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config qwen2_5/0.5B_lora_single_device

--- a/recipes/configs/qwen2_5/1.5B_full.yaml
+++ b/recipes/configs/qwen2_5/1.5B_full.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 1.5B model
 #
 # This config assumes that you've run the following command before launching:
-#   tune download Qwen/Qwen2.5-1.5B-Instruct
+#   tune download Qwen/Qwen2.5-1.5B-Instruct --output-dir /tmp/Qwen2.5-1.5B-Instruct
 #
 # To launch on 2 devices, run the following command from root:
 #   tune run --nproc_per_node 2 full_finetune_distributed --config qwen2_5/1.5B_full

--- a/recipes/configs/qwen2_5/1.5B_full_single_device.yaml
+++ b/recipes/configs/qwen2_5/1.5B_full_single_device.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 1.5B
 #
 # This config assumes that you've run the following command before launching:
-#   tune download Qwen/Qwen2.5-1.5B-Instruct
+#   tune download Qwen/Qwen2.5-1.5B-Instruct --output-dir /tmp/Qwen2.5-1.5B-Instruct
 #
 # The default config uses an optimizer from bitsandbytes. If you do not have it installed,
 # you can install it with:

--- a/recipes/configs/qwen2_5/1.5B_lora.yaml
+++ b/recipes/configs/qwen2_5/1.5B_lora.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 1.5B model
 #
 # This config assumes that you've run the following command before launching:
-#   tune download Qwen/Qwen2.5-1.5B-Instruct
+#   tune download Qwen/Qwen2.5-1.5B-Instruct --output-dir /tmp/Qwen2.5-1.5B-Instruct
 #
 # To launch on 2 devices, run the following command from root:
 #   tune run --nproc_per_node 2 lora_finetune_distributed --config qwen2_5/1.5B_lora

--- a/recipes/configs/qwen2_5/1.5B_lora_single_device.yaml
+++ b/recipes/configs/qwen2_5/1.5B_lora_single_device.yaml
@@ -2,7 +2,7 @@
 # using a Qwen2.5 1.5B model
 #
 # This config assumes that you've run the following command before launching:
-#   tune download Qwen/Qwen2.5-1.5B-Instruct
+#   tune download Qwen/Qwen2.5-1.5B-Instruct --output-dir /tmp/Qwen2.5-1.5B-Instruct
 #
 # To launch on a single device, run the following command from root:
 #   tune run lora_finetune_single_device --config qwen2_5/1.5B_lora_single_device


### PR DESCRIPTION
```bash
$ grep -r --include="*.yaml" "tune download" . | grep -v "output-dir"
...
$ grep -r --include="*.yaml" "tune download" . | grep -v "output-dir" | wc -l
33
```