### PR TITLE
Skip failing tests on MPS

### DIFF
--- a/tests/torchtune/models/flux/test_flux_autoencoder.py
+++ b/tests/torchtune/models/flux/test_flux_autoencoder.py
@@ -6,10 +6,10 @@
 
 import pytest
 import torch
+from tests.test_utils import mps_ignored_test
 
 from torchtune.models.flux import flux_1_autoencoder
 from torchtune.training.seed import set_seed
-from tests.test_utils import mps_ignored_test
 
 BSZ = 32
 CH_IN = 3

--- a/tests/torchtune/models/flux/test_flux_autoencoder.py
+++ b/tests/torchtune/models/flux/test_flux_autoencoder.py
@@ -9,6 +9,7 @@ import torch
 
 from torchtune.models.flux import flux_1_autoencoder
 from torchtune.training.seed import set_seed
+from tests.test_utils import mps_ignored_test
 
 BSZ = 32
 CH_IN = 3
@@ -51,6 +52,7 @@ class TestFluxAutoencoder:
     def z(self):
         return torch.randn(BSZ, CH_Z, RES_Z, RES_Z)
 
+    @mps_ignored_test()
     def test_forward(self, model, img):
         actual = model(img)
         assert actual.shape == (BSZ, CH_IN, RESOLUTION, RESOLUTION)
@@ -64,6 +66,7 @@ class TestFluxAutoencoder:
         loss = y.mean()
         loss.backward()
 
+    @mps_ignored_test()
     def test_encode(self, model, img):
         actual = model.encode(img)
         assert actual.shape == (BSZ, CH_Z, RES_Z, RES_Z)

--- a/tests/torchtune/modules/peft/test_dora.py
+++ b/tests/torchtune/modules/peft/test_dora.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 
 import torch.distributed
-from tests.test_utils import fixed_init_model, gpu_test
+from tests.test_utils import fixed_init_model, gpu_test, mps_ignored_test
 from torch import nn
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._tensor import DTensor, Replicate
@@ -152,6 +152,7 @@ class TestDoRALinear:
         "use_bias, dtype",
         [(False, torch.bfloat16), (True, torch.float32), (False, torch.float32)],
     )
+    @mps_ignored_test()
     def test_qdora_parity(self, use_bias, dtype, dora_linear, qdora_linear):
         with training.set_default_dtype(dtype):
             qdora_linear = qdora_linear(

--- a/tests/torchtune/modules/peft/test_lora.py
+++ b/tests/torchtune/modules/peft/test_lora.py
@@ -9,7 +9,7 @@ from functools import partial
 import pytest
 
 import torch
-from tests.test_utils import fixed_init_model
+from tests.test_utils import fixed_init_model, mps_ignored_test
 from torch import nn
 from torchao.dtypes.nf4tensor import NF4Tensor, to_nf4
 from torchtune import training
@@ -159,6 +159,7 @@ class TestLoRALinear:
         "use_bias, dtype",
         [(False, torch.bfloat16), (True, torch.float32), (False, torch.float32)],
     )
+    @mps_ignored_test()
     def test_qlora_parity(self, use_bias, dtype, qlora_linear, lora_linear):
         qlora_linear = qlora_linear(
             use_bias=use_bias, dtype=dtype, in_dim=512, out_dim=512


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
DIsable 4 failing tests on MPS, as discussed on discord.

```
========================= short test summary info ==========================
FAILED tests/torchtune/models/flux/test_flux_autoencoder.py::TestFluxAutoencoder::test_forward - AssertionError: Tensor-likes are not close!
FAILED tests/torchtune/models/flux/test_flux_autoencoder.py::TestFluxAutoencoder::test_encode - AssertionError: Tensor-likes are not close!
FAILED tests/torchtune/modules/peft/test_dora.py::TestDoRALinear::test_qdora_parity[True-dtype1] - AssertionError: Tensor-likes are not close!
FAILED tests/torchtune/modules/peft/test_lora.py::TestLoRALinear::test_qlora_parity[True-dtype1] - AssertionError: Tensor-likes are not close!
```

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
