### PR TITLE
Update Eleuther Eval to use Message format

### DIFF
--- a/recipes/eleuther_eval.py
+++ b/recipes/eleuther_eval.py
@@ -345,12 +345,13 @@ class _LLMEvalWrapper(HFLM):
         return self._enable_kv_cache
 
     def tok_encode(self, text: str, **kwargs) -> List[int]:
-        # Note on add_bos flag: setting to False as this gives better results, for example
-        # +1% on truthfulqa_mc2 with a LoRA finetune. lit-gpt also sets this to False,
-        # see https://github.com/Lightning-AI/lit-gpt/blob/main/eval/lm_eval_harness.py#L66,
-        # though notably fast-gpt does the opposite
-        # https://github.com/pytorch-labs/gpt-fast/blob/main/eval.py#L123.
-        return self._tokenizer.encode(text=text, add_bos=False, add_eos=False)
+        # Construct the messages
+        messages = []
+        messages.append(Message(role="user", content=text))
+        messages.append(Message(role="assistant", content=""))
+
+        # # Transform the messages
+        return self._tokenizer({"messages": messages}, inference=True)["tokens"]
 
     def tok_batch_encode(
         self, text: List[str], left_truncate_len: int = None, **kwargs

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -50,8 +50,8 @@ class TestEleutherEval:
     @pytest.mark.parametrize(
         "eval_name, expected_acc, bsz",
         [
-            ("truthfulqa_gen", 0.1, 4),
-            ("truthfulqa_gen", 0.1, 1),
+            ("truthfulqa_gen", 0.0, 4),
+            ("truthfulqa_gen", 0.0, 1),
             ("truthfulqa_mc2", 0.4, 4),
         ],
     )
@@ -97,7 +97,7 @@ class TestEleutherEval:
         # |--------------|------:|------|-----:|------|---|-----:|---|-----:|
         # |truthfulqa_mc2|      2|none  |     0|acc   |↑  |0.4497|±  |0.1067|
         search_results = re.search(
-            r"acc(?:_norm)?\s*\|?\s*(?:\↑\s*\|?)?([\d.]+)", out.strip()
+            r"acc(?:_norm)?\s*\|?\s*(?:\↑\s*\|?)?.?([\d.]+)", out.strip()
         )
         assert search_results is not None
         acc_result = float(search_results.group(1))


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses. #2459 

#### Changelog
What are the changes made in this PR?
* Update tok_encode in eluther_eval _LLMEvalWrapper to wrap text as messages and use the tokenizer __calll__ method with inference=True
* Update eleuther eval test for new accuracy figure

#### Test plan
**This is a backwards breaking change** in that the eval numbers will look different. By using the __call__ method you get properly formatted text based on the model tokenizer (including any prompt template). But before now, we were running text evals without any message formatting. This should make eval numbers go up for instruct models but potentially go down for base models, as seen in the regression test.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

[TODO] manually run eval with an instruct model to see if accuracy goes up
