### PR TITLE
Fix MPS `get_device`

### DIFF
--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -67,8 +67,8 @@ def _setup_device(device: torch.device) -> torch.device:
         device (torch.device): The device to set.
 
     Raises:
-        RuntimeError: If device index is not available, or if ``set_device`` is not
-            supported for the device type (e.g. on MPS).
+        RuntimeError: If device index is not available.
+        AttributeError: If ``set_device`` is not supported for the device type (e.g. on MPS).
 
     Returns:
         device
@@ -86,6 +86,10 @@ def _setup_device(device: torch.device) -> torch.device:
     if device.index >= torch_device.device_count():
         raise RuntimeError(
             f"The local rank is larger than the number of available {device_name}s."
+        )
+    if not hasattr(torch_device, "set_device"):
+        raise AttributeError(
+            f"The device type {device_type} does not support the `set_device` method."
         )
     torch_device.set_device(device)
     return device

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -67,7 +67,8 @@ def _setup_device(device: torch.device) -> torch.device:
         device (torch.device): The device to set.
 
     Raises:
-        RuntimeError: If device index is not available.
+        RuntimeError: If device index is not available, or if ``set_device`` is not
+            supported for the device type (e.g. on MPS).
 
     Returns:
         device
@@ -153,7 +154,7 @@ def get_device(device: Optional[str] = None) -> torch.device:
     If CUDA-like is available and being used, this function also sets the CUDA-like device.
 
     Args:
-        device (Optional[str]): The name of the device to use, one of "cuda", "cpu", "npu", or "xpu".
+        device (Optional[str]): The name of the device to use, one of "cuda", "cpu", "npu", "xpu", or "mps".
 
     Example:
         >>> device = get_device("cuda")

--- a/torchtune/utils/_device.py
+++ b/torchtune/utils/_device.py
@@ -153,7 +153,7 @@ def get_device(device: Optional[str] = None) -> torch.device:
     If CUDA-like is available and being used, this function also sets the CUDA-like device.
 
     Args:
-        device (Optional[str]): The name of the device to use, one of "cuda", "cpu", "npu", "xpu", or "mps".
+        device (Optional[str]): The name of the device to use, one of "cuda", "cpu", "npu", or "xpu".
 
     Example:
         >>> device = get_device("cuda")
@@ -166,7 +166,7 @@ def get_device(device: Optional[str] = None) -> torch.device:
     if device is None:
         device = _get_device_type_from_env()
     device = torch.device(device)
-    if device.type in ["cuda", "npu", "xpu", "mps"]:
+    if device.type in ["cuda", "npu", "xpu"]:
         device = _setup_device(device)
     _validate_device_from_env(device)
     return device


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

On main:
```python
>>> from torchtune.utils import get_device
>>> get_device("mps")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/salmanmohammadi/projects/torchtune/torchtune/utils/_device.py", line 170, in get_device
    device = _setup_device(device)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/salmanmohammadi/projects/torchtune/torchtune/utils/_device.py", line 89, in _setup_device
    torch_device.set_device(device)
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'torch.mps' has no attribute 'set_device'
>>> 
```

On this branch:
```python
>>> from torchtune.utils import get_device
>>> get_device("mps")
device(type='mps')
>>> import torch
>>> torch.ones((3,3)).to(device)
tensor([[1., 1., 1.],
        [1., 1., 1.],
        [1., 1., 1.]], device='mps:0')
```