### PR TITLE
Remove dataloader state dict loading

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -729,11 +729,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
         )
-        if dataloader_state_dict is not None:
-            dataloader.load_state_dict(dataloader_state_dict)
-            # B/c we currently only save at epoch boundaries, if we cut the previous epoch short
-            # we need to force the dataloader to finish the last iteration before it's actually used
-            list(dataloader)
+
         return dataloader
 
     def train(self) -> None:

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -600,13 +600,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             drop_last=True,
         )
 
-        print(dataloader_state_dict)
-        breakpoint()
-        if dataloader_state_dict is not None:
-            dataloader.load_state_dict(dataloader_state_dict)
-            # B/c we currently only save at epoch boundaries, if we cut the previous epoch short
-            # we need to force the dataloader to finish the last iteration before it's actually used
-            list(dataloader)
         return dataloader
 
     def save_checkpoint(self, epoch: int) -> None:

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -668,6 +668,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         # self.epochs_run should be non-zero when we're resuming from a checkpoint
         for curr_epoch in range(self.epochs_run, self.total_epochs):
             pbar = tqdm(total=self._steps_per_epoch)
+            self._dataloader.sampler.set_epoch(curr_epoch)
             for idx, batch in enumerate(self._dataloader):
                 # Start tracking CUDA memory for active steps for just the first epoch
                 if (

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -592,11 +592,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
         )
-        if dataloader_state_dict is not None:
-            dataloader.load_state_dict(dataloader_state_dict)
-            # B/c we currently only save at epoch boundaries, if we cut the previous epoch short
-            # we need to force the dataloader to finish the last iteration before it's actually used
-            list(dataloader)
+
         return dataloader
 
     def save_checkpoint(self, epoch: int) -> None:

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -562,12 +562,6 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             drop_last=True,
         )
 
-        if dataloader_state_dict is not None:
-            dataloader.load_state_dict(dataloader_state_dict)
-            # B/c we currently only save at epoch boundaries, if we cut the previous epoch short
-            # we need to force the dataloader to finish the last iteration before it's actually used
-            list(dataloader)
-
         return dataloader
 
     def save_checkpoint(self, epoch: int) -> None:

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -685,8 +685,8 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         self._profiler.start()
         # self.epochs_run should be non-zero when we're resuming from a checkpoint
         for curr_epoch in range(self.epochs_run, self.total_epochs):
-
             pbar = tqdm(total=self._steps_per_epoch)
+            self._dataloader.sampler.set_epoch(curr_epoch)
             for idx, batch in enumerate(self._dataloader):
 
                 # Start tracking CUDA memory for active steps for just the first epoch

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -629,11 +629,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
         )
-        if dataloader_state_dict is not None:
-            dataloader.load_state_dict(dataloader_state_dict)
-            # B/c we currently only save at epoch boundaries, if we cut the previous epoch short
-            # we need to force the dataloader to finish the last iteration before it's actually used
-            list(dataloader)
+
         return dataloader
 
     def save_checkpoint(

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -18,6 +18,7 @@ from omegaconf import DictConfig, ListConfig
 from torch import nn
 from torch.optim import Optimizer
 from torchdata.stateful_dataloader import StatefulDataLoader
+from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
 from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
@@ -546,10 +547,17 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             raise RuntimeError("left_pad_sequence collator is only for inference.")
         collate_fn = _get_component_from_path(collate_fn)
 
+        sampler = StatefulDistributedSampler(
+            ds,
+            num_replicas=1,
+            rank=0,
+            shuffle=shuffle,
+            seed=0,
+        )
         dataloader = StatefulDataLoader(
             dataset=ds,
-            shuffle=shuffle,
             batch_size=batch_size,
+            sampler=sampler,
             collate_fn=(
                 partial(
                     collate_fn,
@@ -562,11 +570,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
         )
-        if dataloader_state_dict is not None:
-            dataloader.load_state_dict(dataloader_state_dict)
-            # B/c we currently only save at epoch boundaries, if we cut the previous epoch short
-            # we need to force the dataloader to finish the last iteration before it's actually used
-            list(dataloader)
+
         return dataloader
 
     def save_checkpoint(self, epoch: int) -> None:
@@ -675,6 +679,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             # self.epochs_run should be non-zero when we're resuming from a checkpoint
             for curr_epoch in range(self.epochs_run, self.total_epochs):
                 pbar = tqdm(total=self._steps_per_epoch)
+                self._dataloader.sampler.set_epoch(curr_epoch)
                 for idx, batch in enumerate(self._dataloader):
                     # Start tracking CUDA memory for active steps for just the first epoch
                     if (

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -56,8 +56,8 @@ class TestFullFinetuneSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama2": [10.5219, 10.5292, 10.5475, 10.5195],
-            "llama3": [11.9611, 11.9432, 11.9326, 11.9807],
+            "llama2": [10.5219, 10.5216, 10.5475, 10.5195],
+            "llama3": [11.9838, 11.9432, 11.9326, 11.9807],
         }
 
         return loss_values_map[model_type]

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -56,8 +56,8 @@ class TestFullFinetuneSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama2": [10.5219, 10.5216, 10.5475, 10.5195],
-            "llama3": [11.9838, 11.9432, 11.9326, 11.9807],
+            "llama2": [10.5201, 10.5217, 10.4945, 10.5136],
+            "llama3": [11.9839, 11.9684, 11.9596, 11.9366],
         }
 
         return loss_values_map[model_type]

--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -56,7 +56,7 @@ class TestKDSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama3": [11.7888, 11.7790, 11.7610, 11.7699],
+            "llama3": [11.7898, 11.7790, 11.7788, 11.7699],
         }
         return loss_values_map[model_type]
 

--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -56,7 +56,7 @@ class TestKDSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama3": [11.7898, 11.7790, 11.7788, 11.7699],
+            "llama3": [11.7898, 11.7825, 11.7788, 11.7671],
         }
         return loss_values_map[model_type]
 

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -52,15 +52,15 @@ class TestLoRAFinetuneSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama2": [10.5208, 10.5037, 10.4863, 10.5986],
-            "llama3": [11.9838, 12.0316, 11.9621, 11.9589],
+            "llama2": [10.5209, 10.5269, 10.5130, 10.5242],
+            "llama3": [11.9838, 11.9691, 11.9616, 11.9383],
         }
         return loss_values_map[model_type]
 
     def _fetch_qlora_expected_loss_values(self, dtype):
         if dtype == "bf16":
-            return [10.5195, 10.5653, 10.5529, 10.4940]
-        return [10.5197, 10.5654, 10.5534, 10.4944]
+            return [10.5197, 10.5272, 10.5129, 10.5243]
+        return [10.5198, 10.5271, 10.5131, 10.5244]
 
     @pytest.mark.integration_test
     @pytest.mark.parametrize(

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -52,15 +52,15 @@ class TestLoRAFinetuneSingleDeviceRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama2": [10.5164, 10.5037, 10.4863, 10.5986],
-            "llama3": [11.9223, 12.0316, 11.9621, 11.9589],
+            "llama2": [10.5208, 10.5037, 10.4863, 10.5986],
+            "llama3": [11.9838, 12.0316, 11.9621, 11.9589],
         }
         return loss_values_map[model_type]
 
     def _fetch_qlora_expected_loss_values(self, dtype):
         if dtype == "bf16":
-            return [10.5308, 10.5653, 10.5529, 10.4940]
-        return [10.5306, 10.5654, 10.5534, 10.4944]
+            return [10.5195, 10.5653, 10.5529, 10.4940]
+        return [10.5197, 10.5654, 10.5534, 10.4944]
 
     @pytest.mark.integration_test
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Our current dataloader is epoch based. We do not need to load the state dict, as long as we call 'set_epoch', which sets the seed to the epoch number + original seed:
```
for curr_epoch in range(self.epochs_run, self.total_epochs):
            self._dataloader.sampler.set_epoch(curr_epoch)
```

The current implementation loads the state dict, then does a full pass on the dataloader, i.e. list(dataloader). For epoch based ckpt, this doesnt help, but make resuming extremely slow, since you have to go over all of it. 

For step based ckpt, we do NOT need list(dataloader). We just need to load the ckpt. 

NOTE: Loading ckpt state dict will need to be reintroduced when we change to step based ckpt.


#### Test plan

unit tests + running multimodal. Notice that grads are not the same, but what matters for this PR is that the batches are the same, and they are, given the loss shape.

```
tune run --nproc_per_node 2 lora_finetune_distributed --config llama3_2_vision/11B_lora epochs=2 max_steps_per_epoch=20 metric_logger=torchtune.training.metric_logging.WandBLogger resume_from_checkpoint=True checkpointer.adapter_checkpoint="epoch_0/adapter_model.pt"
```

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/2bd2958a-06ad-47c6-915e-e2aa5370681f" />


```
tune run full_finetune_single_device --config llama3_2/1B_full_single_device epochs=2 max_steps_per_epoch=20 optimizer=torch.optim.SGDresume_from_checkpoint=True checkpointer.checkpoint_files=["epoch_0/model-00001-of-00001.safetensors"] 
```
![image](https://github.com/user-attachments/assets/d6180d03-f07d-4ab4-a32b-d1aabbea24b0)
