### PR TITLE
Raise error with tensor parallel + fused optimizer

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -160,7 +160,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             )
         if self.tensor_parallel_dim > 1 and cfg.optimizer.get("fused", False):
             raise ValueError(
-                "2D parallelism is currently incompatible with fused optimizer."
+                "Tensor parallelism is currently incompatible with fused optimizer."
             )
 
         self.data_parallel_dim = self.world_size // self.tensor_parallel_dim

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -158,6 +158,11 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             raise ValueError(
                 f"world_size {self.world_size} must be divisible by tensor_parallel_dim {self.tensor_parallel_dim}"
             )
+        if self.tensor_parallel_dim > 1 and cfg.optimizer.get("fused", False):
+            raise ValueError(
+                "2D parallelism is currently incompatible with fused optimizer."
+            )
+
         self.data_parallel_dim = self.world_size // self.tensor_parallel_dim
 
         # Logging attributes


### PR DESCRIPTION
Our current tensor parallel implementation is incompatible with fused Adam. I think this is because we are not currently applying sequence parallel to our norm layers. However, enabling that requires a bit more work. Until then, let's just raise an error to make the behavior explicit.