### PR TITLE
Use rank info to save trace files

### DIFF
--- a/torchtune/training/_profiler.py
+++ b/torchtune/training/_profiler.py
@@ -103,7 +103,7 @@ def trace_handler(
 
     exporter = tensorboard_trace_handler(
         curr_trace_dir,
-        worker_name=f"r0-{now.year}-{now.month}-{now.day}-{now.hour}-{now.minute}",
+        worker_name=f"r{rank}-{now.year}-{now.month}-{now.day}-{now.hour}-{now.minute}",
         use_gzip=True,
     )
     exporter(prof)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Uses the rank to distinguish between trace files

```
# Run distributed recipes with profiler.enabled=True
# Before:
r0-2025-3-14-14-46.1741988781221064630.pt.trace.json.gz
r0-2025-3-14-14-46.1741988781256638216.pt.trace.json.gz
r0-2025-3-14-14-46.1741988781282550104.pt.trace.json.gz
r0-2025-3-14-14-46.1741988781301135140.pt.trace.json.gz
r0-2025-3-14-14-46.1741988781321276994.pt.trace.json.gz
r0-2025-3-14-14-46.1741988781353229963.pt.trace.json.gz
r0-2025-3-14-14-46.1741988781412318247.pt.trace.json.gz
r0-2025-3-14-14-46.1741988781423326877.pt.trace.json.gz
# After:
r0-2025-3-14-16-24.1741994642707396628.pt.trace.json.gz
r1-2025-3-14-16-24.1741994642718752063.pt.trace.json.gz
r2-2025-3-14-16-24.1741994642557805526.pt.trace.json.gz
r3-2025-3-14-16-24.1741994642600611536.pt.trace.json.gz
r4-2025-3-14-16-24.1741994642755974383.pt.trace.json.gz
r5-2025-3-14-16-24.1741994642644193262.pt.trace.json.gz
r6-2025-3-14-16-24.1741994642713199729.pt.trace.json.gz
r7-2025-3-14-16-24.1741994642642299820.pt.trace.json.gz
```

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [X] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [X] I did not change any public API
- [ ] I have added an example to docs or docstrings
