### PR TITLE
Linear Cross Entropy

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -66,7 +66,7 @@ you can also install the package locally with the following command.
     pip install -e .
 
     # or for a developer installation
-    pip install -e .["dev"]
+    pip install -e ".[dev]"
 
 |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "urllib3<2.0.0",
     "wandb",
     "expecttest",
+    "cut-cross-entropy @ git+https://github.com/apple/ml-cross-entropy.git",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Hi there 👋 

This PR adds support for Linear Cross Entropy loss (a.k.a. Cut Cross Entropy) proposed by Apple in [CUT YOUR LOSSES
IN LARGE-VOCABULARY LANGUAGE MODELS](https://arxiv.org/pdf/2411.09009) paper by adding support of the official [implementation](https://github.com/apple/ml-cross-entropy/tree/main).

So, from now on, we have:
- `CCE`: chunked cross entropy
- `LCE`: linear cross entropy

The benefit of LCE is that it reduces VRAM usage, especially for models with large vocab sizes.

This is done with 3 things:
1) **Custom Kernels**.
LCE uses custom CUDA kernels to perform matrix multiplications and the log-sum-exp reduction in shared memory. 
Usually you need to first calculate logits by multiplying embeddings (B, T, hidden_dim) with the output layer (hidden_dim, vocab_size) and then calculate loss with these logits and target labels.
LCE doesn't materialize this matrix with logits in the global memory (this matrix might be huge with modern LLMs that have large vocab size), but rather multiplies only a part (at a time) of output layer weights with logits in the shared (fast) memory and immediately calculates loss there (flash attention playbook).
This avoids materializing logits matrix (saves memory) and saves memory bandwidth (no need to move data from the global to shared memory and back multiple times).

2) **Gradient filtering**.
LCE leverages the sparsity of the softmax gradient to skip elements of the gradient computation that have a negligible contribution. This improves the throughput of LCE by reducing unnecessary computation.

3) **Vocabulary sorting**.
LCE uses vocabulary sorting to group tokens with similar average logits together. This increases the block-level sparsity and improves the effectiveness of gradient filtering.


-------

I ran a quick single device LoRA recipe with `gemma 2 2b` model.
This is the best possible case for LCE, since this model is relatively small, but has the same size of the vocab as larger models of gemma 2 family.

I ran 4 experiments:
- `CCE (non-compiled)`: chunked cross-entropy without compilation of model and loss
- `CCE`: chunked cross-entropy with compilation
- `LCE`: linear cross entropy with compilation
- `LCE (torch_compile impl)`: an implementation for older GPUs and MPS devices

> [!NOTE]
> To do this, one needs to change loss section of a config
> ```yaml
> loss:
>     _component_: cut_cross_entropy.LinearCrossEntropy
>     impl: torch_compile # (older than Ampere GPUs or MPS devices)
> ```


| Name                     | Peak Memory Reserved (GB) | Time  |
|--------------------------|---------------------------|-------|
| CCE (non-compiled)       | 21.6                      | 10:15 |
| CCE                      | 12.3                      | 09:18 |
| LCE                      | 7.73                      | 04:51 |
| LCE (torch_compile impl) | 9.1                       | 04:43 |

<img width="1396" alt="Screenshot 2025-03-17 at 6 55 01 PM" src="https://github.com/user-attachments/assets/8d2bfccd-e301-43ea-93bb-c8b09aba0e9c" />

As one can see, the loss chart is identical in all cases, yet LCE significantly reduced reserved memory size and reduced time for training.

-----------

#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
