### PR TITLE
Enable instantiation from globals

### DIFF
--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -33,6 +33,11 @@ _CONFIG = {
 }
 
 
+# Test local function
+def local_fn():
+    return "hello world"
+
+
 class TestUtils:
     def test_get_component_from_path(self):
         # Test valid paths with three components
@@ -48,10 +53,6 @@ class TestUtils:
         path = "torchtune.models.llama2.llama2_7b"
         result = _get_component_from_path(path)
         assert callable(result), f"Resolved '{path}' is not callable"
-
-        # Test local function
-        def local_fn():
-            return "hello world"
 
         globals_dict = {"local_fn": local_fn}
         fn = _get_component_from_path("local_fn", globals_dict)

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -84,7 +84,7 @@ class TestUtils:
         # Single-part path not found
         with pytest.raises(
             InstantiationError,
-            match=r"Could not resolve 'nonexistent': not a module and not found in globals\.",
+            match=r"Could not resolve 'nonexistent': not a module and not found in caller's globals\.",
         ):
             _get_component_from_path("nonexistent")
 

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -33,6 +33,10 @@ _CONFIG = {
 }
 
 
+def local_test_func():
+    return "hello world"
+
+
 class TestUtils:
     def test_get_component_from_path(self):
         good_paths = [
@@ -51,6 +55,11 @@ class TestUtils:
             InstantiationError, match="Error loading 'torchtune.models.dummy'"
         ):
             _ = _get_component_from_path("torchtune.models.dummy")
+
+        # test that a local function instantiates
+        my_fn = _get_component_from_path("local_test_func")
+        output = my_fn()
+        assert output == "hello world", f"output == {output}, not hello world"
 
     @mock.patch(
         "torchtune.config._parse.OmegaConf.load", return_value=OmegaConf.create(_CONFIG)

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -39,12 +39,15 @@ class TestUtils:
         valid_paths = [
             "torchtune",
             "os.path.join",
-            "torchtune.models.llama2.llama2_7b",
         ]
         for path in valid_paths:
             result = _get_component_from_path(path)
             assert result is not None, f"Failed to resolve valid path '{path}'"
-            assert callable(result), f"Resolved '{path}' is not callable"
+
+        # test callable
+        path = "torchtune.models.llama2.llama2_7b"
+        result = _get_component_from_path(path)
+        assert callable(result), f"Resolved '{path}' is not callable"
 
         # Test local function
         def local_fn():

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -54,13 +54,8 @@ class TestUtils:
         result = _get_component_from_path(path)
         assert callable(result), f"Resolved '{path}' is not callable"
 
-        globals_dict = {"local_fn": local_fn}
-        fn = _get_component_from_path("local_fn", globals_dict)
-        output = fn()
-        assert output == "hello world", f"Got {output=}. Expected 'hello world'."
-
-        # Test local function without globals
-        fn = _get_component_from_path("local_fn")
+        # simulate call from globals
+        fn = _get_component_from_path("local_fn", globals())
         output = fn()
         assert output == "hello world", f"Got {output=}. Expected 'hello world'."
 

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -84,7 +84,7 @@ class TestUtils:
         # Single-part path not found
         with pytest.raises(
             InstantiationError,
-            match=r"Could not resolve 'nonexistent': not a module and not found in caller's globals\.",
+            match=r"Could not resolve 'nonexistent': not a module and not found in the caller's globals\.",
         ):
             _get_component_from_path("nonexistent")
 

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -81,22 +81,25 @@ class TestUtils:
                 _get_component_from_path(path)
 
         # Test non-existent components
-        nonexistent_paths = [
-            "os.nonexistent.attr",
-            "os.path.nonexistent",
-        ]
-        for path in nonexistent_paths:
-            with pytest.raises(
-                InstantiationError, match=f"Module '{path}' has no attribute '.*'"
-            ):
-                _get_component_from_path(path)
-
-        # Test non-existent module
-        path = "nonexistent"
+        # Single-part path not found
         with pytest.raises(
-            InstantiationError, match=f"Module '{path}' has no attribute '.*'"
+            InstantiationError,
+            match=r"Could not resolve 'nonexistent': not a module and not found in globals\.",
         ):
-            _get_component_from_path(path)
+            _get_component_from_path("nonexistent")
+
+        # Multi-part path with import failure
+        with pytest.raises(
+            InstantiationError, match=r"Could not import module 'os\.nonexistent': .*"
+        ):
+            _get_component_from_path("os.nonexistent.attr")
+
+        # Multi-part path with attribute error
+        with pytest.raises(
+            InstantiationError,
+            match=r"Module 'os\.path' has no attribute 'nonexistent'",
+        ):
+            _get_component_from_path("os.path.nonexistent")
 
     @mock.patch(
         "torchtune.config._parse.OmegaConf.load", return_value=OmegaConf.create(_CONFIG)

--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -55,7 +55,7 @@ class TestUtils:
         assert callable(result), f"Resolved '{path}' is not callable"
 
         # simulate call from globals
-        fn = _get_component_from_path("local_fn", globals())
+        fn = _get_component_from_path("local_fn")
         output = fn()
         assert output == "hello world", f"Got {output=}. Expected 'hello world'."
 

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -89,10 +89,14 @@ def _get_component_from_path(
             if name in search_globals:
                 return search_globals[name]
             else:
+                scope = (
+                    "the provided globals"
+                    if caller_globals is not None
+                    else "the caller's globals"
+                )
                 raise InstantiationError(
-                    f"Could not resolve '{name}': not a module and not found in caller's globals."
+                    f"Could not resolve '{name}': not a module and not found in {scope}."
                 ) from None
-
     module_path = ".".join(parts[:-1])
     try:
         module = import_module(module_path)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Before this PR, you couldn't instantiate 'my_local_function', .e.g. in a script or a jupyter notebook. We only supported functions that were importable. Now you can do this

```
def my_local_function():
    return 0
config = {"foo": "_component_": "my_local_function"}
foo = instantiate(config)
```