### PR TITLE
Fix GRPO profiling

### DIFF
--- a/recipes/dev/grpo_full_finetune_distributed.py
+++ b/recipes/dev/grpo_full_finetune_distributed.py
@@ -990,7 +990,10 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
                     self._is_rank_zero
                     and curr_epoch == 0
                     and self.profiler_profile_memory
-                    and idx == self.profiler_wait_steps + self.profiler_warmup_steps + self.profiler_active_steps
+                    and idx
+                    == self.profiler_wait_steps
+                    + self.profiler_warmup_steps
+                    + self.profiler_active_steps
                     and self._device.type == "cuda"
                 ):
                     torch.cuda.memory._record_memory_history(enabled=None)

--- a/recipes/dev/grpo_full_finetune_distributed.py
+++ b/recipes/dev/grpo_full_finetune_distributed.py
@@ -1024,7 +1024,6 @@ class FullGRPOFinetuneRecipeDistributed(FTRecipeInterface):
             if self._epochs_run % self._save_every_n_epochs == 0:
                 self.save_checkpoint(curr_epoch)
             if training_completed:
-                self._profiler.stop()
                 return
 
         self._profiler.stop()


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Eliminated a memory leak in the GRPO recipe


So it turns out that the GRPO recipe had an annoying memory leak because I messed up the profiling. The profiler kept running and recording stats, in some cases eventually running out of CPU memory. This fixes it, properly halting the recording of CUDA memory history.

