### PR TITLE
Depend on pinned torchdata 0.11.0 for release 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 keywords = ["pytorch", "finetuning", "llm"]
 dependencies = [
     # Stable torchdata (no nightly support)
-    "torchdata",
+    "torchdata==0.11.0",
 
     # Hugging Face integrations
     "datasets",


### PR DESCRIPTION
Since we depend on torchdata now, specify version this release is compatible with