### PR TITLE
Enable TorchTune and Meta Checkpointers to use dcp behind a flag 

### DIFF
--- a/recipes/configs/llama3_1/8B_full.yaml
+++ b/recipes/configs/llama3_1/8B_full.yaml
@@ -18,13 +18,12 @@
 # best to use 8B_full_single_device.yaml for those cases
 
 
-
 output_dir: /tmp/torchtune/llama3_1_8B/full # /tmp may be deleted by your system. Change it to your preference.
 
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.llama3.llama3_tokenizer
-  path: /home/ankitageorge/.cache/huggingface/hub/models--meta-llama--Llama-3.1-8B-Instruct/blobs/82e9d31979e92ab929cd544440f129d9ecd797b69e327f80f17e1c50d5551b55
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
   max_seq_len: null
 
 # Dataset
@@ -37,15 +36,19 @@ shuffle: True
 # Model Arguments
 model:
   _component_: torchtune.models.llama3_1.llama3_1_8b
-# temp changes for testing locally
+
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
-  checkpoint_dir: hf://meta-llama/Llama-3.1-8B-Instruct/
-  checkpoint_files: []
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  checkpoint_files: [
+    model-00001-of-00004.safetensors,
+    model-00002-of-00004.safetensors,
+    model-00003-of-00004.safetensors,
+    model-00004-of-00004.safetensors
+  ]
   recipe_checkpoint: null
-  output_dir: hf://ankitageorge/Llama-testing/
+  output_dir: ${output_dir}
   model_type: LLAMA3
-  enable_dcp: True
 resume_from_checkpoint: False
 
 # Fine-tuning arguments

--- a/recipes/configs/llama3_1/8B_full.yaml
+++ b/recipes/configs/llama3_1/8B_full.yaml
@@ -18,12 +18,13 @@
 # best to use 8B_full_single_device.yaml for those cases
 
 
+
 output_dir: /tmp/torchtune/llama3_1_8B/full # /tmp may be deleted by your system. Change it to your preference.
 
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.llama3.llama3_tokenizer
-  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  path: /home/ankitageorge/.cache/huggingface/hub/models--meta-llama--Llama-3.1-8B-Instruct/blobs/82e9d31979e92ab929cd544440f129d9ecd797b69e327f80f17e1c50d5551b55
   max_seq_len: null
 
 # Dataset
@@ -36,19 +37,15 @@ shuffle: True
 # Model Arguments
 model:
   _component_: torchtune.models.llama3_1.llama3_1_8b
-
+# temp changes for testing locally
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
-  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
-  checkpoint_files: [
-    model-00001-of-00004.safetensors,
-    model-00002-of-00004.safetensors,
-    model-00003-of-00004.safetensors,
-    model-00004-of-00004.safetensors
-  ]
+  checkpoint_dir: hf://meta-llama/Llama-3.1-8B-Instruct/
+  checkpoint_files: []
   recipe_checkpoint: null
-  output_dir: ${output_dir}
+  output_dir: hf://ankitageorge/Llama-testing/
   model_type: LLAMA3
+  enable_dcp: True
 resume_from_checkpoint: False
 
 # Fine-tuning arguments

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -111,11 +111,9 @@ class _CheckpointerInterface(Protocol):
 
     """
 
-    def load_checkpoint(self, **kwargs) -> Dict[str, Any]:
-        ...
+    def load_checkpoint(self, **kwargs) -> Dict[str, Any]: ...
 
-    def save_checkpoint(self, state_dict: Dict[str, Any], **kwargs) -> None:
-        ...
+    def save_checkpoint(self, state_dict: Dict[str, Any], **kwargs) -> None: ...
 
 
 class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
@@ -143,6 +141,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
             should_load_recipe_state flag instead.
         should_load_recipe_state (bool): If True, the checkpointer will load the additional checkpoint files corresponding to
             the recipe state from a previous run. Default is False
+        enable_dcp (bool): If True, use DCP to load the checkpoint. Default is False.
 
 
     Raises:
@@ -924,14 +923,14 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     "Saving Llama3.2 Vision adapter weights to PEFT format is not supported, saving to torchtune format instead"
                 )
             else:
-                state_dict[
-                    training.ADAPTER_KEY
-                ] = convert_weights.tune_to_peft_adapter_weights(
-                    state_dict[training.ADAPTER_KEY],
-                    num_heads=self._config["num_attention_heads"],
-                    num_kv_heads=self._config["num_key_value_heads"],
-                    dim=self._config["hidden_size"],
-                    head_dim=self._config.get("head_dim", None),
+                state_dict[training.ADAPTER_KEY] = (
+                    convert_weights.tune_to_peft_adapter_weights(
+                        state_dict[training.ADAPTER_KEY],
+                        num_heads=self._config["num_attention_heads"],
+                        num_kv_heads=self._config["num_key_value_heads"],
+                        dim=self._config["hidden_size"],
+                        head_dim=self._config.get("head_dim", None),
+                    )
                 )
                 output_path = os.path.join(
                     self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME
@@ -969,11 +968,11 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     "PEFT integration for Llama3.2 Vision is not supported, skipping adapter config save"
                 )
             else:
-                state_dict[
-                    training.ADAPTER_CONFIG
-                ] = convert_weights.tune_to_peft_adapter_config(
-                    adapter_config=state_dict[training.ADAPTER_CONFIG],
-                    base_model_name_or_path=self.repo_id,
+                state_dict[training.ADAPTER_CONFIG] = (
+                    convert_weights.tune_to_peft_adapter_config(
+                        adapter_config=state_dict[training.ADAPTER_CONFIG],
+                        base_model_name_or_path=self.repo_id,
+                    )
                 )
 
                 output_path = (

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -144,6 +144,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         should_load_recipe_state (bool): If True, the checkpointer will load the additional checkpoint files corresponding to
             the recipe state from a previous run. Default is False
 
+
     Raises:
         ValueError: If more than one checkpoint file is provided
     """
@@ -167,7 +168,8 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
             len(checkpoint_files) == 0 and not enable_dcp
         ):
             raise ValueError(
-                "Currently we only support reading from a single checkpoint file. "
+                "Currently we only support reading from a single checkpoint file, "
+                "or none if DCP is enabled."
                 f"Got {len(checkpoint_files)} files instead."
             )
 
@@ -1053,6 +1055,7 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
                 should_load_recipe_state instead.
         should_load_recipe_state (bool): If True, the checkpointer will load the additional checkpoint files corresponding to
                 the recipe state from a previous run. Default is False
+        enable_dcp (bool): If True, use DCP to load/save the checkpoint. Default is False.
 
     Raises:
         ValueError: If ``checkpoint_files`` is not a list of length 1
@@ -1077,7 +1080,8 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
             len(checkpoint_files) == 0 and not enable_dcp
         ):
             raise ValueError(
-                "Currently we only support reading from a single checkpoint file. "
+                "Currently we only support reading from a single checkpoint file, "
+                "or none if DCP is enabled."
                 f"Got {len(checkpoint_files)} files instead."
             )
 

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -43,6 +43,7 @@ RECIPE_STATE_DIRNAME = "recipe_state"
 # Needed when setting up output dir in checkpointing
 REPO_ID_FNAME = "original_repo_id"
 SUFFIXES_TO_NOT_COPY = [
+    ".distcp",
     ".pt",
     ".pth",
     ".bin",


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Enable TorchTune and Meta checkpointers to take advantage of dcp saving and loading of checkpoints if enable_dcp is enabled

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x ] run unit tests via `pytest tests`
- [ x] run recipe tests via `pytest tests -m integration_test`
- [ x] manually run any new or modified recipes with sufficient proof of correctness
- [ x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x ] I have added an example to docs or docstrings
