### PR TITLE
RFC: Update-based training loop refactor, scale loss and token count calculation rather than gradients

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -791,13 +791,13 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     except StopIteration:
                         break
 
-                    utils.batch_to_device(batch, self._device)
-
                     # Calculate the number of unmasked tokens in the current batch
                     # and increment the total number of tokens seen in the step
                     current_num_tokens = (
-                        batch["labels"] != self._loss_fn.ignore_index
-                    ).sum()
+                        (batch["labels"] != self._loss_fn.ignore_index)
+                        .sum()
+                        .to(self._device)
+                    )
                     num_tokens += current_num_tokens
                     batches.append((batch, current_num_tokens.item()))
 
@@ -812,6 +812,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 num_tokens = num_tokens / self.parallel_dims.non_data_parallel_size
 
                 for batch, token_count in batches:
+                    utils.batch_to_device(batch, self._device)
                     # Shape [b, s], needed for the loss not the model
                     labels = batch.pop("labels")
 

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -8,6 +8,7 @@
 import logging
 import os
 from dataclasses import dataclass
+from functools import cached_property
 from itertools import chain
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 
@@ -121,6 +122,11 @@ class ParallelDims:
     @property
     def tp_enabled(self):
         return self.tp > 1
+
+    @cached_property
+    def non_data_parallel_size(self):
+        # update this as new parallelism strategies are added
+        return self.tp
 
 
 def _get_sharding_strategy(strategy: str) -> ShardingStrategy:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (enhancement)

https://github.com/pytorch/torchtune/issues/2515

#### Changelog
This motivation behind this PR was to remove gradient scaling. `num_tokens` is corrected to calculate the actual number of tokens in unique training examples for the update step, and `loss` is scaled accordingly (and adjusted for over-counting from non-dp workers). This required a larger refactor of the training loop to count up to `update_steps` rather than iterating through the dataloader, then grouping the prefetch of gradient accumulation batches.

**Upsides**

* Less nesting
* More logical grouping of gradient accumulation / forward/backward steps before update
* Variables now hold the correct value (e.g. `num_tokens` now contains the actual number of tokens across the update step, on each rank)
* Implicitly corrects calculation of TPS per GPU
* Use of new context setters for methods like HSDP (e.g. `is_last_backwards_step`) can be localised to the forward/backward loop which should be quite clean
* Pattern can relatively painlessly be reverted
* Added a `num_tokens` metric - nice metric for gauging how effective packing a given dataset is

**Downsides**

* Currently does not account for future use of loss parallel, context parallel, etc.
* Profiler wait/warmup steps are now relative to _update_ steps rather than _forward_ steps. This may actually be desirable (I assumed this was the case until this refactor, and makes use of the term `steps` more consistent)
* Prefetching examples technically uses slightly more memory (pedantic note, but still)
* Likely to cause merge conflicts with in-flight work which includes changes to the training loop for this recipe

I recognise that this is beyond the scope of the initial motivation, but I think this format may be preferable in terms of readability and flexibility.

Losses are near identical (seeded with cudnn determinism mode enabled). There is very minor TPS benefit to avoiding the grad scaling. This is more substantial without gradient accumulation since the parameter read/write occurs more frequently. It may be more notable with much larger models.

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/cb71b63d-04fd-4ae3-87ca-beb18ac97752" />

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
