### PR TITLE
Use DCP in HFCheckpointer to read/write directly to HuggingFace

### DIFF
--- a/tests/torchtune/training/checkpointing/test_checkpointer.py
+++ b/tests/torchtune/training/checkpointing/test_checkpointer.py
@@ -11,6 +11,7 @@ from typing import Tuple
 
 import pytest
 
+import safetensors
 import torch
 from torch import randn
 
@@ -160,6 +161,12 @@ class TestHFLlama2FullModelCheckpointer:
 
         torch.save(state_dict_1, checkpoint_file_1)
         torch.save(state_dict_2, checkpoint_file_2)
+        safetensors.torch.save_file(
+            state_dict_1, checkpoint_dir / "model-00001-of-00002.safetensors"
+        )
+        safetensors.torch.save_file(
+            state_dict_2, checkpoint_dir / "model-00002-of-00002.safetensors"
+        )
 
         config = {
             "hidden_size": 64,
@@ -169,6 +176,14 @@ class TestHFLlama2FullModelCheckpointer:
         config_file = Path.joinpath(checkpoint_dir, "config.json")
         with config_file.open("w") as f:
             json.dump(config, f)
+        metadata_file = Path.joinpath(checkpoint_dir, "model.safetensors.index.json")
+        metadata = {"weight_map": {}}
+        for key in state_dict_1.keys():
+            metadata["weight_map"][key] = "model-00001-of-00002.safetensors"
+        for key in state_dict_2.keys():
+            metadata["weight_map"][key] = "model-00002-of-00002.safetensors"
+        with metadata_file.open("w") as f:
+            json.dump(metadata, f)
 
         return (checkpoint_file_1, checkpoint_file_2)
 
@@ -503,6 +518,77 @@ class TestHFLlama2FullModelCheckpointer:
                 torch.testing.assert_close(
                     actual_adapter_state_dict[k], expected_adapter_state_dict[new_k]
                 )
+
+    def test_save_load_checkpoint_multiple_file_with_dcp(
+        self,
+        multi_file_checkpointer: FullModelHFCheckpointer,
+        llama2_hf_checkpoints: Tuple[Path, Path],
+    ):
+        """
+        Test ``load_checkpoint`` method within the FullModelCheckpointer for multiple
+        checkpoint files with DCP enabled.
+
+        We test:
+        * ``load_checkpoint`` loads the right sets of keys
+        * Internal state of the checkpointer is correctly updated
+        * Converted checkpoint can be loaded into the llama2 torchtune implementation
+        """
+        multi_file_checkpointer._enable_dcp = True
+        # Read the state dict directly from files
+        checkpoint_file_1, checkpoint_file_2 = llama2_hf_checkpoints
+        orig_state_dict_1 = safe_torch_load(checkpoint_file_1)
+        orig_state_dict_2 = safe_torch_load(checkpoint_file_2)
+
+        # merged state dict from checkpointer
+        state_dict = multi_file_checkpointer.load_checkpoint()
+
+        # We ignore inv_freq as is standard practice
+        assert len(state_dict["model"].keys()) + 2 == len(
+            orig_state_dict_1.keys()
+        ) + len(orig_state_dict_2.keys())
+
+        # the keys in the weight_map should match up with the keys in the weight_map
+        for key in orig_state_dict_1.keys():
+            if "inv_freq" in key:
+                continue
+            assert key in multi_file_checkpointer._weight_map
+
+        for key in orig_state_dict_2.keys():
+            if "inv_freq" in key:
+                continue
+            assert key in multi_file_checkpointer._weight_map
+
+        # finally loading into the model should work
+        model = llama2.llama2(
+            vocab_size=_VOCAB_SIZE,
+            num_layers=2,
+            num_heads=_NUM_HEADS,
+            num_kv_heads=_NUM_KV_HEADS,
+            embed_dim=_DIM,
+            max_seq_len=128,
+        )
+        model.load_state_dict(state_dict["model"])
+
+        multi_file_checkpointer.save_checkpoint(state_dict, epoch=3)
+
+        # Reload the output checkpoint file and compare to the original checkpoint. This
+        # assumes we know what the name of the file is. This is fine, breaking this logic
+        # should be something we capture through this test
+        output_file_1 = Path.joinpath(
+            checkpoint_file_1.parent.parent / "output_dir",
+            "epoch_3",
+            SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="2".zfill(5)),
+        ).with_suffix(".safetensors")
+        output_file_2 = Path.joinpath(
+            checkpoint_file_2.parent.parent / "output_dir",
+            "epoch_3",
+            SHARD_FNAME.format(cpt_idx="2".zfill(5), num_shards="2".zfill(5)),
+        ).with_suffix(".safetensors")
+        output_state_dict_1 = safe_torch_load(output_file_1)
+        output_state_dict_2 = safe_torch_load(output_file_2)
+
+        assert len(output_state_dict_1.keys()) + 1 == len(orig_state_dict_1.keys())
+        assert len(output_state_dict_2.keys()) + 1 == len(orig_state_dict_2.keys())
 
 
 class TestHFMistralRewardModelFullModelCheckpointer:

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -110,9 +110,11 @@ class _CheckpointerInterface(Protocol):
 
     """
 
-    def load_checkpoint(self, **kwargs) -> Dict[str, Any]: ...
+    def load_checkpoint(self, **kwargs) -> Dict[str, Any]:
+        ...
 
-    def save_checkpoint(self, state_dict: Dict[str, Any], **kwargs) -> None: ...
+    def save_checkpoint(self, state_dict: Dict[str, Any], **kwargs) -> None:
+        ...
 
 
 class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
@@ -893,14 +895,14 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     "Saving Llama3.2 Vision adapter weights to PEFT format is not supported, saving to torchtune format instead"
                 )
             else:
-                state_dict[training.ADAPTER_KEY] = (
-                    convert_weights.tune_to_peft_adapter_weights(
-                        state_dict[training.ADAPTER_KEY],
-                        num_heads=self._config["num_attention_heads"],
-                        num_kv_heads=self._config["num_key_value_heads"],
-                        dim=self._config["hidden_size"],
-                        head_dim=self._config.get("head_dim", None),
-                    )
+                state_dict[
+                    training.ADAPTER_KEY
+                ] = convert_weights.tune_to_peft_adapter_weights(
+                    state_dict[training.ADAPTER_KEY],
+                    num_heads=self._config["num_attention_heads"],
+                    num_kv_heads=self._config["num_key_value_heads"],
+                    dim=self._config["hidden_size"],
+                    head_dim=self._config.get("head_dim", None),
                 )
                 output_path = os.path.join(
                     self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME
@@ -938,11 +940,11 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     "PEFT integration for Llama3.2 Vision is not supported, skipping adapter config save"
                 )
             else:
-                state_dict[training.ADAPTER_CONFIG] = (
-                    convert_weights.tune_to_peft_adapter_config(
-                        adapter_config=state_dict[training.ADAPTER_CONFIG],
-                        base_model_name_or_path=self.repo_id,
-                    )
+                state_dict[
+                    training.ADAPTER_CONFIG
+                ] = convert_weights.tune_to_peft_adapter_config(
+                    adapter_config=state_dict[training.ADAPTER_CONFIG],
+                    base_model_name_or_path=self.repo_id,
                 )
 
                 output_path = (
@@ -977,7 +979,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 self._output_dir, RECIPE_STATE_DIRNAME, "recipe_state.pt"
             )
             parent_path = os.path.dirname(output_path)
-            self._fs.mkdir(parent_path, exist_ok=True)
+            self._fs.mkdirs(parent_path, exist_ok=True)
             torch.save(state_dict, output_path)
             logger.info(
                 "Recipe checkpoint of size "

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -401,6 +401,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         should_load_recipe_state (bool): If True, the checkpointer will load the additional checkpoint files corresponding to
             the receipe state from a previous run. Default is False
         enable_dcp (bool): If True, the checkpointer will load the checkpoint file using dcp checkpointing apis.
+            This is currently an experimental feature.
 
     Raises:
         ValueError: If ther checkpoint_dir and output_dir are not on the same filesystem

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -15,7 +15,8 @@ from typing import Any, Dict, List, Optional, Protocol, Union
 
 import torch
 import torch.distributed as dist
-from safetensors.torch import save_file
+from fsspec.core import url_to_fs
+from safetensors.torch import save as save_safetensors, save_file
 from torch.distributed.checkpoint import (
     async_save,
     FileSystemReader,
@@ -109,11 +110,9 @@ class _CheckpointerInterface(Protocol):
 
     """
 
-    def load_checkpoint(self, **kwargs) -> Dict[str, Any]:
-        ...
+    def load_checkpoint(self, **kwargs) -> Dict[str, Any]: ...
 
-    def save_checkpoint(self, state_dict: Dict[str, Any], **kwargs) -> None:
-        ...
+    def save_checkpoint(self, state_dict: Dict[str, Any], **kwargs) -> None: ...
 
 
 class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
@@ -399,6 +398,10 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             Default is True.
         should_load_recipe_state (bool): If True, the checkpointer will load the additional checkpoint files corresponding to
             the receipe state from a previous run. Default is False
+        enable_dcp (bool): If True, the checkpointer will load the checkpoint file using dcp checkpointing apis.
+
+    Raises:
+        ValueError: If ther checkpoint_dir and output_dir are not on the same filesystem
     """
 
     def __init__(
@@ -412,8 +415,8 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         resume_from_checkpoint: bool = False,
         safe_serialization: bool = True,
         should_load_recipe_state: bool = False,
+        enable_dcp: bool = False,
     ) -> None:
-
         self._should_load_recipe_state = should_load_recipe_state
         if resume_from_checkpoint:
             self._should_load_recipe_state = resume_from_checkpoint
@@ -422,13 +425,23 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             )
 
         self._safe_serialization = safe_serialization
-        self._checkpoint_dir = Path(checkpoint_dir)
+        self._checkpoint_dir = checkpoint_dir
         self._model_type = ModelType[model_type]
-        self._output_dir = Path(output_dir)
+        self._output_dir = output_dir
         check_outdir_not_in_ckptdir(
             ckpt_dir=self._checkpoint_dir, out_dir=self._output_dir
         )
-        self._output_dir.mkdir(parents=True, exist_ok=True)
+        self._enable_dcp = enable_dcp
+
+        self._fs, _ = url_to_fs(self._checkpoint_dir)
+        output_fs, _ = url_to_fs(self._output_dir)
+        if self._fs != output_fs:
+            raise ValueError(
+                f"Checkpoint and output directories must be on the same filesystem. "
+                f"Got {self._fs} and {output_fs} instead."
+            )
+
+        self._fs.mkdirs(output_dir, exist_ok=True)
 
         # weight_map contains the state_dict key -> checkpoint file mapping so we can correctly
         # parition the state dict into output checkpoint files. This is updated during checkpoint
@@ -436,19 +449,20 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         self._weight_map: Dict[str, str] = None
 
         # the config.json file contains model params needed for state dict conversion
-        self._config = json.loads(
-            Path.joinpath(self._checkpoint_dir, "config.json").read_text()
-        )
+        self._config = None
+        with self._fs.open(
+            os.path.join(self._checkpoint_dir, "config.json"), "r"
+        ) as json_file:
+            self._config = json.loads(json_file.read())
 
         # repo_id is necessary for when saving an adapter config, so its compatible with HF.
         # This json file is produced and saved in the download step.
         # contents are {"repo_id": "some_model/some_model_version"}
-        repo_id_path = Path.joinpath(self._checkpoint_dir, REPO_ID_FNAME).with_suffix(
-            ".json"
-        )
+        repo_id_path = os.path.join(self._checkpoint_dir, REPO_ID_FNAME) + ".json"
+
         self.repo_id = None
-        if repo_id_path.exists():
-            with open(repo_id_path, "r") as json_file:
+        if self._fs.exists(repo_id_path):
+            with self._fs.open(repo_id_path, "r") as json_file:
                 data = json.load(json_file)
                 self.repo_id = data.get("repo_id")
 
@@ -512,24 +526,49 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         # the recipe state and adapter weights
         converted_state_dict: Dict[str, Dict[str, torch.Tensor]] = {}
 
-        # _checkpoint_paths are already sorted so simply enumerate to generate the right id
-        for cpt_idx, cpt_path in enumerate(self._checkpoint_paths):
-            state_dict = safe_torch_load(cpt_path)
-            for key, value in state_dict.items():
-                # Ensure that the state dict is a flat dict of keys and tensors. Breaking this assumption
-                # will break recipe code
-                if not isinstance(value, torch.Tensor):
-                    raise ValueError(
-                        f"Expected all values in the state dict to be torch.Tensor. "
-                        f"Found {type(value)} instead."
-                    )
-                # idx is written in the 4 digit format (eg: 0001, 0002, etc.)
-                self._weight_map[key] = f"{cpt_idx + 1:04}"
-            merged_state_dict.update(state_dict)
+        if self._enable_dcp:
+            from torch.distributed.checkpoint import (
+                _HuggingFaceLoadPlanner,
+                _HuggingFaceStorageReader,
+            )
 
-            # delete the state_dict to free up memory; TODO check if this del is needed
-            del state_dict
-            gc.collect()
+            # DCP load using the storage reader
+            hf_storage_reader = _HuggingFaceStorageReader(path=self._checkpoint_dir)
+            metadata = hf_storage_reader.read_metadata()
+            state_dict = {}
+            for key in metadata.state_dict_metadata.keys():
+                # arbitrary value to ensure that the state_dict is not empty
+                state_dict[key] = torch.empty(1)
+
+            self._weight_map = metadata.storage_data
+
+            load(
+                state_dict=state_dict,
+                storage_reader=hf_storage_reader,
+                planner=_HuggingFaceLoadPlanner(),
+            )
+
+            merged_state_dict = state_dict
+        else:
+            # _checkpoint_paths are already sorted so simply enumerate to generate the right id
+            for cpt_idx, cpt_path in enumerate(self._checkpoint_paths):
+                state_dict = safe_torch_load(cpt_path)
+                for key, value in state_dict.items():
+                    # Ensure that the state dict is a flat dict of keys and tensors. Breaking this assumption
+                    # will break recipe code
+                    if not isinstance(value, torch.Tensor):
+                        raise ValueError(
+                            f"Expected all values in the state dict to be torch.Tensor. "
+                            f"Found {type(value)} instead."
+                        )
+                    # idx is written in the 4 digit format (eg: 0001, 0002, etc.)
+                    self._weight_map[key] = f"{cpt_idx + 1:04}"
+                merged_state_dict.update(state_dict)
+
+                # delete the state_dict to free up memory; TODO check if this del is needed
+                del state_dict
+                gc.collect()
+
         if self._model_type in (ModelType.PHI3_MINI, ModelType.PHI4):
             log_rank_zero(
                 logger=logger,
@@ -729,76 +768,102 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     head_dim=self._config.get("head_dim", None),
                 )
 
-            # split the state_dict into separate dicts, one for each output checkpoint file
-            # e.g. split_state_dicts= {
-            #       "0001": {"key1": tensor1, "key2": tensor2},
-            #       "0002": {"key3": tensor3}
-            #       }
-            split_state_dicts: Dict[str, Dict[str, torch.Tensor]] = {}
-            total_size = 0
-            for key, weight in state_dict[training.MODEL_KEY].items():
-                cpt_idx = self._weight_map[key]
-
-                # initialize dict
-                if cpt_idx not in split_state_dicts:
-                    split_state_dicts[cpt_idx] = {}
-
-                split_state_dicts[cpt_idx].update({key: weight})
-                total_size += weight.numel() * weight.element_size()
-
-            # write the partitioned state dicts to the right checkpoint file
-            # e.g. model-00001-of-00004.safetensors, model-00002-of-00004.safetensors, etc
-            num_shards = len(split_state_dicts)
-            map_original_name_to_new_name = {}
-            for cpt_idx, model_state_dict in split_state_dicts.items():
-                # TODO: We should probably use the original shard name and just add a prefix
-                # however, having the SHARD_FNAME standardizes our checkpoints
-                shard_name = SHARD_FNAME.format(
-                    cpt_idx=f"{cpt_idx}".zfill(5), num_shards=f"{num_shards}".zfill(5)
-                )
-                map_original_name_to_new_name[cpt_idx] = shard_name
-                output_path = Path.joinpath(
-                    self._output_dir, f"epoch_{epoch}", shard_name
-                )
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                if not self._safe_serialization:
-                    output_path = output_path.with_suffix(".bin")
-                    torch.save(model_state_dict, output_path)
-                else:
-                    output_path = output_path.with_suffix(".safetensors")
-                    save_file(model_state_dict, output_path, metadata={"format": "pt"})
-
-                logger.info(
-                    "Model checkpoint of size "
-                    f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
-                    f"saved to {output_path}"
+            if self._enable_dcp:
+                from torch.distributed.checkpoint import (
+                    _HuggingFaceSavePlanner,
+                    _HuggingFaceStorageWriter,
                 )
 
-            # Save the appropriate index file based on serialization format
-            # e.g. {metadata: {total_size: 1234}, weight_map: {"key1": "model_0001.safetensors", "key2": "model_0002.safetensors"}}
-            if self._safe_serialization:
-                weight_map = {
-                    k: map_original_name_to_new_name[cpt_idx] + ".safetensors"
-                    for k, cpt_idx in self._weight_map.items()
-                }
-                index_file_name = SAFETENSOR_INDEX_FNAME
+                # DCP save using the storage writer
+                fqn_to_file_index_mapping = {}
+                for fqn, filename in self._weight_map.items():
+                    index = int(filename.split("-")[1])
+                    fqn_to_file_index_mapping[fqn] = index
+                storage_writer = _HuggingFaceStorageWriter(
+                    path=os.path.join(self._output_dir, f"epoch_{epoch}"),
+                    fqn_to_index_mapping=fqn_to_file_index_mapping,
+                )
+                save(
+                    state_dict=state_dict[training.MODEL_KEY],
+                    storage_writer=storage_writer,
+                    planner=_HuggingFaceSavePlanner(),
+                    no_dist=True,
+                )
             else:
-                weight_map = {
-                    k: map_original_name_to_new_name[cpt_idx] + ".bin"
-                    for k, cpt_idx in self._weight_map.items()
+                # split the state_dict into separate dicts, one for each output checkpoint file
+                # e.g. split_state_dicts= {
+                #       "0001": {"key1": tensor1, "key2": tensor2},
+                #       "0002": {"key3": tensor3}
+                #       }
+                split_state_dicts: Dict[str, Dict[str, torch.Tensor]] = {}
+                total_size = 0
+                for key, weight in state_dict[training.MODEL_KEY].items():
+                    cpt_idx = self._weight_map[key]
+
+                    # initialize dict
+                    if cpt_idx not in split_state_dicts:
+                        split_state_dicts[cpt_idx] = {}
+
+                    split_state_dicts[cpt_idx].update({key: weight})
+                    total_size += weight.numel() * weight.element_size()
+
+                # write the partitioned state dicts to the right checkpoint file
+                # e.g. model-00001-of-00004.safetensors, model-00002-of-00004.safetensors, etc
+                num_shards = len(split_state_dicts)
+                map_original_name_to_new_name = {}
+                for cpt_idx, model_state_dict in split_state_dicts.items():
+                    # TODO: We should probably use the original shard name and just add a prefix
+                    # however, having the SHARD_FNAME standardizes our checkpoints
+                    shard_name = SHARD_FNAME.format(
+                        cpt_idx=f"{cpt_idx}".zfill(5),
+                        num_shards=f"{num_shards}".zfill(5),
+                    )
+                    map_original_name_to_new_name[cpt_idx] = shard_name
+                    output_path = os.path.join(
+                        self._output_dir, f"epoch_{epoch}", shard_name
+                    )
+                    self._fs.mkdirs(os.path.dirname(output_path), exist_ok=True)
+                    if not self._safe_serialization:
+                        output_path = output_path = ".bin"
+                        torch.save(model_state_dict, output_path)
+                    else:
+                        output_path = output_path + ".safetensors"
+                        save_file(
+                            model_state_dict, output_path, metadata={"format": "pt"}
+                        )
+
+                    logger.info(
+                        "Model checkpoint of size "
+                        f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
+                        f"saved to {output_path}"
+                    )
+
+                # Save the appropriate index file based on serialization format
+                # e.g. {metadata: {total_size: 1234},
+                # weight_map: {"key1": "model_0001.safetensors", "key2": "model_0002.safetensors"}}
+                if self._safe_serialization:
+                    weight_map = {
+                        k: map_original_name_to_new_name[cpt_idx] + ".safetensors"
+                        for k, cpt_idx in self._weight_map.items()
+                    }
+                    index_file_name = SAFETENSOR_INDEX_FNAME
+                else:
+                    weight_map = {
+                        k: map_original_name_to_new_name[cpt_idx] + ".bin"
+                        for k, cpt_idx in self._weight_map.items()
+                    }
+                    index_file_name = TORCH_INDEX_FNAME
+
+                index_path = os.path.join(
+                    self._output_dir, f"epoch_{epoch}", index_file_name
+                )
+
+                index_data = {
+                    "metadata": {"total_size": total_size},
+                    "weight_map": weight_map,
                 }
-                index_file_name = TORCH_INDEX_FNAME
-
-            index_path = Path.joinpath(
-                self._output_dir, f"epoch_{epoch}", index_file_name
-            )
-
-            index_data = {
-                "metadata": {"total_size": total_size},
-                "weight_map": weight_map,
-            }
-            with open(index_path, "w") as f:
-                json.dump(index_data, f, indent=2)
+                with self._fs.open(index_path, "w") as f:
+                    json.dump(index_data, f, indent=2)
 
         if training.ADAPTER_KEY in state_dict:
 
@@ -806,11 +871,13 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             # convert_weights.tune_to_peft_adapter_weights, we do NOT have a fn
             # convert_weights.peft_to_tune. The .pt format is not needed, but
             # it is an easy way to distinguish the adapters. Ideally we should save only one.
-            output_path = Path.joinpath(
-                self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME
-            ).with_suffix(".pt")
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            torch.save(state_dict[training.ADAPTER_KEY], output_path)
+            output_path = (
+                os.path.join(self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME)
+                + ".pt"
+            )
+            self._fs.mkdirs(os.path.dirname(output_path), exist_ok=True)
+            with self._fs.open(output_path, "wb") as f:
+                torch.save(state_dict[training.ADAPTER_KEY], f)
             logger.info(
                 "Adapter checkpoint of size "
                 f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
@@ -826,29 +893,31 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     "Saving Llama3.2 Vision adapter weights to PEFT format is not supported, saving to torchtune format instead"
                 )
             else:
-                state_dict[
-                    training.ADAPTER_KEY
-                ] = convert_weights.tune_to_peft_adapter_weights(
-                    state_dict[training.ADAPTER_KEY],
-                    num_heads=self._config["num_attention_heads"],
-                    num_kv_heads=self._config["num_key_value_heads"],
-                    dim=self._config["hidden_size"],
-                    head_dim=self._config.get("head_dim", None),
+                state_dict[training.ADAPTER_KEY] = (
+                    convert_weights.tune_to_peft_adapter_weights(
+                        state_dict[training.ADAPTER_KEY],
+                        num_heads=self._config["num_attention_heads"],
+                        num_kv_heads=self._config["num_key_value_heads"],
+                        dim=self._config["hidden_size"],
+                        head_dim=self._config.get("head_dim", None),
+                    )
                 )
-                output_path = Path.joinpath(
+                output_path = os.path.join(
                     self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME
                 )
-                output_path.parent.mkdir(parents=True, exist_ok=True)
+                self._fs.mkdirs(os.path.dirname(output_path), exist_ok=True)
                 if not self._safe_serialization:
-                    output_path = output_path.with_suffix(".bin")
-                    torch.save(state_dict[training.ADAPTER_KEY], output_path)
+                    output_path = output_path + ".bin"
+                    with self._fs.open(output_path, "wb") as f:
+                        torch.save(state_dict[training.ADAPTER_KEY], f)
                 else:
-                    output_path = output_path.with_suffix(".safetensors")
-                    save_file(
-                        state_dict[training.ADAPTER_KEY],
-                        output_path,
-                        metadata={"format": "pt"},
-                    )
+                    output_path = output_path + ".safetensors"
+                    with self._fs.open(output_path, "wb") as f:
+                        save_bytes = save_safetensors(
+                            state_dict[training.ADAPTER_KEY],
+                            metadata={"format": "pt"},
+                        )
+                        f.write(save_bytes)
                 logger.info(
                     "Adapter checkpoint of size "
                     f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
@@ -869,17 +938,20 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     "PEFT integration for Llama3.2 Vision is not supported, skipping adapter config save"
                 )
             else:
-                state_dict[
-                    training.ADAPTER_CONFIG
-                ] = convert_weights.tune_to_peft_adapter_config(
-                    adapter_config=state_dict[training.ADAPTER_CONFIG],
-                    base_model_name_or_path=self.repo_id,
+                state_dict[training.ADAPTER_CONFIG] = (
+                    convert_weights.tune_to_peft_adapter_config(
+                        adapter_config=state_dict[training.ADAPTER_CONFIG],
+                        base_model_name_or_path=self.repo_id,
+                    )
                 )
 
-                output_path = Path.joinpath(
-                    self._output_dir, f"epoch_{epoch}", ADAPTER_CONFIG_FNAME
-                ).with_suffix(".json")
-                with open(output_path, "w") as f:
+                output_path = (
+                    os.path.join(
+                        self._output_dir, f"epoch_{epoch}", ADAPTER_CONFIG_FNAME
+                    )
+                    + ".json"
+                )
+                with self._fs.open(output_path, "w") as f:
                     json.dump(state_dict[training.ADAPTER_CONFIG], f)
                 logger.info(
                     "Adapter checkpoint of size "
@@ -891,7 +963,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         # So its easy to run inference with the model using this epoch's checkpoint
         copy_files(
             self._checkpoint_dir,
-            Path.joinpath(self._output_dir, f"epoch_{epoch}"),
+            os.path.join(self._output_dir, f"epoch_{epoch}"),
             ignore_suffixes=SUFFIXES_TO_NOT_COPY,
         )
 
@@ -901,10 +973,11 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             _ = state_dict.pop(training.MODEL_KEY, None)
             _ = state_dict.pop(training.ADAPTER_KEY, None)
             _ = state_dict.pop(training.ADAPTER_CONFIG, None)
-            output_path = Path.joinpath(
+            output_path = os.path.join(
                 self._output_dir, RECIPE_STATE_DIRNAME, "recipe_state.pt"
             )
-            output_path.parent.mkdir(parents=True, exist_ok=True)
+            parent_path = os.path.dirname(output_path)
+            self._fs.mkdir(parent_path, exist_ok=True)
             torch.save(state_dict, output_path)
             logger.info(
                 "Recipe checkpoint of size "

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -335,7 +335,8 @@ def get_largest_iter_folder(
 
     fs, _ = url_to_fs(dir)
     # Iterate over the directory contents
-    for fname in fs.ls(dir):
+    for fpath in fs.ls(dir):
+        fname = os.path.basename(fpath)
         match = regex.match(fname)
         if match:
             # Extract the number from the match

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -14,7 +14,9 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from warnings import warn
 
 import torch
-from safetensors import safe_open
+from fsspec.core import url_to_fs
+from huggingface_hub import HfFileSystem
+from safetensors.torch import load
 
 from torchtune.utils._logging import get_logger
 
@@ -190,28 +192,31 @@ class FormattedCheckpointFiles:
         ]
 
 
-def get_path(input_dir: Path, filename: str, missing_ok: bool = False) -> Path:
+def get_path(
+    input_dir: Union[Path, str], filename: str, missing_ok: bool = False
+) -> str:
     """
     Utility to recover and validate the path for a given file within a given directory.
 
     Args:
-        input_dir (Path): Directory containing the file
+        input_dir (Union[Path, str]): Directory containing the file
         filename (str): Name of the file
         missing_ok (bool): Whether to raise an error if the file is missing.
 
     Returns:
-        Path: Path to the file
+        str: Path to the file
 
     Raises:
         ValueError: If the file is missing and missing_ok is False.
     """
-    if not input_dir.is_dir():
+    fs, _ = url_to_fs(input_dir)
+    if not fs.isdir(input_dir):
         raise ValueError(f"{input_dir} is not a valid directory.")
 
-    file_path = Path.joinpath(input_dir, filename)
+    file_path = os.path.join(input_dir, filename)
 
     # If missing_ok is False, raise an error if the path is invalid
-    if not missing_ok and not file_path.is_file():
+    if not missing_ok and not fs.isfile(file_path):
         raise ValueError(f"No file with name: {filename} found in {input_dir}.")
     return file_path
 
@@ -238,22 +243,31 @@ def safe_torch_load(
     try:
         # convert the path into a string since pathlib Path and mmap don't work
         # well together
+        fs, _ = url_to_fs(str(checkpoint_path))
         is_safetensors_file = (
             True if str(checkpoint_path).endswith(".safetensors") else False
         )
         if is_safetensors_file:
-            result = {}
-            with safe_open(checkpoint_path, framework="pt", device="cpu") as f:
-                for k in f.keys():
-                    result[k] = f.get_tensor(k)
-            state_dict = result
+            with fs.open(checkpoint_path, "rb") as checkpoint_file:
+                state_dict = load(checkpoint_file.read())
         else:
-            state_dict = torch.load(
-                str(checkpoint_path),
-                map_location="cpu",
-                mmap=mmap,
-                weights_only=weights_only,
-            )
+            if isinstance(fs, HfFileSystem):
+                # HfFileSystem does not support mmap
+                mmap = False
+                with fs.open(checkpoint_path, "rb") as checkpoint_file:
+                    state_dict = torch.load(
+                        checkpoint_file,
+                        map_location="cpu",
+                        mmap=mmap,
+                        weights_only=weights_only,
+                    )
+            else:
+                state_dict = torch.load(
+                    checkpoint_path,
+                    map_location="cpu",
+                    mmap=mmap,
+                    weights_only=weights_only,
+                )
     except Exception as e:
         raise ValueError(f"Unable to load checkpoint from {checkpoint_path}. ") from e
     return state_dict
@@ -319,8 +333,9 @@ def get_largest_iter_folder(
     iter_folders = []
     regex = re.compile(pattern)
 
+    fs, _ = url_to_fs(dir)
     # Iterate over the directory contents
-    for fname in os.listdir(dir):
+    for fname in fs.ls(dir):
         match = regex.match(fname)
         if match:
             # Extract the number from the match
@@ -362,19 +377,23 @@ def copy_files(
     This will copy all files from 'path/to/input_dir' to 'path/to/output_dir', except those that
     already exist in the destination or have the specified suffixes.
     """
-
+    fs, _ = url_to_fs(input_dir)
     max_file_size = max_file_size_mb * 1024 * 1024
-    for root, dirs, files in os.walk(input_dir):
+    for root, dirs, files in fs.walk(input_dir):
 
         # Filter out directories that start with '.'. E.g. ".cache/"
         dirs[:] = [d for d in dirs if not d.startswith(".")]
 
         # Construct the corresponding directory in the output
-        relative_path = os.path.relpath(root, input_dir)
-        dest_dir = os.path.join(output_dir, relative_path)
+        protocol = fs.protocol if isinstance(fs.protocol, tuple) else (fs.protocol)
+        if "local" in protocol:
+            relative_path = os.path.relpath(root, input_dir)
+            dest_dir = os.path.join(output_dir, relative_path)
+        else:
+            dest_dir = output_dir
 
         # Create the directory in the output if it doesn't exist
-        os.makedirs(dest_dir, exist_ok=True)
+        fs.makedirs(dest_dir, exist_ok=True)
 
         for file in files:
             # Skip files that start with '.'. E.g. ".git"
@@ -391,34 +410,34 @@ def copy_files(
             dest_file = os.path.join(dest_dir, file)
 
             # Check the file size
-            if os.path.getsize(src_file) > max_file_size:
+            if fs.size(src_file) > max_file_size:
                 print(
                     f"Skipping copying {src_file} to {output_dir} as it exceeds the size limit of {max_file_size_mb} MiB."
                 )
                 continue
 
             # Copy the file if it doesn't already exist in the destination
-            if not os.path.exists(dest_file):
-                shutil.copy2(src_file, dest_file)
+            if not fs.exists(dest_file):
+                fs.cp_file(src_file, dest_file)
 
     return
 
 
 def get_recipe_checkpoint_path(
-    output_dir: Path,
+    output_dir: Union[str, Path],
     recipe_checkpoint: Optional[str] = None,
     should_load_recipe_state: bool = False,
-) -> Optional[Path]:
+) -> Optional[str]:
     """
     If recipe_checkpoint is None, look for recipe_state.pt in {output_dir}/{RECIPE_STATE_DIRNAME}/recipe_state.pt.
     This is to make it easier to resume from a previous run, without having to specify the recipe_checkpoint.
 
     Args:
-        output_dir (Path): Directory containing the recipe checkpoint.
+        output_dir (Union[str, Path]): Directory containing the recipe checkpoint.
         recipe_checkpoint (Optional[str]): Name of the recipe checkpoint file. Defaults to None.
         should_load_recipe_state (bool): Whether to load the recipe state from the checkpoint.
     Returns:
-        Optional[Path]: Path to the recipe checkpoint file if should_load_recipe_state is True, otherwise None.
+        Optional[str]: Path to the recipe checkpoint file if should_load_recipe_state is True, otherwise None.
     Raises:
         ValueError: If should_load_recipe_state is True and the recipe checkpoint file is missing.
     """
@@ -439,27 +458,27 @@ def get_recipe_checkpoint_path(
             f"Could not find it at {recipe_checkpoint_path}."
         )
 
-    return Path(recipe_checkpoint_path)
+    return recipe_checkpoint_path
 
 
 def get_adapter_checkpoint_path(
-    output_dir: Path,
+    output_dir: Union[Path, str],
     adapter_checkpoint: Optional[str] = None,
     should_load_recipe_state: bool = False,
     pattern: str = r"^epoch_(\d+)",
-) -> Optional[Path]:
+) -> Optional[str]:
     r"""
     If adapter_checkpoint is None, look for it in {output_dir}/epoch_{latest_epoch}/adapter_model.pt.
     This is to make it easier to resume from a previous run, without having to specify the adapter_checkpoint.
 
     Args:
-        output_dir (Path): Directory containing the adapter checkpoint.
+        output_dir (Union[Path, str]): Directory containing the adapter checkpoint.
         adapter_checkpoint (Optional[str]): Name of the adapter checkpoint file. Defaults to None.
         should_load_recipe_state (bool): Whether to load the recipe state from checkpoint.
         pattern (str): Regex pattern to match the epoch folder. Defaults to "epoch_(\d+)".
 
     Returns:
-        Optional[Path]: Path to the adapter checkpoint file, or None if not applicable.
+        Optional[str]: Path to the adapter checkpoint file, or None if not applicable.
 
     Raises:
         ValueError: If the adapter checkpoint file is missing or if the adapter checkpoint file is not a .pt file.
@@ -491,7 +510,7 @@ def get_adapter_checkpoint_path(
         if os.path.exists(tentative_adapter_checkpoint_path):
             adapter_checkpoint_path = tentative_adapter_checkpoint_path
 
-    return Path(adapter_checkpoint_path) if adapter_checkpoint_path else None
+    return adapter_checkpoint_path if adapter_checkpoint_path else None
 
 
 def get_model_checkpoint_path(
@@ -593,15 +612,21 @@ def get_model_checkpoint_path(
     return checkpoint_paths
 
 
-def check_outdir_not_in_ckptdir(ckpt_dir: Path, out_dir: Path) -> bool:
+def check_outdir_not_in_ckptdir(
+    ckpt_dir: Union[Path, str], out_dir: Union[Path, str]
+) -> bool:
     """
     Checks that the output directory is not equal to or a subdirectory of the checkpoint directory.
     This is necessary to avoid making copies of copies when geting config files from ckpt_dir.
     """
-
     # Resolve the absolute paths to avoid issues with relative paths
-    _ckpt_dir = ckpt_dir.resolve()
-    _out_dir = out_dir.resolve()
+    if isinstance(ckpt_dir, Path):
+        _ckpt_dir = ckpt_dir.resolve()
+    if isinstance(out_dir, Path):
+        _out_dir = out_dir.resolve()
+
+    _ckpt_dir = Path(ckpt_dir)
+    _out_dir = Path(out_dir)
 
     # Check if out_dir is the same as ckpt_dir or a subdirectory of it
     if _out_dir == _ckpt_dir or _ckpt_dir in _out_dir.parents:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [X ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
This was originally done in https://github.com/pytorch/torchtune/pull/2494, but the diff stack got into a weird state with so many commits and squashing/rebasing, so created a new pr

#### Changelog
What are the changes made in this PR?
* Add the ability to read and write checkpoints directly in HF format to HF, behind the enable_dcp flag.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x ] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x ] manually run any new or modified recipes with sufficient proof of correctness
- [ x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x ] I have added an example to docs or docstrings
