### PR TITLE
🐛 [Multi-node Full Fine Tuning Example] Fix file path references and disable fused optimizer

### DIFF
--- a/recipes/configs/llama3_3/70B_full_multinode.yaml
+++ b/recipes/configs/llama3_3/70B_full_multinode.yaml
@@ -53,7 +53,7 @@ epochs: 1
 optimizer:
   _component_: torch.optim.AdamW
   lr: 2e-5
-  fused: True
+  fused: False
 
 loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss

--- a/recipes/configs/llama3_3/70B_full_multinode.yaml
+++ b/recipes/configs/llama3_3/70B_full_multinode.yaml
@@ -9,12 +9,12 @@
 #
 # This config is only tested on 2 nodes w/ 8 H100 machines.
 
-output_dir: /tmp/torchtune/llama3_3_70B/full
+output_dir: ${output_dir}
 
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.llama3.llama3_tokenizer
-  path: /tmp/Llama-3.3-70B-Instruct/original/tokenizer.model
+  path: ${checkpoint_dir}/original/tokenizer.model
   max_seq_len: 1024
 
 # Dataset
@@ -30,7 +30,7 @@ model:
 
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
-  checkpoint_dir: /tmp/Llama-3.3-70B-Instruct/
+  checkpoint_dir: ${checkpoint_dir}
   checkpoint_files:
     filename_format: model-{}-of-{}.safetensors
     max_filename: "00030"


### PR DESCRIPTION
#### Context
Fix bugs with the Multi-node Full Fine tuning example a

#### Changelog
What are the changes made in this PR?
* Disable Fused Optimizer:
  * Tensor Parallelism does not support this feature.
* Fix directory references 
  *  Use ${checkpoint_dir} instead of /tmp/Llama-3.3-70B-Instruct and ${output_dir} instead of /tmp/torchtune/llama3_3_70B/full


#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.
* PyTorch version 2.5.1
* testing sbatch script:
```#!/bin/bash
# Copyright (c) Meta Platforms, Inc. and affiliates.
# All rights reserved.

# This source code is licensed under the BSD-style license found in the
# LICENSE file in the root directory of this source tree.

# ---------- SBATCH commands ---------- #
#SBATCH --job-name=torchtune-multi-node
#SBATCH --ntasks=2
#SBATCH --nodes=2
#SBATCH --gpus-per-task=8
#SBATCH --cpus-per-task=96

. venv/bin/activate

# ---------- Set env variables ---------- #
# Grab the IP for head node:
# You may need to set this to the fully qualified domain name of your head node
nodes=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
nodes_array=($nodes)
head_node=${nodes_array[0]}
head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
echo Node IP: $head_node_ip

# You might need to explicitly set the network interface for distributed backends:
# export NCCL_SOCKET_IFNAME=...
# export GLOO_SOCKET_IFNAME=...

export NCCL_DEBUG=INFO

export TORCH_DIST_INIT_BARRIER=1
export LOGLEVEL=INFO

# ---------- Launch training ---------- #
# You probably want to load in a virtual env w/ conda...
# module load conda
# conda activate torchtune
# ...or venv
# source torchtune/bin/activate

SHARED_FS=/home/brian/model # <-- Replace w/ your filesystem
CHECKPOINT_DIR="$SHARED_FS/Llama-3.3-70B-Instruct"
OUTPUT_DIR="$SHARED_FS/Llama3.3-70B-fft-output"
#rsync --progress --stats -a $CHECKPOINT_DIR /tmp
# Adjust sbatch --ntasks and sbatch --nodes above and --nnodes below to your specific node count
srun tune run --nnodes 2 --nproc_per_node 8 --rdzv_id 101 --rdzv_backend c10d --rdzv_endpoint "$head_node_ip:29500" \
    full_finetune_distributed --config ./ttune_sample.yaml checkpoint_dir=$CHECKPOINT_DIR output_dir=$OUTPUT_DIR
```
* Saved patched TorchTune config file as ./ttune_sample.yaml
* Saved sbatch script as ttune.slurm
* Run with `sbatch ttune.slurm`
* Output of torchtune run: https://gist.github.com/brianlechthaler/0c42c28e1d6f761619639abe4cdb2dbb




#### UX
No changes made to API
