### PR TITLE
Adapter size calls should use fsspec

### DIFF
--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -996,7 +996,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             torch.save(state_dict, output_path)
             logger.info(
                 "Recipe checkpoint of size "
-                f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
+                f"{self._fs.size(output_path) / 1024**3:.2f} GiB "
                 f"saved to {output_path}"
             )
         else:

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -895,7 +895,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 torch.save(state_dict[training.ADAPTER_KEY], f)
             logger.info(
                 "Adapter checkpoint of size "
-                f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
+                f"{self._fs.size(output_path) / 1024**3:.2f} GiB "
                 f"saved to {output_path}"
             )
 
@@ -935,7 +935,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                         f.write(save_bytes)
                 logger.info(
                     "Adapter checkpoint of size "
-                    f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
+                    f"{self._fs.size(output_path) / 1024**3:.2f} GiB "
                     f"saved to {output_path}"
                 )
         elif adapter_only:
@@ -970,7 +970,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     json.dump(state_dict[training.ADAPTER_CONFIG], f)
                 logger.info(
                     "Adapter checkpoint of size "
-                    f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
+                    f"{self._fs.size(output_path) / 1024**3:.2f} GiB "
                     f"saved to {output_path}"
                 )
 

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -457,7 +457,9 @@ def get_recipe_checkpoint_path(
             output_dir, RECIPE_STATE_DIRNAME, "recipe_state.pt"
         )
 
-    if not recipe_checkpoint_path or not os.path.exists(recipe_checkpoint_path):
+    fs, _ = url_to_fs(recipe_checkpoint_path)
+
+    if not recipe_checkpoint_path or not fs.exists(recipe_checkpoint_path):
         raise ValueError(
             "If `should_load_recipe_state=True`, recipe_checkpoint file must be provided. "
             f"Could not find it at {recipe_checkpoint_path}."
@@ -495,7 +497,8 @@ def get_adapter_checkpoint_path(
 
     if adapter_checkpoint:
         adapter_checkpoint_path = os.path.join(output_dir, adapter_checkpoint)
-        if not os.path.exists(adapter_checkpoint_path):
+        fs, _ = url_to_fs(adapter_checkpoint_path)
+        if not fs.exists(adapter_checkpoint_path):
             raise ValueError(
                 f"Adapter checkpoint file {adapter_checkpoint_path} does not exist."
             )
@@ -512,7 +515,8 @@ def get_adapter_checkpoint_path(
         tentative_adapter_checkpoint_path = os.path.join(
             output_dir, largest_iter_folder, "adapter_model.pt"
         )
-        if os.path.exists(tentative_adapter_checkpoint_path):
+        fs, _ = url_to_fs(tentative_adapter_checkpoint_path)
+        if fs.exists(tentative_adapter_checkpoint_path):
             adapter_checkpoint_path = tentative_adapter_checkpoint_path
 
     return adapter_checkpoint_path if adapter_checkpoint_path else None


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Adapter size calls should use fsspec fs so that it works with HfFileSystem as well as LocalFs

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x ] I did not change any public API
- [ ] I have added an example to docs or docstrings
