### PR TITLE
[MODEL] Mistral Nemo 12B Support

### DIFF
--- a/recipes/configs/mistral/12B_full_low_memory.yaml
+++ b/recipes/configs/mistral/12B_full_low_memory.yaml
@@ -1,0 +1,117 @@
+# Config for single device full finetuning in full_finetune_single_device.py
+# using a Mistral 12B model
+#
+# This config uses hyperparameters based on small set of experiments and information
+# available on various forums. These are not meant to replicate the numbers
+# from the paper
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download mistralai/Mistral-Nemo-Base-2407 --output-dir /tmp/Mistral-Nemo-12B-v0.1 --ignore-patterns "*consolidated.safetensors*" --hf-token <HF_TOKEN>
+#
+# The default config uses an optimizer from bitsandbytes. If you do not have it installed,
+# you can install it with
+#   pip install bitsandbytes
+#
+# To launch on a single device, run the following command from root:
+#   tune run full_finetune_single_device --config mistral/12B_full_low_memory
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run full_finetune_single_device --config mistral/12B_full_low_memory checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+output_dir: /tmp/torchtune/mistral_12B/full_low_memory # /tmp may be deleted by your system. Change it to your preference.
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.mistral.mistral_tekken_tokenizer
+  path: /workspace/Mistral-Nemo-12B-v0.1/tekken.json
+  max_seq_len: null
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.alpaca_dataset
+  packed: False  # True increases speed
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: torchtune.models.mistral.mistral_nemo_12b
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /workspace/Mistral-Nemo-12B-v0.1
+  checkpoint_files: [
+    model-00001-of-00005.safetensors,
+    model-00002-of-00005.safetensors,
+    model-00003-of-00005.safetensors,
+    model-00004-of-00005.safetensors,
+    model-00005-of-00005.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: MISTRAL
+resume_from_checkpoint: False
+
+# Fine-tuning arguments
+batch_size: 2
+epochs: 1
+optimizer:
+  _component_: bitsandbytes.optim.PagedAdamW
+  lr: 5e-6
+loss:
+  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
+max_steps_per_epoch: null
+gradient_accumulation_steps: 1  # Use to increase effective batch size
+optimizer_in_bwd: True  # True saves memory. Requires gradient_accumulation_steps=1
+
+# Training env
+device: cuda
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: True  # True reduces memory
+
+# Reduced precision
+dtype: bf16
+
+# Model compilation
+clip_grad_norm: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: True
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/torchtune/models/mistral/__init__.py
+++ b/torchtune/models/mistral/__init__.py
@@ -18,6 +18,8 @@ from ._model_builders import (
     mistral_tokenizer,
     qlora_mistral_7b,
     qlora_mistral_reward_7b,
+    mistral_tekken_tokenizer,
+    mistral_nemo_12b,
 )
 from ._prompt_template import MistralChatTemplate
 from ._tokenizer import MistralTokenizer
@@ -36,4 +38,6 @@ __all__ = [
     "mistral_tokenizer",
     "qlora_mistral_7b",
     "qlora_mistral_reward_7b",
+    "mistral_tekken_tokenizer",
+    "mistral_nemo_12b",
 ]

--- a/torchtune/models/mistral/_component_builders.py
+++ b/torchtune/models/mistral/_component_builders.py
@@ -46,6 +46,7 @@ def mistral(
     attn_dropout: float = 0.0,
     norm_eps: float = 1e-5,
     rope_base: int = 10_000,
+    head_dim: int = None,
 ) -> TransformerDecoder:
     """
     Build the decoder associated with the mistral model. This includes:
@@ -72,11 +73,13 @@ def mistral(
             Default: 0.0
         norm_eps (float): epsilon in RMS norms
         rope_base (int): base for the rotary positional embeddings. Default: 10_000
+        head_dim (int): the attention head dimension. Default: None
 
     Returns:
         TransformerDecoder: Instantiation of mistral model.
     """
-    head_dim = embed_dim // num_heads
+    output_proj_dim = num_heads * head_dim if head_dim else embed_dim
+    head_dim = head_dim or embed_dim // num_heads
     num_kv_heads = num_kv_heads if num_kv_heads else num_heads
 
     rope = RotaryPositionalEmbeddings(
@@ -92,7 +95,7 @@ def mistral(
             q_proj=nn.Linear(embed_dim, num_heads * head_dim, bias=False),
             k_proj=nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False),
             v_proj=nn.Linear(embed_dim, num_kv_heads * head_dim, bias=False),
-            output_proj=nn.Linear(embed_dim, embed_dim, bias=False),
+            output_proj=nn.Linear(output_proj_dim, embed_dim, bias=False),
             pos_embeddings=rope,
             kv_cache=None,
             max_seq_len=max_seq_len,

--- a/torchtune/models/mistral/_model_builders.py
+++ b/torchtune/models/mistral/_model_builders.py
@@ -16,6 +16,7 @@ from torchtune.data._prompt_templates import _get_prompt_template
 
 from torchtune.modules import TransformerDecoder
 from torchtune.models.mistral._tokenizer import MistralTokenizer
+from torchtune.models.mistral._tekken_tokenizer import MistralTekkenTokenizer
 from torchtune.modules.peft import LORA_ATTN_MODULES
 from functools import partial
 
@@ -216,3 +217,46 @@ Builder for creating a Mistral reward 7B model with QLoRA enabled. Base model we
 that LoRA is applied to are quantized per the QLoRA paper: https://arxiv.org/abs/2305.14314.
 Please see `lora_mistral_reward_7b` for full API arguments.
 """
+
+def mistral_nemo_12b() -> TransformerDecoder:
+    """
+    Builder for creating a Mistral Nemo 12B model initialized w/ the parameter values
+    from https://huggingface.co/mistralai/Mistral-Nemo-Base-2407
+
+    Returns:
+        TransformerDecoder: Instantiation of Mistral Nemo 12B model
+    """
+    return mistral(
+        vocab_size=131072,
+        num_layers=40,
+        num_heads=32,
+        num_kv_heads=8,
+        embed_dim=5120,
+        intermediate_dim=14336,
+        max_seq_len=131072,
+        attn_dropout=0.0,
+        norm_eps=1e-5,
+        rope_base=1_000_000,
+        head_dim=128,
+    )
+
+def mistral_tekken_tokenizer(path: str, max_seq_len: Optional[int] = None, prompt_template: Optional[_TemplateType] = "torchtune.models.mistral.MistralChatTemplate", truncation_type: str = "right",) -> MistralTekkenTokenizer:
+    """
+    Tekken tokenizer for Mistral Nemo models.
+
+    Args:
+        path (str): path to the tekken.json tokenizer file
+        max_seq_len (Optional[int]): maximum sequence length for tokenizing a single list of messages,
+            after which the input will be truncated. Default is None.
+        prompt_template (Optional[_TemplateType]): optional specified prompt template.
+            If a string, it is assumed to be the dotpath of a :class:`~torchtune.data.PromptTemplateInterface`
+            class. If a dictionary, it is assumed to be a custom prompt template mapping role to the
+            prepend/append tags. Default is :class:`~torchtune.models.mistral.MistralChatTemplate`.
+        truncation_type (str): type of truncation to apply, either "left" or "right".
+            Default is "right".
+
+    Returns:
+        MistralTekkenTokenizer: Instantiation of the Mistral Tekken tokenizer
+    """
+    return MistralTekkenTokenizer(path=path, max_seq_len=max_seq_len, prompt_template=_get_prompt_template(prompt_template) if prompt_template is not None else None, truncation_type=truncation_type)
+

--- a/torchtune/models/mistral/_tekken_tokenizer.py
+++ b/torchtune/models/mistral/_tekken_tokenizer.py
@@ -1,0 +1,321 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+from enum import Enum
+from functools import cached_property
+from itertools import groupby
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+
+import tiktoken
+
+from torchtune.data import Message, PromptTemplate
+from torchtune.models.mistral._prompt_template import MistralChatTemplate
+from torchtune.modules.transforms import Transform
+from torchtune.modules.transforms.tokenizers import (
+    ModelTokenizer,
+    tokenize_messages_no_special_tokens,
+)
+
+WHITESPACE_CHARS = [" ", "\n", "\t", "\r", "\v"]
+
+
+class SpecialTokenPolicy(Enum):
+    """What to do with special tokens when encoding/decoding."""
+    IGNORE = 0
+    KEEP = 1
+    RAISE = 2
+
+
+def _reload_mergeable_ranks(vocab, max_vocab=None):
+    """Reload mergeable ranks from vocab."""
+    token2id = {}
+    for i, token_info in enumerate(vocab):
+        if max_vocab is not None and i >= max_vocab:
+            break
+        token_bytes = token_info["token_bytes"]
+        # Decode base64 to bytes
+        import base64
+        token_bytes = base64.b64decode(token_bytes)
+        token2id[token_bytes] = i
+    return token2id
+
+
+class MistralTekkenTokenizer(ModelTokenizer, Transform):
+    """
+    Mistral's implementation of the Tekken tokenizer for Nemo models
+
+    Args:
+        path (str): Path to pretrained tokenizer file (tekken.json).
+        max_seq_len (Optional[int]): A max sequence length to truncate tokens to.
+            Default: None
+        prompt_template (Optional[PromptTemplate]): template used to format the messages based on their role.
+            Default is :class:`~torchtune.models.mistral.MistralChatTemplate`.
+        truncation_type (str): type of truncation to apply, either "left" or "right".
+            Default is "right".
+
+    Examples:
+        >>> tokenizer = MistralTekkenTokenizer("/path/to/tekken.json")
+        >>> tokenized_text = tokenizer.encode("Hello world!", add_bos=True, add_eos=True)
+        >>> print(tokenized_text)
+        [1, 31587, 29644, 102, 2]
+    """
+
+    # Special tokens for Tekken tokenizer
+    SPECIAL_TOKENS = (
+        "<unk>",
+        "<s>",
+        "</s>",
+        "<begin_inst>",
+        "<end_inst>",
+        "<begin_tools>",
+        "<end_tools>",
+        "<begin_tool_results>",
+        "<end_tool_results>",
+        "<tool_calls>",
+        "<img>",
+        "<pad>",
+        "<img_break>",
+        "<img_end>",
+        "<prefix>",
+        "<middle>",
+        "<suffix>",
+        "<begin_system>",
+        "<end_system>",
+        "<begin_tool_content>",
+    )
+    SPECIAL_TOKEN_TEMPLATE = "<SPECIAL_{id}>"
+
+    def __init__(
+        self,
+        path: str,
+        max_seq_len: Optional[int] = None,
+        prompt_template: Optional[PromptTemplate] = MistralChatTemplate(),
+        truncation_type: str = "right",
+    ):
+        # Load the tokenizer configuration from the JSON file
+        with open(path, "r") as f:
+            model_data = json.load(f)
+        
+        # Extract configuration
+        vocab = model_data["vocab"]
+        pattern = model_data["config"]["pattern"]
+        vocab_size = model_data["config"]["default_vocab_size"]
+        num_special_tokens = model_data["config"]["default_num_special_tokens"]
+        
+        # Validate vocab size
+        assert vocab_size <= len(vocab) + num_special_tokens, (
+            vocab_size, len(vocab), num_special_tokens,
+        )
+        
+        self._vocab_size = vocab_size
+        self._path = path
+        
+        # Set up special tokens
+        special_tokens = list(self.SPECIAL_TOKENS)
+        assert len(special_tokens) == len(set(special_tokens)), f"Special tokens must be unique: {special_tokens}"
+        assert len(special_tokens) < num_special_tokens
+        
+        # Add filler special tokens if needed
+        special_filler = [
+            self.SPECIAL_TOKEN_TEMPLATE.format(id=i)
+            for i in range(len(special_tokens), num_special_tokens)
+        ]
+        
+        if special_filler:
+            print(f"Adding special tokens {special_filler[0]}, ..., {special_filler[-1]}")
+        
+        special_tokens = special_tokens + special_filler
+        assert len(set(special_tokens)) == len(special_tokens) == num_special_tokens, special_tokens
+        
+        # Calculate inner vocab size
+        inner_vocab_size = vocab_size - num_special_tokens
+        
+        # Reload vocab
+        self._tekken_token2id_nospecial = _reload_mergeable_ranks(vocab, max_vocab=inner_vocab_size)
+        assert set(range(inner_vocab_size)) == set(self._tekken_token2id_nospecial.values()), (
+            inner_vocab_size, self._tekken_token2id_nospecial,
+        )
+        
+        # Initialize tiktoken model
+        self._model = tiktoken.Encoding(
+            name=Path(path).stem,
+            pat_str=pattern,
+            mergeable_ranks=self._tekken_token2id_nospecial,
+            special_tokens={},  # special tokens are handled manually
+        )
+        
+        self._all_special_tokens = special_tokens
+        self._vocab = [self.id_to_piece(i) for i in range(vocab_size)]
+        self._special_token_policy = SpecialTokenPolicy.RAISE
+        
+        # TorchTune specific attributes
+        self.max_seq_len = max_seq_len
+        self.prompt_template = prompt_template
+        self.truncation_type = truncation_type
+        
+        # During generation, stop when eos_id is encountered
+        self.stop_tokens = [self.eos_id]
+
+    def id_to_piece(self, token_id: int) -> str:
+        """Convert token ID to string representation."""
+        if token_id < len(self._all_special_tokens):
+            return self._all_special_tokens[token_id]
+        
+        try:
+            return self._model.decode([token_id - len(self._all_special_tokens)])
+        except:
+            return "<?>"
+
+    @property
+    def eos_id(self) -> int:
+        """Get the end-of-sequence token ID."""
+        return self.SPECIAL_TOKENS.index("</s>")
+
+    @property
+    def bos_id(self) -> int:
+        """Get the beginning-of-sequence token ID."""
+        return self.SPECIAL_TOKENS.index("<s>")
+
+    @property
+    def pad_id(self) -> int:
+        """Get the padding token ID."""
+        return self.SPECIAL_TOKENS.index("<pad>")
+
+    @property
+    def unk_id(self) -> int:
+        """Get the unknown token ID."""
+        return self.SPECIAL_TOKENS.index("<unk>")
+
+    @property
+    def vocab_size(self) -> int:
+        """Get the vocabulary size."""
+        return self._vocab_size
+
+    @property
+    def num_special_tokens(self) -> int:
+        """Get the number of special tokens."""
+        return len(self._all_special_tokens)
+
+    def encode(
+        self,
+        text: str,
+        add_bos: bool = True,
+        add_eos: bool = True,
+        trim_leading_whitespace: bool = False,
+    ) -> List[int]:
+        """
+        Encode a string into a list of token IDs
+
+        Args:
+            text (str): The input text to be encoded, unbatched.
+            add_bos (bool): Whether to prepend BOS special token (Beginning of Sentence) to the input, defaults to True.
+            add_eos (bool): Whether to append EOS special token (End of Sentence) to the input, defaults to True.
+            trim_leading_whitespace (bool): Whether to trim leading whitespace, defaults to False.
+        Returns:
+            List[int]: The encoded token IDs.
+        """
+        if trim_leading_whitespace and text and text[0] in WHITESPACE_CHARS:
+            text = text.lstrip()
+            
+        tokens: List[int] = self._model.encode(text)
+        tokens = [t + self.num_special_tokens for t in tokens]
+        
+        if add_bos:
+            tokens = [self.bos_id, *tokens]
+        if add_eos:
+            tokens = [*tokens, self.eos_id]
+            
+        return tokens
+
+    def decode(
+        self,
+        token_ids: List[int],
+    ) -> str:
+        """Decode token IDs to strings.
+
+        Args:
+            token_ids (List[int]): The input token IDs to be decoded.
+
+        Returns:
+            str: The decoded text.
+        """
+        return "".join(self._decode_all(token_ids, self._special_token_policy))
+
+    def _decode_all(self, tokens: List[int], special_token_policy: SpecialTokenPolicy) -> List[str]:
+        """Decode tokens with special token handling."""
+        # Lump special and non-special tokens together to minimize calls to decode
+        decoded: List[str] = []
+        for is_special, group in groupby(tokens, lambda t: t < self.num_special_tokens):
+            group_list = list(group)
+            if is_special:
+                if special_token_policy == SpecialTokenPolicy.RAISE:
+                    raise ValueError(
+                        f"Decoding `tokens` that contain special tokens ({group_list}) is not allowed. \n"
+                        "Either make sure `tokens` do not include any special tokens or, "
+                        "if you want to decode `tokens` that includes special tokens, "
+                        "change the tokenizer's special token policy to IGNORE or KEEP."
+                    )
+                elif special_token_policy == SpecialTokenPolicy.KEEP:
+                    decoded.extend(self._all_special_tokens[t] for t in group_list)
+                elif special_token_policy == SpecialTokenPolicy.IGNORE:
+                    continue
+            else:
+                decoded.append(self._model.decode([t - self.num_special_tokens for t in group_list]))
+        return decoded
+
+    def tokenize_messages(
+        self,
+        messages: List[Message],
+        *,
+        add_eos: bool = True,
+    ) -> Tuple[List[int], List[bool]]:
+        r"""Tokenize a list of messages one at a time then concatenate them,
+        returning a list of tokens and a list of masks.
+
+        Args:
+            messages (List[Message]): A list of messages, each containing role, content,
+                and masked attributes.
+            add_eos (bool): Whether to append EOS after assistant message, default to True
+
+        Returns:
+            Tuple[List[int], List[bool]]: The tokenized messages
+        """
+        templated_messages = (
+            self.prompt_template(messages)
+            if self.prompt_template is not None
+            else messages
+        )
+        return tokenize_messages_no_special_tokens(
+            tokenizer=self,
+            messages=templated_messages,
+            bos_id=self.bos_id,
+            eos_id=self.eos_id if add_eos else None,
+            truncation_type=self.truncation_type,
+        )
+
+    def __call__(
+        self, sample: Mapping[str, Any], inference: bool = False
+    ) -> Mapping[str, Any]:
+        """
+        Apply ``tokenize_messages`` to the "messages" field in the sample.
+
+        Args:
+            sample (Mapping[str, Any]): A sample with a "messages" field containing
+                a List[Message] to tokenize
+            inference (bool): Whether the template is being used for inference or not.
+
+        Returns:
+            Mapping[str, Any]: The sample with added "tokens" and "mask" fields
+                and the "messages" field removed.
+            inference (bool): Whether the template is being used for inference or not.
+        """
+        messages = sample.pop("messages")
+        tokens, mask = self.tokenize_messages(messages)
+        sample["tokens"] = tokens
+        sample["mask"] = mask
+        return sample


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Issue: #1716

#### Changelog
What are the changes made in this PR?

* Added Mistral's "v3" tokenizer called Tekken (tiktoken based)
* Added support for specifying `head_dim` (default=None for backward compatibility) in the MistralModel for loading the model weights with correct shapes

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
