### PR TITLE
Fix TP test expected values

### DIFF
--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -193,7 +193,16 @@ class TestFullFinetuneDistributedRecipe:
         monkeypatch.setattr(sys, "argv", cmd)
         runpy.run_path(TUNE_PATH, run_name="__main__")
         loss_values = get_loss_values_from_metric_logger(log_file)
-        expected_loss_values = self._fetch_expected_loss_values_multi_rank(model_type)
+
+        # For tp_dim = 2, we have dp_dim = 2, so 2x global batch size.
+        # For tp_dim = 4 there is no data parallelism (since there are 4 workers).
+        # This means we expect the multi-rank loss for tp_dim=2 but single-rank loss for tp_dim=4.
+        expected_loss_values = (
+            self._fetch_expected_loss_values_multi_rank(model_type)
+            if tensor_parallel_dim == 2
+            else self._fetch_expected_loss_values_single_rank(model_type)
+        )
+
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-4, atol=1e-4
         )


### PR DESCRIPTION
The test_2d_loss_parallel tests fail when run locally. However, they don't get caught on CI because our runners there do not have 4 GPUs. The failure is because we need to adjust the loss values depending on whether data parallelism is enabled or not.

Before this change:

```
pytest -m integration_test tests/recipes/test_full_finetune_distributed.py -k 'test_loss_2d_parallel'
...
FAILED tests/recipes/test_full_finetune_distributed.py::TestFullFinetuneDistributedRecipe::test_loss_2d_parallel[llama3/8B_full-llama3-tune-4-1-True-4] - AssertionError: Scalars are not close!
============== 1 failed, 1 passed, 14 deselected in 37.72s =========
```

After this change:

```
pytest -m integration_test tests/recipes/test_full_finetune_distributed.py -k 'test_loss_2d_parallel'
...
=========== 2 passed, 14 deselected in 36.39s ==============
```