### PR TITLE
[Fix] Incorrect Labels Shift for Packed Data

### DIFF
--- a/recipes/dev/early_exit_finetune_distributed.py
+++ b/recipes/dev/early_exit_finetune_distributed.py
@@ -392,11 +392,6 @@ class EarlyExitFinetuneRecipeDistributed(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
         # Setup early exit loss
         (
             self._do_output_hidden_states,
@@ -899,12 +894,6 @@ class EarlyExitFinetuneRecipeDistributed(FTRecipeInterface):
                     else:
                         logits = outputs
 
-                # Shift labels to compute loss
-                # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-                # But this way we dont need to slice the logits. We just add an ignore index to labels.
-                labels = torch.hstack(
-                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-                )
                 if not isinstance(logits, list):
                     labels = labels.reshape(-1)
                     logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/dev/lora_finetune_distributed_multi_dataset.py
+++ b/recipes/dev/lora_finetune_distributed_multi_dataset.py
@@ -343,11 +343,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -824,12 +819,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 with self.activations_handling_ctx:
                     logits = self._model(**batch)
 
-                # Shift labels to compute loss
-                # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-                # But this way we dont need to slice the logits. We just add an ignore index to labels.
-                labels = torch.hstack(
-                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-                )
                 if not isinstance(logits, list):
                     labels = labels.reshape(-1)
                     logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -421,9 +421,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             if self._val_dataloader is None
             else max(cfg.batch_size, self._val_dataloader.batch_size)
         )
-        self.ignore_labels_cache = torch.full(
-            (bsz_cache, 1), self._loss_fn.ignore_index, device=self._device
-        )
 
     def _setup_lr_scheduler(
         self,
@@ -797,12 +794,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         with self.activations_handling_ctx:
             logits = self._model(**batch)
 
-        # Shift labels to compute loss
-        # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-        # But this way we dont need to slice the logits. We just add an ignore index to labels.
-        labels = torch.hstack(
-            (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-        )
         if not isinstance(logits, list):
             labels = labels.reshape(-1)
             logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -342,11 +342,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -636,12 +631,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         with self.activations_handling_ctx:
             logits = self._model(**batch)
 
-        # Shift labels to compute loss
-        # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-        # But this way we dont need to slice the logits. We just add an ignore index to labels.
-        labels = torch.hstack(
-            (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-        )
         if not isinstance(logits, list):
             labels = labels.reshape(-1)
             logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -326,11 +326,6 @@ class KDRecipeDistributed(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -786,12 +781,6 @@ class KDRecipeDistributed(FTRecipeInterface):
         # run model
         logits = self._model(tokens, mask=mask, input_pos=input_pos)
 
-        # Shift labels to compute loss
-        # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-        # But this way we dont need to slice the logits. We just add an ignore index to labels.
-        labels = torch.hstack(
-            (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-        )
         if not isinstance(logits, list):
             labels = labels.reshape(-1)
             logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -367,16 +367,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        bsz_cache = (
-            cfg.batch_size
-            if self._val_dataloader is None
-            else max(cfg.batch_size, self._val_dataloader.batch_size)
-        )
-        self.ignore_labels_cache = torch.full(
-            (bsz_cache, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -911,12 +901,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         with self.activations_handling_ctx:
             logits = self._model(**batch)
 
-        # Shift labels to compute loss
-        # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-        # But this way we dont need to slice the logits. We just add an ignore index to labels.
-        labels = torch.hstack(
-            (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-        )
         if not isinstance(logits, list):
             labels = labels.reshape(-1)
             logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -347,11 +347,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -644,12 +639,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         with self.activations_handling_ctx:
             logits = self._model(**batch)
 
-        # Shift labels to compute loss
-        # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-        # But this way we dont need to slice the logits. We just add an ignore index to labels.
-        labels = torch.hstack(
-            (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-        )
         if not isinstance(logits, list):
             labels = labels.reshape(-1)
             logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -347,11 +347,6 @@ class QATRecipeDistributed(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -813,12 +808,6 @@ class QATRecipeDistributed(FTRecipeInterface):
                 with self.activations_handling_ctx:
                     logits = self._model(**batch)
 
-                # Shift labels to compute loss
-                # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-                # But this way we dont need to slice the logits. We just add an ignore index to labels.
-                labels = torch.hstack(
-                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-                )
                 if not isinstance(logits, list):
                     labels = labels.reshape(-1)
                     logits = logits.reshape(-1, logits.size(-1))

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -369,11 +369,6 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
         self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
 
-        # Used to ignore labels for loss computation
-        self.ignore_labels_cache = torch.full(
-            (cfg.batch_size, 1), self._loss_fn.ignore_index, device=self._device
-        )
-
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
     ) -> Union[torch.profiler.profile, DummyProfiler]:
@@ -840,12 +835,6 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 with self.activations_handling_ctx:
                     logits = self._model(**batch)
 
-                # Shift labels to compute loss
-                # equivalent to doing labels[..., 1:] and logits[..., :-1, :]
-                # But this way we dont need to slice the logits. We just add an ignore index to labels.
-                labels = torch.hstack(
-                    (labels[..., 1:], self.ignore_labels_cache[: labels.shape[0]])
-                )
                 if not isinstance(logits, list):
                     labels = labels.reshape(-1)
                     logits = logits.reshape(-1, logits.size(-1))

--- a/tests/torchtune/datasets/multimodal/test_vqa_dataset.py
+++ b/tests/torchtune/datasets/multimodal/test_vqa_dataset.py
@@ -33,7 +33,7 @@ class TestMultimodalInstructDataset:
         ]
 
         expected_labels = [
-            [-100, -100, -100, -100, -100, -100, -100, -100, -100, -100, 7, 5, -1]
+            [-100, -100, -100, -100, -100, -100, -100, -100, -100, 7, 5, -1, -100]
         ]
 
         assert len(dataset) == 1

--- a/tests/torchtune/datasets/test_alpaca_dataset.py
+++ b/tests/torchtune/datasets/test_alpaca_dataset.py
@@ -49,9 +49,9 @@ class TestAlpacaDataset:
         input, labels = alpaca_ds[0]["tokens"], alpaca_ds[0]["labels"]
 
         assert len(input) == len(labels)
-        assert labels[-1] == tokenizer.eos_id
+        assert labels[-2] == tokenizer.eos_id
         assert input[0] == tokenizer.bos_id
-        assert CROSS_ENTROPY_IGNORE_IDX not in labels
+        assert CROSS_ENTROPY_IGNORE_IDX not in labels[:-1]
 
     @patch("torchtune.datasets._sft.load_dataset")
     def test_label_masking(self, load_dataset, tokenizer, sample):
@@ -68,7 +68,7 @@ class TestAlpacaDataset:
         input, labels = alpaca_ds[0]["tokens"], alpaca_ds[0]["labels"]
 
         assert len(input) == len(labels)
-        assert labels[-1] == tokenizer.eos_id
+        assert labels[-2] == tokenizer.eos_id
         assert input[0] == tokenizer.bos_id
         assert labels.count(CROSS_ENTROPY_IGNORE_IDX) == 27
 
@@ -85,9 +85,9 @@ class TestAlpacaDataset:
         input, labels = alpaca_ds[0]["tokens"], alpaca_ds[0]["labels"]
 
         assert len(input) == len(labels)
-        assert labels[-1] == tokenizer.eos_id
+        assert labels[-2] == tokenizer.eos_id
         assert input[0] == tokenizer.bos_id
-        assert CROSS_ENTROPY_IGNORE_IDX not in labels
+        assert CROSS_ENTROPY_IGNORE_IDX not in labels[:-1]
 
 
 class TestAlpacaToMessages:

--- a/tests/torchtune/datasets/test_chat_dataset.py
+++ b/tests/torchtune/datasets/test_chat_dataset.py
@@ -43,10 +43,10 @@ class TestChatDataset:
         ]
         prompt_lengths = (12, 3)
         expected_labels = [
-            [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[0]
+            [CROSS_ENTROPY_IGNORE_IDX] * (prompt_lengths[0] - 1)
             + [3, 7, 2, 4, 2, 3, -1]
             + [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[1]
-            + [1, 6, -1]
+            + [1, 6, -1, CROSS_ENTROPY_IGNORE_IDX]
         ]
 
         ds = chat_dataset(

--- a/tests/torchtune/datasets/test_concat_dataset.py
+++ b/tests/torchtune/datasets/test_concat_dataset.py
@@ -7,6 +7,7 @@
 import pytest
 from datasets import Dataset
 from torch.utils.data import Dataset as TorchDataset
+from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
 from torchtune.datasets._concat import ConcatDataset
 from torchtune.datasets._packed import PackedDataset
 
@@ -20,7 +21,7 @@ class DummyDataset(TorchDataset):
             raise IndexError()
         return {
             "tokens": [index] * self.sample_size,
-            "labels": [index] * self.sample_size,
+            "labels": [index] * (self.sample_size - 1) + [CROSS_ENTROPY_IGNORE_IDX],
         }
 
     def __len__(self):

--- a/tests/torchtune/datasets/test_grammar_dataset.py
+++ b/tests/torchtune/datasets/test_grammar_dataset.py
@@ -40,7 +40,7 @@ class TestGrammarDataset:
         input, labels = grammar_ds[0]["tokens"], grammar_ds[0]["labels"]
 
         assert input == [0, 7, 2, 3, 6, 4, 8, 5, 8, 5, 7, 4, 3, 6, 4, 8, 9, 2, 9, -1]
-        assert labels == input
+        assert labels[:-1] == input[1:]
 
     @patch("torchtune.datasets._sft.load_dataset")
     def test_label_masking(self, load_dataset, tokenizer):

--- a/tests/torchtune/datasets/test_instruct_dataset.py
+++ b/tests/torchtune/datasets/test_instruct_dataset.py
@@ -26,9 +26,10 @@ class TestInstructDataset:
         ]
         prompt_lengths = (10, 9)
         expected_labels = [
-            [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[0] + [2, 2, 5, 2, 2, 6, -1],
-            [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[1]
-            + [8, 3, 15, 3, 4, 9, 3, 15, -1],
+            [CROSS_ENTROPY_IGNORE_IDX] * (prompt_lengths[0] - 1)
+            + [2, 2, 5, 2, 2, 6, -1, CROSS_ENTROPY_IGNORE_IDX],
+            [CROSS_ENTROPY_IGNORE_IDX] * (prompt_lengths[1] - 1)
+            + [8, 3, 15, 3, 4, 9, 3, 15, -1, CROSS_ENTROPY_IGNORE_IDX],
         ]
 
         system_prompt = "follow this prompt"
@@ -51,8 +52,8 @@ class TestInstructDataset:
             assert prompt == expected_tokenized_prompts[i]
             if train_on_input:
                 assert (
-                    label[system_prompt_offset:]
-                    == expected_tokenized_prompts[i][system_prompt_offset:]
+                    label[system_prompt_offset:-1]
+                    == expected_tokenized_prompts[i][system_prompt_offset + 1 :]
                 )
             else:
                 assert label == expected_labels[i]

--- a/tests/torchtune/datasets/test_samsum_dataset.py
+++ b/tests/torchtune/datasets/test_samsum_dataset.py
@@ -69,7 +69,7 @@ class TestSamsumDataset:
             9,
             -1,
         ]
-        assert labels == input
+        assert labels[:-1] == input[1:]
 
     @patch("torchtune.datasets._sft.load_dataset")
     def test_label_masking(self, load_dataset, tokenizer):

--- a/tests/torchtune/datasets/test_sft_dataset.py
+++ b/tests/torchtune/datasets/test_sft_dataset.py
@@ -95,10 +95,10 @@ class TestSFTDataset:
         ]
         prompt_lengths = (12, 3)
         expected_labels = [
-            [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[0]
-            + [3, 7, 2, 4, 2, 3, -1]
-            + [CROSS_ENTROPY_IGNORE_IDX] * prompt_lengths[1]
-            + [1, 6, -1]
+            [CROSS_ENTROPY_IGNORE_IDX] * (prompt_lengths[0] - 1)
+            + [3, 7, 2, 4, 2, 3, -1, CROSS_ENTROPY_IGNORE_IDX]
+            + [CROSS_ENTROPY_IGNORE_IDX] * (prompt_lengths[1] - 1)
+            + [1, 6, -1, CROSS_ENTROPY_IGNORE_IDX]
         ]
         ds = SFTDataset(
             source="iam/agoofy/goober",

--- a/torchtune/datasets/_sft.py
+++ b/torchtune/datasets/_sft.py
@@ -163,13 +163,16 @@ class SFTTransform(Transform):
                 raise ValueError(error_message)
 
             # Wherever mask == True, set to CROSS_ENTROPY_IGNORE_IDX. Otherwise keep as tokens
+            # Shift labels to be off by 1 from the logits.
+            # Padding added at the end so we dont need to slice the logits.
             tokenized_dict["labels"] = list(
                 np.where(
-                    tokenized_dict["mask"],
+                    tokenized_dict["mask"][1:],
                     CROSS_ENTROPY_IGNORE_IDX,
-                    tokenized_dict["tokens"],
+                    tokenized_dict["tokens"][1:],
                 )
             )
+            tokenized_dict["labels"].append(CROSS_ENTROPY_IGNORE_IDX)
             assert len(tokenized_dict["tokens"]) == len(tokenized_dict["labels"])
         else:
             tokenized_dict = transformed_sample

--- a/torchtune/datasets/_text_completion.py
+++ b/torchtune/datasets/_text_completion.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 from datasets import load_dataset
 from torch.utils.data import Dataset
+from torchtune.data._common import CROSS_ENTROPY_IGNORE_IDX
 from torchtune.data._utils import truncate
 from torchtune.datasets._packed import PackedDataset
 from torchtune.modules.transforms.tokenizers import ModelTokenizer
@@ -71,8 +72,10 @@ class TextCompletionDataset(Dataset):
         if self._tokenizer.max_seq_len is not None:
             tokens = truncate(tokens, self._tokenizer.max_seq_len - 1)
 
-        # No need to offset labels by 1 - happens in the recipe
-        labels = tokens.copy()
+        # Shift labels to be off by 1 from the logits.
+        # Padding added at the end so we dont need to slice the input.
+        labels = tokens[1:].copy()
+        labels.append(CROSS_ENTROPY_IGNORE_IDX)
 
         return {"tokens": tokens, "labels": labels}
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

@felipemello1 discovered that how we compute our shifted labels in the [recipe](https://github.com/pytorch/torchtune/blob/1075d9cddfd28d5f1d4ab4e154af6fa80d537fa5/recipes/full_finetune_single_device.py#L642) breaks when we do packed training. Instead of shifting the whole sequence over one and then appending an ignore token at the end of the whole packed sequence, we need to do it on the individual sequences before packing.

This would only affect a single token at each boundary, so it's unclear how much it affected performance in practice. 

#### Changelog
What are the changes made in this PR?
* Updated 10 sft based recipes `git grep hstack -> 10 recipes (full, lora, qat, kd, dev)`
* For each recipe removed ignore_index_cache and label shift logic
* Updated SFTDataset and TextCompletionDataset to handle shifting the labels
* Updated 7 dataset unit tests to have correct exepected_labels

#### Test plan
- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

To compare loss I ran `tune run full_finetune_single_device --config llama3_2/1B_full_single_device tokenizer.max_seq_len=8092 dataset.packed=True compile=True optimizer=torch.optim.AdamW metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project="Fix Packed"` on main and on this branch.

<img width="1652" alt="Screenshot 2025-04-18 at 4 58 33 PM" src="https://github.com/user-attachments/assets/86da511b-ede9-4fe0-b550-d364e97cf938" />

The bug doesn't seem to have made a noticeable impact on Alpaca loss. 