### PR TITLE
bump version check in 2d parallel loss test

### DIFF
--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -130,7 +130,7 @@ class TestFullFinetuneDistributedRecipe:
         )
 
     @pytest.mark.skipif(
-        torch.__version__ < "2.7.0", reason="2D parallel test requires PyTorch >= 2.7"
+        torch.__version__ < "2.8.0", reason="2D parallel test requires PyTorch >= 2.8"
     )
     @pytest.mark.integration_test
     @pytest.mark.parametrize(


### PR DESCRIPTION
Shortest-lived fix of our CI ever..

I was a bit lazy and rather than finding the exact nightly where all the appropriate ops were implemented in PyTorch core to support our 2D parallel implementation I just used 2.7 as a proxy. Now that 2.7 is out, it's clear that wasn't sufficient. The tests do pass on nightlies (at least after 4/7, which is my current local env). So I am gonna be a bit lazy again and just bump the check to 2.8. If someone wants to find the exact nightly and do this properly that'd be even better.