### PR TITLE
Revert change from MultiProcessTestCase to FSDPTest

### DIFF
--- a/tests/torchtune/modules/peft/test_dora.py
+++ b/tests/torchtune/modules/peft/test_dora.py
@@ -288,7 +288,6 @@ class TestDistributedDoRALinear(FSDPTest):
 
     @gpu_test(gpu_count=2)
     def test_dora_distributed_init(self):
-        print("HEY HI {self.rank")
         torch.cuda.set_device(f"cuda:{self.rank}")
         self.run_subtests(
             {
@@ -299,7 +298,6 @@ class TestDistributedDoRALinear(FSDPTest):
 
     def _test_dora_distributed_init(self, load_dora_weights):
         rank = self.rank
-        print(f"HI IN THE TEST {rank}")
         is_rank_zero = rank == 0
         device = f"cuda:{rank}"
         layers = ["w1", "w2", "w3"]

--- a/tests/torchtune/modules/peft/test_dora.py
+++ b/tests/torchtune/modules/peft/test_dora.py
@@ -16,8 +16,7 @@ from torch import nn
 from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._tensor import DTensor, Replicate
 
-# from torch.testing._internal.common_fsdp import FSDPTest
-from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_fsdp import FSDPTest
 from torchao.dtypes.nf4tensor import NF4Tensor, to_nf4
 from torchtune import training
 from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
@@ -275,7 +274,7 @@ class TestDoRALinear:
             dora_linear.initialize_dora_magnitude()
 
 
-class TestDistributedDoRALinear(MultiProcessTestCase):
+class TestDistributedDoRALinear(FSDPTest):
     @property
     def world_size(self) -> int:
         return 2
@@ -289,6 +288,7 @@ class TestDistributedDoRALinear(MultiProcessTestCase):
 
     @gpu_test(gpu_count=2)
     def test_dora_distributed_init(self):
+        print("HEY HI {self.rank")
         torch.cuda.set_device(f"cuda:{self.rank}")
         self.run_subtests(
             {
@@ -299,6 +299,7 @@ class TestDistributedDoRALinear(MultiProcessTestCase):
 
     def _test_dora_distributed_init(self, load_dora_weights):
         rank = self.rank
+        print(f"HI IN THE TEST {rank}")
         is_rank_zero = rank == 0
         device = f"cuda:{rank}"
         layers = ["w1", "w2", "w3"]

--- a/tests/torchtune/training/test_distributed.py
+++ b/tests/torchtune/training/test_distributed.py
@@ -19,8 +19,8 @@ from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     CheckpointWrapper,
 )
-from torch.testing._internal.common_distributed import MultiProcessTestCase
-from torch.testing._internal.common_fsdp import MLP
+
+from torch.testing._internal.common_fsdp import FSDPTest, MLP
 from torchao.dtypes.nf4tensor import NF4Tensor
 from torchtune import modules, training
 from torchtune.models.llama2._component_builders import lora_llama2
@@ -121,7 +121,7 @@ def _get_n_lora_and_tformer_layers(model):
     return num_lora_ab, num_transformer_layers
 
 
-class TestFullyShardState(MultiProcessTestCase):
+class TestFullyShardState(FSDPTest):
     @property
     def world_size(self) -> int:
         return 2
@@ -388,7 +388,7 @@ class TestFullyShardState(MultiProcessTestCase):
         return result[0]
 
 
-class TestTensorParalell(MultiProcessTestCase):
+class TestTensorParalell(FSDPTest):
     @property
     def world_size(self) -> int:
         return 2


### PR DESCRIPTION
Pointed out by @iamzainhuda that these tests are actually skipping. Confirmed locally that switching back to FSDPTest causes them to execute again