### PR TITLE
Save LoRA Llama4 checkpoints

### DIFF
--- a/recipes/configs/llama4/scout_17B_16E_lora.yaml
+++ b/recipes/configs/llama4/scout_17B_16E_lora.yaml
@@ -42,6 +42,7 @@ checkpointer:
   recipe_checkpoint: null
   output_dir: ${output_dir}
   model_type: LLAMA4
+save_adapter_weights_only: True # use this for faster checkpoint save
 resume_from_checkpoint: False
 
 # Dataset

--- a/recipes/configs/llama4/scout_17B_16E_lora.yaml
+++ b/recipes/configs/llama4/scout_17B_16E_lora.yaml
@@ -66,7 +66,7 @@ lr_scheduler:
   _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
   num_warmup_steps: 100
 loss:
-  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
+  _component_: torchtune.modules.loss.LinearCrossEntropyLoss
 clip_grad_norm: null
 
 # cuda, cpu, rocm, xpu...

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -199,7 +199,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 )
         elif (
             self._enable_activation_checkpointing
-            and cfg.checkpointer.model_type != "LLAMA3_VISION"
+            and cfg.checkpointer._model_type != "LLAMA3_VISION"
         ):
             utils.log_rank_zero(
                 log,
@@ -284,6 +284,13 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             self._metric_logger.log_config(cfg)
 
         checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
+        if (
+            self._checkpointer._model_type == "LLAMA4"
+            and self._save_adapter_weights_only is False
+        ):
+            raise ValueError(
+                "For Llama4 training, you should set save_adapter_weights_only to True."
+            )
         self._compile = cfg.get("compile", False)
 
         self._model = self._setup_model(

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -199,7 +199,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                 )
         elif (
             self._enable_activation_checkpointing
-            and cfg.checkpointer._model_type != "LLAMA3_VISION"
+            and cfg.checkpointer.model_type != "LLAMA3_VISION"
         ):
             utils.log_rank_zero(
                 log,
@@ -283,14 +283,15 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             # log config with parameter override
             self._metric_logger.log_config(cfg)
 
-        checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
         if (
-            self._checkpointer._model_type == "LLAMA4"
+            cfg.checkpointer.model_type == "LLAMA4"
             and self._save_adapter_weights_only is False
         ):
             raise ValueError(
                 "For Llama4 training, you should set save_adapter_weights_only to True."
             )
+
+        checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
         self._compile = cfg.get("compile", False)
 
         self._model = self._setup_model(

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -921,10 +921,10 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     training.ADAPTER_KEY
                 ] = convert_weights.tune_to_peft_adapter_weights(
                     state_dict[training.ADAPTER_KEY],
-                    num_heads=config["text_config"]["num_attention_heads"],
-                    num_kv_heads=config["text_config"]["num_key_value_heads"],
-                    dim=config["text_config"]["hidden_size"],
-                    head_dim=config["text_config"].get("head_dim", None),
+                    num_heads=config["num_attention_heads"],
+                    num_kv_heads=config["num_key_value_heads"],
+                    dim=config["hidden_size"],
+                    head_dim=config.get("head_dim", None),
                 )
                 output_path = os.path.join(
                     self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -907,15 +907,19 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 logger.warning(
                     "Saving Llama3.2 Vision adapter weights to PEFT format is not supported, saving to torchtune format instead"
                 )
+            elif self._model_type == ModelType.LLAMA4:
+                logger.warning(
+                    "Saving Llama4 adapter weights to PEFT format is not supported, saving to torchtune format instead"
+                )
             else:
                 state_dict[
                     training.ADAPTER_KEY
                 ] = convert_weights.tune_to_peft_adapter_weights(
                     state_dict[training.ADAPTER_KEY],
-                    num_heads=self._config["num_attention_heads"],
-                    num_kv_heads=self._config["num_key_value_heads"],
-                    dim=self._config["hidden_size"],
-                    head_dim=self._config.get("head_dim", None),
+                    num_heads=self._config["text_config"]["num_attention_heads"],
+                    num_kv_heads=self._config["text_config"]["num_key_value_heads"],
+                    dim=self._config["text_config"]["hidden_size"],
+                    head_dim=self._config["text_config"].get("head_dim", None),
                 )
                 output_path = os.path.join(
                     self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -912,14 +912,19 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                     "Saving Llama4 adapter weights to PEFT format is not supported, saving to torchtune format instead"
                 )
             else:
+                config = (
+                    self._config["text_config"]
+                    if "text_config" in self._config
+                    else self._config
+                )
                 state_dict[
                     training.ADAPTER_KEY
                 ] = convert_weights.tune_to_peft_adapter_weights(
                     state_dict[training.ADAPTER_KEY],
-                    num_heads=self._config["text_config"]["num_attention_heads"],
-                    num_kv_heads=self._config["text_config"]["num_key_value_heads"],
-                    dim=self._config["text_config"]["hidden_size"],
-                    head_dim=self._config["text_config"].get("head_dim", None),
+                    num_heads=config["text_config"]["num_attention_heads"],
+                    num_kv_heads=config["text_config"]["num_key_value_heads"],
+                    dim=config["text_config"]["hidden_size"],
+                    head_dim=config["text_config"].get("head_dim", None),
                 )
                 output_path = os.path.join(
                     self._output_dir, f"epoch_{epoch}", ADAPTER_MODEL_FNAME


### PR DESCRIPTION
Fixes #2643

We need some special handling to save checkpoints of MoE models. For now we only support running with `save_adapter_weights_only=True`, which we make default in the config. Since PEFT does not (as far as I can tell) support applying LoRA to the equivalent of our `GroupedExperts` layer, we do not support any PEFT integration for Llama4, and just save the adapter weights in the torchtune format.


### Test plan:

```
tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora \
max_steps_per_epoch=20 epochs=2 metric_logger=torchtune.training.metric_logging.WandBLogger \
metric_logger.project=testing-lora-ckpts metric_logger.name=first-run
```

Then 

```
tune run --nproc_per_node 8 lora_finetune_distributed --config llama4/scout_17B_16E_lora \
max_steps_per_epoch=20 epochs=2 metric_logger=torchtune.training.metric_logging.WandBLogger \
metric_logger.project=testing-lora-ckpts metric_logger.name=second-run resume_from_checkpoint=True \
checkpointer.adapter_checkpoint=epoch_0/adapter_model.pt
```
<img width="1367" alt="Screenshot 2025-04-30 at 12 04 10 PM" src="https://github.com/user-attachments/assets/80d1e38f-ac40-45d2-8ccb-6aaaabe58bc3" />


### Appendix: merging LoRA weights for 3D parameters

(This is not currently relevant because we error when `save_adapter_weights_only=False` for Llama4 due to checkpoint save timeouts. However, we still add the handling in this PR, which has been tested on a smaller model. The approach follows.)

For non-MoE params: LoRA A's weight's shape is `(rank, in_dim)` and LoRA B's weight's shape is `(out_dim, rank)`.

For MoE grouped experts layers: LoRA A weight's shape is `(num_experts, in_dim, rank)` and LoRA B weight's shape is `(num_experts, rank, out_dim)`.

So whereas for vanilla LoRA layers we update `base_weight += (alpha / rank) * lora_b_weight @ lora_a_weight`, for grouped experts layers we need to update `base_weight += (alpha / rank) * (lora_b_weight.tranpose(1,2) @ lora_a_weight.transpose(1,2)).transpose(1,2)`, where in the grouped experts case we are using the bmm version of the @ operator.