### PR TITLE
Reduce RAM usage when loading state dict for distributed workload

### DIFF
--- a/tests/torchtune/modules/peft/test_dora.py
+++ b/tests/torchtune/modules/peft/test_dora.py
@@ -357,6 +357,7 @@ class TestDistributedDoRALinear(MultiProcessTestCase):
                 ffn,
                 adapter_state_dict,
                 device,
+                release_sd=False,
             )
             if is_rank_zero:
                 for dora_linear in [ffn.w1, ffn.w2, ffn.w3]:

--- a/tests/torchtune/modules/peft/test_dora.py
+++ b/tests/torchtune/modules/peft/test_dora.py
@@ -386,6 +386,7 @@ class TestDistributedDoRALinear(MultiProcessTestCase):
             ffn,
             base_model_state_dict,
             device,
+            release_sd=False,
         )
 
         # After this, everything should be off meta device

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -399,6 +399,7 @@ def load_from_full_model_state_dict(
             if cpu_offload:
                 sharded_tensor = sharded_tensor.cpu()
             sharded_sd[param_name] = nn.Parameter(sharded_tensor)
+            full_sd[param_name] = None
         # choose `assign=True` since we cannot call `copy_` on meta tensor
         return model.load_state_dict(sharded_sd, strict=strict, assign=True)
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

As mentioned in https://github.com/pytorch/torchtune/issues/1318, the RAM usage is very high when loading state dict without DCP `set_model_state_dict` api at the moment. Model checkpoints are loaded using the mmap trick at first. Files are mapped and tensors are not actually loaded into RAM until being copied inside this loop. 
https://github.com/pytorch/torchtune/blob/1823abd22558a1e74228bf08e21dccbbca33f661/torchtune/training/_distributed.py#L342 `full_tensor` are stored in `full_sd` so the memory will not be released after used. As a result, each process will have a full state dict in its cpu memory at the end of the loop, which's huge for large models launched with many processes. 


#### Changelog
What are the changes made in this PR?
* Add an option to release `full_tensor` from RAM at the end of each iteration instead of having the full state dict in RAM (for each process).

#### Test plan
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)

#### UX
- [x] I did not change any public API
