### PR TITLE
Resolve #2636

### DIFF
--- a/tests/torchtune/models/llama3_2_vision/test_llama_vision_lora.py
+++ b/tests/torchtune/models/llama3_2_vision/test_llama_vision_lora.py
@@ -12,7 +12,7 @@ from torchtune.models.llama3_2_vision._component_builders import (
     lora_llama3_2_vision_encoder,
 )
 from torchtune.modules.model_fusion import DeepFusionModel
-from torchtune.modules.peft import get_adapter_params, LoRATrainable
+from torchtune.modules.peft import get_adapter_params, TrainableParams
 from torchtune.training.seed import set_seed
 
 EMBED_DIM = 128
@@ -36,8 +36,8 @@ def lora_llama3_2_vision(
     fusion_type,
 ) -> DeepFusionModel:
     encoder = lora_llama3_2_vision_encoder(
-        encoder_lora=encoder_type == LoRATrainable.LORA,
-        fusion_lora=fusion_type == LoRATrainable.LORA,
+        encoder_lora=encoder_type == TrainableParams.LORA,
+        fusion_lora=fusion_type == TrainableParams.LORA,
         lora_attn_modules=LORA_ATTN_MODULES,
         apply_lora_to_mlp=False,
         apply_lora_to_output=False,
@@ -58,8 +58,8 @@ def lora_llama3_2_vision(
         quantize_base=False,
     )
     decoder = lora_llama3_2_vision_decoder(
-        decoder_lora=decoder_type == LoRATrainable.LORA,
-        fusion_lora=fusion_type == LoRATrainable.LORA,
+        decoder_lora=decoder_type == TrainableParams.LORA,
+        fusion_lora=fusion_type == TrainableParams.LORA,
         lora_attn_modules=LORA_ATTN_MODULES,
         apply_lora_to_mlp=False,
         apply_lora_to_output=False,
@@ -83,9 +83,9 @@ def lora_llama3_2_vision(
     return DeepFusionModel(
         encoder=encoder,
         decoder=decoder,
-        encoder_trainable=encoder_type != LoRATrainable.FROZEN,
-        decoder_trainable=decoder_type != LoRATrainable.FROZEN,
-        fusion_trainable=fusion_type != LoRATrainable.FROZEN,
+        encoder_trainable=encoder_type != TrainableParams.FROZEN,
+        decoder_trainable=decoder_type != TrainableParams.FROZEN,
+        fusion_trainable=fusion_type != TrainableParams.FROZEN,
     )
 
 
@@ -101,17 +101,17 @@ class TestLlamaVisionLora:
 
     def test_lora_args(self):
         model = lora_llama3_2_vision(
-            LoRATrainable.LORA,
-            LoRATrainable.FROZEN,
-            LoRATrainable.FROZEN,
+            TrainableParams.LORA,
+            TrainableParams.FROZEN,
+            TrainableParams.FROZEN,
         )
         encoder = set(get_adapter_params(model).keys())
         assert len(encoder) == 32, "Only the clip encoder should be trainable."
 
         model = lora_llama3_2_vision(
-            LoRATrainable.FROZEN,
-            LoRATrainable.LORA,
-            LoRATrainable.FROZEN,
+            TrainableParams.FROZEN,
+            TrainableParams.LORA,
+            TrainableParams.FROZEN,
         )
         decoder = set(get_adapter_params(model).keys())
         assert (
@@ -119,9 +119,9 @@ class TestLlamaVisionLora:
         ), "Only the decoder self attention layers should be trainable."
 
         model = lora_llama3_2_vision(
-            LoRATrainable.FROZEN,
-            LoRATrainable.FROZEN,
-            LoRATrainable.LORA,
+            TrainableParams.FROZEN,
+            TrainableParams.FROZEN,
+            TrainableParams.LORA,
         )
         fusion = set(get_adapter_params(model).keys())
         assert len(fusion) == 48, "Only the fusion layers should be trainable."
@@ -133,9 +133,9 @@ class TestLlamaVisionLora:
 
     def test_forward(self, inputs):
         model = lora_llama3_2_vision(
-            LoRATrainable.LORA,
-            LoRATrainable.LORA,
-            LoRATrainable.LORA,
+            TrainableParams.LORA,
+            TrainableParams.LORA,
+            TrainableParams.LORA,
         )
         fixed_init_model(model, min_val=-0.25, max_val=0.5)
         tokens = torch.randint(0, VOCAB_SIZE, (BSZ, SEQ_LEN))

--- a/torchtune/models/llama3_2_vision/_model_builders.py
+++ b/torchtune/models/llama3_2_vision/_model_builders.py
@@ -18,7 +18,7 @@ from torchtune.models.llama3_2_vision._component_builders import (  # noqa
 
 from torchtune.models.llama3_2_vision._transform import Llama3VisionTransform
 from torchtune.modules.model_fusion import DeepFusionModel
-from torchtune.modules.peft import LORA_ATTN_MODULES, LoRATrainable
+from torchtune.modules.peft import LORA_ATTN_MODULES, TrainableParams
 
 
 def llama3_2_vision_transform(
@@ -162,17 +162,17 @@ def lora_llama3_2_vision_11b(
         a subset of the attention projections in each layer.
 
     """
-    decoder_type = LoRATrainable(decoder_trainable.lower())
-    encoder_type = LoRATrainable(encoder_trainable.lower())
-    fusion_type = LoRATrainable(fusion_trainable.lower())
-    assert LoRATrainable.FULL not in [
+    decoder_type = TrainableParams(decoder_trainable.lower())
+    encoder_type = TrainableParams(encoder_trainable.lower())
+    fusion_type = TrainableParams(fusion_trainable.lower())
+    assert TrainableParams.FULL not in [
         decoder_type,
         encoder_type,
         fusion_type,
     ], "We've temporarily removed support for mixed LoRA + Full Finetuning yet. Please don't use the 'full' option and use llama3_2_vision_11b if you need full finetuning"
     encoder = lora_llama3_2_vision_encoder(
-        encoder_lora=encoder_type == LoRATrainable.LORA,
-        fusion_lora=fusion_type == LoRATrainable.LORA,
+        encoder_lora=encoder_type == TrainableParams.LORA,
+        fusion_lora=fusion_type == TrainableParams.LORA,
         lora_attn_modules=lora_attn_modules,
         apply_lora_to_mlp=apply_lora_to_mlp,
         apply_lora_to_output=apply_lora_to_output,
@@ -196,8 +196,8 @@ def lora_llama3_2_vision_11b(
         scaler_block_size=200 if quantize_base else None,
     )
     decoder = lora_llama3_2_vision_decoder(
-        decoder_lora=decoder_type == LoRATrainable.LORA,
-        fusion_lora=fusion_type == LoRATrainable.LORA,
+        decoder_lora=decoder_type == TrainableParams.LORA,
+        fusion_lora=fusion_type == TrainableParams.LORA,
         lora_attn_modules=lora_attn_modules,
         apply_lora_to_mlp=apply_lora_to_mlp,
         apply_lora_to_output=apply_lora_to_output,
@@ -221,9 +221,9 @@ def lora_llama3_2_vision_11b(
     return DeepFusionModel(
         encoder=encoder,
         decoder=decoder,
-        encoder_trainable=encoder_type != LoRATrainable.FROZEN,
-        decoder_trainable=decoder_type != LoRATrainable.FROZEN,
-        fusion_trainable=fusion_type != LoRATrainable.FROZEN,
+        encoder_trainable=encoder_type != TrainableParams.FROZEN,
+        decoder_trainable=decoder_type != TrainableParams.FROZEN,
+        fusion_trainable=fusion_type != TrainableParams.FROZEN,
     )
 
 
@@ -325,17 +325,17 @@ def lora_llama3_2_vision_90b(
         a subset of the attention projections in each layer.
 
     """
-    decoder_type = LoRATrainable(decoder_trainable.lower())
-    encoder_type = LoRATrainable(encoder_trainable.lower())
-    fusion_type = LoRATrainable(fusion_trainable.lower())
-    assert LoRATrainable.FULL not in [
+    decoder_type = TrainableParams(decoder_trainable.lower())
+    encoder_type = TrainableParams(encoder_trainable.lower())
+    fusion_type = TrainableParams(fusion_trainable.lower())
+    assert TrainableParams.FULL not in [
         decoder_type,
         encoder_type,
         fusion_type,
     ], "We've temporarily removed support for mixed LoRA + Full Finetuning yet. Please don't use the 'full' option and use llama3_2_vision_90b if you need full finetuning"
     encoder = lora_llama3_2_vision_encoder(
-        encoder_lora=encoder_type == LoRATrainable.LORA,
-        fusion_lora=fusion_type == LoRATrainable.LORA,
+        encoder_lora=encoder_type == TrainableParams.LORA,
+        fusion_lora=fusion_type == TrainableParams.LORA,
         lora_attn_modules=lora_attn_modules,
         apply_lora_to_mlp=apply_lora_to_mlp,
         apply_lora_to_output=apply_lora_to_output,
@@ -359,8 +359,8 @@ def lora_llama3_2_vision_90b(
         scaler_block_size=200 if quantize_base else None,
     )
     decoder = lora_llama3_2_vision_decoder(
-        decoder_lora=decoder_type == LoRATrainable.LORA,
-        fusion_lora=fusion_type == LoRATrainable.LORA,
+        decoder_lora=decoder_type == TrainableParams.LORA,
+        fusion_lora=fusion_type == TrainableParams.LORA,
         lora_attn_modules=lora_attn_modules,
         apply_lora_to_mlp=apply_lora_to_mlp,
         apply_lora_to_output=apply_lora_to_output,
@@ -384,9 +384,9 @@ def lora_llama3_2_vision_90b(
     return DeepFusionModel(
         encoder=encoder,
         decoder=decoder,
-        encoder_trainable=encoder_type != LoRATrainable.FROZEN,
-        decoder_trainable=decoder_type != LoRATrainable.FROZEN,
-        fusion_trainable=fusion_type != LoRATrainable.FROZEN,
+        encoder_trainable=encoder_type != TrainableParams.FROZEN,
+        decoder_trainable=decoder_type != TrainableParams.FROZEN,
+        fusion_trainable=fusion_type != TrainableParams.FROZEN,
     )
 
 

--- a/torchtune/models/llama4/_model_builders.py
+++ b/torchtune/models/llama4/_model_builders.py
@@ -17,7 +17,7 @@ from torchtune.models.llama4._tokenizer import LLAMA4_SPECIAL_TOKENS
 from torchtune.models.llama4._transform import Llama4Transform
 
 from torchtune.modules.model_fusion import EarlyFusionModel
-from torchtune.modules.peft import LORA_ATTN_MODULES, LoRATrainable
+from torchtune.modules.peft import LORA_ATTN_MODULES, TrainableParams
 from torchtune.utils import torch_version_ge
 
 """
@@ -253,10 +253,10 @@ def lora_llama4_scout_17b_16e(
     Returns:
         EarlyFusionModel: Instantiation of a 17B Llama4 MOE LoRA model with encoders.
     """
-    decoder_type = LoRATrainable(decoder_trainable.lower())
-    vision_encoder_type = LoRATrainable(encoder_trainable.lower())
-    fusion_type = LoRATrainable(fusion_trainable.lower())
-    assert LoRATrainable.FULL not in [
+    decoder_type = TrainableParams(decoder_trainable.lower())
+    vision_encoder_type = TrainableParams(encoder_trainable.lower())
+    fusion_type = TrainableParams(fusion_trainable.lower())
+    assert TrainableParams.FULL not in [
         decoder_type,
         vision_encoder_type,
         fusion_type,
@@ -265,8 +265,8 @@ def lora_llama4_scout_17b_16e(
     decoder_embed_dim = 5120
 
     vision_encoder = lora_llama4_vision_encoder(
-        encoder_lora=vision_encoder_type == LoRATrainable.LORA,
-        fusion_lora=fusion_type == LoRATrainable.LORA,
+        encoder_lora=vision_encoder_type == TrainableParams.LORA,
+        fusion_lora=fusion_type == TrainableParams.LORA,
         lora_attn_modules=lora_attn_modules,
         apply_lora_to_mlp=apply_lora_to_mlp,
         apply_lora_to_output=apply_lora_to_output,
@@ -287,7 +287,7 @@ def lora_llama4_scout_17b_16e(
     )
 
     decoder = lora_llama4_decoder(
-        decoder_lora=decoder_type == LoRATrainable.LORA,
+        decoder_lora=decoder_type == TrainableParams.LORA,
         lora_attn_modules=lora_attn_modules,
         apply_lora_to_mlp=apply_lora_to_mlp,
         apply_lora_to_output=apply_lora_to_output,
@@ -319,8 +319,8 @@ def lora_llama4_scout_17b_16e(
             "vision": LLAMA4_SPECIAL_TOKENS["<|patch|>"],
         },
         encoders_trainable={
-            "vision": encoder_trainable != LoRATrainable.FROZEN,
+            "vision": encoder_trainable != TrainableParams.FROZEN,
         },
-        decoder_trainable=decoder_trainable != LoRATrainable.FROZEN,
-        fusion_trainable=fusion_trainable != LoRATrainable.FROZEN,
+        decoder_trainable=decoder_trainable != TrainableParams.FROZEN,
+        fusion_trainable=fusion_trainable != TrainableParams.FROZEN,
     )

--- a/torchtune/modules/peft/__init__.py
+++ b/torchtune/modules/peft/__init__.py
@@ -16,7 +16,7 @@ from ._utils import (  # noqa
     validate_missing_and_unexpected_for_lora,
 )
 from .dora import DoRALinear
-from .lora import LoRALinear, LoRATrainable, QATLoRALinear
+from .lora import LoRALinear, TrainableParams, QATLoRALinear
 
 
 __all__ = [
@@ -31,5 +31,5 @@ __all__ = [
     "get_adapter_state_dict",
     "get_merged_lora_ckpt",
     "get_lora_module_names",
-    "LoRATrainable",
+    "TrainableParams",
 ]

--- a/torchtune/modules/peft/__init__.py
+++ b/torchtune/modules/peft/__init__.py
@@ -16,7 +16,7 @@ from ._utils import (  # noqa
     validate_missing_and_unexpected_for_lora,
 )
 from .dora import DoRALinear
-from .lora import LoRALinear, TrainableParams, QATLoRALinear
+from .lora import LoRALinear, QATLoRALinear, TrainableParams
 
 
 __all__ = [

--- a/torchtune/modules/peft/lora.py
+++ b/torchtune/modules/peft/lora.py
@@ -17,7 +17,7 @@ from torchtune.modules.low_precision import _register_nf4_dispatch_ops  # noqa: 
 from torchtune.modules.peft import AdapterModule
 
 
-class LoRATrainable(Enum):
+class TrainableParams(Enum):
     FULL = "full"
     LORA = "lora"
     FROZEN = "frozen"


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* #2636

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
