### PR TITLE
Decouple rl test job

### DIFF
--- a/.github/workflows/rl_test.yaml
+++ b/.github/workflows/rl_test.yaml
@@ -1,13 +1,21 @@
 name: GPU tests
 
 on:
-  schedule:
-    # Runs at midnight every day
-    - cron:  '0 0 * * *'
   push:
-    branches: [ main ]
+    paths:
+      - 'torchtune/recipes/dev/**grpo**'
+      - 'torchtune/recipes/configs/dev/**grpo**'
+      - 'torchtune/dev/rl/**'
+      - 'torchtune/dev/grpo/**'
   pull_request:
-  workflow_dispatch:
+    paths:
+      - 'torchtune/recipes/dev/**grpo**'
+      - 'torchtune/recipes/configs/dev/**grpo**'
+      - 'torchtune/dev/rl/**'
+      - 'torchtune/dev/grpo/**'
+  schedule:
+    # Runs at midnight evvery day
+    - cron: '0 0 * * *'
 
 concurrency:
   group: gpu-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
@@ -54,7 +62,10 @@ jobs:
         run: python -m pip install lm-eval>=0.4.5
       - name: Install the torchtune library with dev options
         run: python -m pip install -e ".[dev]"
+      - name: Install the torchtune libary with async_rl options
+        if: ${{ matrix.python-version != '3.9' }}
+        run:  python -m pip install -e ".[async_rl]"
       - name: Run recipe and unit tests with coverage
-        run: pytest tests --ignore tests/torchtune/modules/_export --with-integration --cov=. --cov-report=xml --durations=20 -vv
+        run: pytest tests --ignore tests/torchtune/modules/_export --with-integration -m rl_test --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/rl_test.yaml
+++ b/.github/workflows/rl_test.yaml
@@ -66,6 +66,6 @@ jobs:
         if: ${{ matrix.python-version != '3.9' }}
         run:  python -m pip install -e ".[async_rl]"
       - name: Run recipe and unit tests with coverage
-        run: pytest tests --ignore tests/torchtune/modules/_export --with-integration -m rl_test --cov=. --cov-report=xml --durations=20 -vv
+        run: pytest tests --ignore tests/torchtune/modules/_export --with-integration --run-rl-tests --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/rl_test.yaml
+++ b/.github/workflows/rl_test.yaml
@@ -66,6 +66,6 @@ jobs:
         if: ${{ matrix.python-version != '3.9' }}
         run:  python -m pip install -e ".[async_rl]"
       - name: Run recipe and unit tests with coverage
-        run: pytest tests --ignore tests/torchtune/modules/_export --with-integration --run-rl-tests --cov=. --cov-report=xml --durations=20 -vv
+        run: pytest tests/torchtune/dev/rl tests/recipes/dev --run-rl-tests --with-integration --cov=. --cov-report=xml --durations=20 -vv
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,9 @@ Whenever running tests in torchtune, favor using the command line flags as much 
 Note that the above flags can be combined with other pytest flags, so e.g. `pytest tests -m integration_test -k 'test_loss'` will run only recipe tests matching the substring `test_loss`.
 
 > [!NOTE]
+> torchtune now contains a [prototype for an asynchronous implementation of GRPO](recipes/dev/async_grpo.md), complete with corresponding tests. Since this prototype brings with it additional dependencies, we do not run any of our async RL tests by default. To run an async RL test, you should append `--run-rl-tests` to your pytest command. E.g. `pytest --with-integration --run-rl-tests tests/recipes/dev/test_async_grpo_full_finetune_distributed.py`.
+
+> [!NOTE]
 > Expected reference values for many of our tests have been calculated on Intel-based CPUs, or CUDA-based GPUs. Precision differences when testing on other hardware may cause certain tests to fail due to calculated values falling outside the configured tolerance limits. These tests may be skipped based on detected hardware (e.g. for [MPS](https://github.com/pytorch/torchtune/blob/ca95345b732d41bab7261d208cd5c860a2f76a5a/tests/test_utils.py#L345)).
 
 &nbsp;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,3 +122,9 @@ def pytest_addoption(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Silence progress bar when fetching assets from S3",
     )
+    parser.addoption(
+        "--run-rl-tests",
+        action="store_true",
+        default=False,
+        help="Run RL tests",
+    )

--- a/tests/recipes/dev/test_async_grpo_full_finetune_distributed.py
+++ b/tests/recipes/dev/test_async_grpo_full_finetune_distributed.py
@@ -58,6 +58,7 @@ class TestAsyncGRPOFullFinetuneDistributedRecipe:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=4)
     @skip_if_lt_python_310()
+    @pytest.mark.rl_test
     def test_basic_run(self, tmpdir, monkeypatch):
         """Test that the recipe runs without errors with minimal configuration."""
         import ray

--- a/tests/recipes/dev/test_async_grpo_full_finetune_distributed.py
+++ b/tests/recipes/dev/test_async_grpo_full_finetune_distributed.py
@@ -17,6 +17,7 @@ from tests.test_utils import (
     gen_log_file_name,
     get_loss_values_from_metric_logger,
     gpu_test,
+    rl_test,
     skip_if_lt_python_310,
     TOKENIZER_PATHS,
 )
@@ -58,7 +59,7 @@ class TestAsyncGRPOFullFinetuneDistributedRecipe:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=4)
     @skip_if_lt_python_310()
-    @pytest.mark.rl_test
+    @rl_test()
     def test_basic_run(self, tmpdir, monkeypatch):
         """Test that the recipe runs without errors with minimal configuration."""
         import ray

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -379,3 +379,10 @@ def mps_ignored_test() -> bool:
         reason="Test skipped due to torch being compiled with MPS"
         "see https://github.com/pytorch/torchtune/issues/1707 for more information",
     )
+
+
+def rl_test() -> bool:
+    return pytest.mark.skipif(
+        "not config.getoption('--run-rl-tests')",
+        reason="Only run when --run-rl-tests is given",
+    )

--- a/tests/torchtune/dev/rl/workers/test_postprocessing.py
+++ b/tests/torchtune/dev/rl/workers/test_postprocessing.py
@@ -100,6 +100,7 @@ class TestPostProcessingWorker:
     @gpu_test(gpu_count=1)
     @pytest.mark.skipif(not _has_ray, reason="requires ray")
     @skip_if_lt_python_310()
+    @pytest.mark.rl_test
     def test_run(self, cfg, log_file):
         ray.init(num_cpus=19, num_gpus=1)
 

--- a/tests/torchtune/dev/rl/workers/test_postprocessing.py
+++ b/tests/torchtune/dev/rl/workers/test_postprocessing.py
@@ -27,7 +27,7 @@ else:
 
 import torch
 from omegaconf import OmegaConf
-from tests.test_utils import gen_log_file_name, gpu_test, skip_if_lt_python_310
+from tests.test_utils import gen_log_file_name, gpu_test, rl_test, skip_if_lt_python_310
 
 grpo_samples = 4
 max_generated_tokens = 32
@@ -100,7 +100,7 @@ class TestPostProcessingWorker:
     @gpu_test(gpu_count=1)
     @pytest.mark.skipif(not _has_ray, reason="requires ray")
     @skip_if_lt_python_310()
-    @pytest.mark.rl_test
+    @rl_test()
     def test_run(self, cfg, log_file):
         ray.init(num_cpus=19, num_gpus=1)
 

--- a/tests/torchtune/rl/test_parameter_server.py
+++ b/tests/torchtune/rl/test_parameter_server.py
@@ -134,6 +134,7 @@ inference:
 
     @pytest.mark.integration_test
     @gpu_test(gpu_count=2)
+    @pytest.mark.rl_test
     def test_receive_from_trainer(self) -> None:
         import ray
         from torchtune.dev.rl.workers import VLLMParameterServer
@@ -169,6 +170,7 @@ inference:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=4)
     @pytest.mark.parametrize("tp_size", (1, 2))
+    @pytest.mark.rl_test
     def test_send_to_generator(self, tp_size) -> None:
         import ray
 

--- a/tests/torchtune/rl/test_parameter_server.py
+++ b/tests/torchtune/rl/test_parameter_server.py
@@ -25,7 +25,7 @@ from typing import Dict
 import pytest
 import torch
 from omegaconf import OmegaConf
-from tests.test_utils import gpu_test, skip_if_lt_python_310
+from tests.test_utils import gpu_test, rl_test, skip_if_lt_python_310
 
 
 @remote(num_cpus=1, num_gpus=1)
@@ -134,7 +134,7 @@ inference:
 
     @pytest.mark.integration_test
     @gpu_test(gpu_count=2)
-    @pytest.mark.rl_test
+    @rl_test()
     def test_receive_from_trainer(self) -> None:
         import ray
         from torchtune.dev.rl.workers import VLLMParameterServer
@@ -170,7 +170,7 @@ inference:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=4)
     @pytest.mark.parametrize("tp_size", (1, 2))
-    @pytest.mark.rl_test
+    @rl_test()
     def test_send_to_generator(self, tp_size) -> None:
         import ray
 


### PR DESCRIPTION
Separating out our async RL tests into their own runner, which runs only under certain conditions.

We now have two GPU jobs:

`rl_test.yaml` runs only if any of the `dev/rl` or `dev/grpo` files are modified. It will run only our async RL tests, which now need to be decorated by `@rl_test()`. The YAML file currently assumes that any such tests live under `tests/recipes/dev/rl` or `tests/torchtune/dev/rl`. If we move our async RL tests or add any in a new location we will need to update the runner's pytest command to include them.

`gpu_test.yaml` runs all other tests (i.e. our full test suite prior to #2637) on every PR. 

For local pytest runs, async RL tests will be skipped by default. Any pytest command can be supplemented with the flag `--run-rl-tests` in order to run them. (Note that RL tests are a subset of integration tests, so you will also need to use either `-m integration_test` or `--with-integration` as well.)