### PR TITLE
Add add_end_token to Phi tokenizers #2480

### DIFF
--- a/tests/torchtune/models/phi3/test_phi3_tokenizer.py
+++ b/tests/torchtune/models/phi3/test_phi3_tokenizer.py
@@ -5,6 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
+import sys, os
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+print(sys.path)
 
 from tests.common import ASSETS
 from torchtune.data import Message
@@ -120,7 +125,7 @@ class TestPhi3MiniTokenizer:
                 "good conversation over coffee.",
             ),
         ]
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=False)
+        tokens, mask = tokenizer.tokenize_messages(messages, add_end_tokens=False)
 
         # Drop eos token
         expected_tokens = expected_tokens[:]
@@ -128,3 +133,18 @@ class TestPhi3MiniTokenizer:
         expected_mask = [True] * 86 + [False] * 126
         assert expected_tokens == tokens
         assert expected_mask == mask
+
+
+# obj = TestPhi3MiniTokenizer()
+# tokenizer = obj.tokenizer()
+# expected_tokens = [1, 32010, 323, 418, 202, 31, 128, 15, 120, 47, 88, 584, 23, 1665, 182, 9, 434, 295, 85, 4,
+#                     780, 47, 636, 9, 1094, 213, 23, 9, 69, 69, 164, 1153, 299, 35, 961, 132, 237, 7, 5, 761, 4,
+#                     12, 0, 313, 120, 47, 88, 584, 166, 493, 171, 54, 299, 9, 906, 244, 19, 186, 767, 303, 671,
+#                     92, 209, 24, 190, 52, 38, 4, 12, 0, 1243, 7, 69, 135, 213, 166, 32007, 32001, 6, 21, 45, 128,
+#                     71, 58, 38, 14, 10, 652, 35, 462, 101, 1306, 7, 341, 171, 20, 14, 127, 26, 652, 7, 10, 1268,
+#                     4, 6, 21, 45, 591, 9, 566, 22, 994, 913, 38, 20, 52, 24, 10, 1306, 734, 14, 71, 365, 1382, 7,
+#                     10, 801, 105, 88, 244, 985, 7, 4, 6, 21, 45, 9, 566, 126, 180, 11, 5, 1137, 7, 10, 1089, 151,
+#                     8, 1156, 213, 342, 7, 10, 384, 104, 54, 470, 4, 6, 21, 45, 287, 14, 33, 125, 135, 24, 101,
+#                     512, 66, 7, 28, 822, 15, 542, 69, 59, 110, 14, 365, 229, 7, 3, 36, 267, 36, 125, 135, 24,
+#                     101, 1503, 182, 9, 222, 1661, 191, 332, 92, 92, 24, 24, 4, 32007]
+# obj.test_tokenize_messages_drop_eos(obj.tokenizer, expected_tokens)

--- a/tests/torchtune/models/phi3/test_phi3_tokenizer.py
+++ b/tests/torchtune/models/phi3/test_phi3_tokenizer.py
@@ -5,11 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-import sys, os
-
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-
-print(sys.path)
 
 from tests.common import ASSETS
 from torchtune.data import Message
@@ -133,18 +128,3 @@ class TestPhi3MiniTokenizer:
         expected_mask = [True] * 86 + [False] * 126
         assert expected_tokens == tokens
         assert expected_mask == mask
-
-
-# obj = TestPhi3MiniTokenizer()
-# tokenizer = obj.tokenizer()
-# expected_tokens = [1, 32010, 323, 418, 202, 31, 128, 15, 120, 47, 88, 584, 23, 1665, 182, 9, 434, 295, 85, 4,
-#                     780, 47, 636, 9, 1094, 213, 23, 9, 69, 69, 164, 1153, 299, 35, 961, 132, 237, 7, 5, 761, 4,
-#                     12, 0, 313, 120, 47, 88, 584, 166, 493, 171, 54, 299, 9, 906, 244, 19, 186, 767, 303, 671,
-#                     92, 209, 24, 190, 52, 38, 4, 12, 0, 1243, 7, 69, 135, 213, 166, 32007, 32001, 6, 21, 45, 128,
-#                     71, 58, 38, 14, 10, 652, 35, 462, 101, 1306, 7, 341, 171, 20, 14, 127, 26, 652, 7, 10, 1268,
-#                     4, 6, 21, 45, 591, 9, 566, 22, 994, 913, 38, 20, 52, 24, 10, 1306, 734, 14, 71, 365, 1382, 7,
-#                     10, 801, 105, 88, 244, 985, 7, 4, 6, 21, 45, 9, 566, 126, 180, 11, 5, 1137, 7, 10, 1089, 151,
-#                     8, 1156, 213, 342, 7, 10, 384, 104, 54, 470, 4, 6, 21, 45, 287, 14, 33, 125, 135, 24, 101,
-#                     512, 66, 7, 28, 822, 15, 542, 69, 59, 110, 14, 365, 229, 7, 3, 36, 267, 36, 125, 135, 24,
-#                     101, 1503, 182, 9, 222, 1661, 191, 332, 92, 92, 24, 24, 4, 32007]
-# obj.test_tokenize_messages_drop_eos(obj.tokenizer, expected_tokens)

--- a/tests/torchtune/models/phi4/test_phi4_tokenizer.py
+++ b/tests/torchtune/models/phi4/test_phi4_tokenizer.py
@@ -42,7 +42,7 @@ class TestPhi4Tokenizer:
                 content="Yes, it is!",
             ),
         ]
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=True)
+        tokens, mask = tokenizer.tokenize_messages(messages, add_end_tokens=True)
 
         expected_mask = [True] * 20 + [False] * 9
         assert expected_tokens == tokens
@@ -62,7 +62,7 @@ class TestPhi4Tokenizer:
             ),
         ]
         tokens, mask = tokenizer.tokenize_messages(
-            messages, ignore_system_prompt=True, add_eos=True
+            messages, ignore_system_prompt=True, add_end_tokens=True
         )
 
         # fmt: off
@@ -91,7 +91,7 @@ class TestPhi4Tokenizer:
             ),
         ]
 
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=False)
+        tokens, mask = tokenizer.tokenize_messages(messages, add_end_tokens=False)
         expected_mask = [True] * 20 + [False] * 8
         # Drop eos token.
         assert expected_tokens[:-1] == tokens

--- a/torchtune/models/phi3/_tokenizer.py
+++ b/torchtune/models/phi3/_tokenizer.py
@@ -134,7 +134,7 @@ class Phi3MiniTokenizer(ModelTokenizer, Transform):
         self,
         messages: List[Message],
         *,
-        add_eos: bool = False,
+        add_end_tokens: bool = False,
         ignore_system_prompt: bool = False,
     ) -> Tuple[List[int], List[bool]]:
         r"""Tokenize a list of messages one at a time then concatenate them,
@@ -160,7 +160,7 @@ class Phi3MiniTokenizer(ModelTokenizer, Transform):
         Args:
             messages (List[Message]): A list of messages, each containing role, content,
                 and masked attributes.
-            add_eos (bool): Whether to append EOS after assistant message, default to False
+            add_end_tokens (bool): Whether to append EOS after assistant message, default to False
             ignore_system_prompt (bool): Whether to ignore system prompt, defaults to False.
 
         Raises:
@@ -235,7 +235,7 @@ class Phi3MiniTokenizer(ModelTokenizer, Transform):
             mask.extend([message.masked] * len(tokens))
 
             # If assistant message, append EOS at end
-            if end_of_turn and add_eos:
+            if end_of_turn and add_end_tokens:
                 tokenized_messages.append(self.eos_id)
                 mask.append(message.masked)
                 end_of_turn = False
@@ -252,13 +252,13 @@ class Phi3MiniTokenizer(ModelTokenizer, Transform):
             tokenized_messages = truncate(
                 tokens=tokenized_messages,
                 max_seq_len=self.max_seq_len,
-                eos_id=self.eos_id if add_eos else None,
+                eos_id=self.eos_id if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
             mask = truncate(
                 tokens=mask,
                 max_seq_len=self.max_seq_len,
-                eos_id=True if add_eos else None,
+                eos_id=True if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
 
@@ -281,7 +281,7 @@ class Phi3MiniTokenizer(ModelTokenizer, Transform):
             inference (bool): Whether the template is being used for inference or not.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_end_tokens=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample

--- a/torchtune/models/phi4/_tokenizer.py
+++ b/torchtune/models/phi4/_tokenizer.py
@@ -112,7 +112,7 @@ class Phi4Tokenizer(ModelTokenizer, Transform):
         self,
         messages: List[Message],
         *,
-        add_eos: bool = False,
+        add_end_tokens: bool = False,
         ignore_system_prompt: bool = False,
     ) -> Tuple[List[int], List[bool]]:
         templated_messages = (
@@ -141,7 +141,7 @@ class Phi4Tokenizer(ModelTokenizer, Transform):
                         f"Unsupported message content type: {item['type']}"
                     )
 
-            if add_eos and message.role == "assistant":
+            if add_end_tokens and message.role == "assistant":
                 tokens.append(self.special_tokens["<|im_end|>"])
             elif message.role != "assistant":
                 tokens.append(self.special_tokens["<|im_end|>"])
@@ -157,13 +157,13 @@ class Phi4Tokenizer(ModelTokenizer, Transform):
             tokenized_messages = truncate(
                 tokens=tokenized_messages,
                 max_seq_len=self.max_seq_len,
-                eos_id=self.eos_id if add_eos else None,
+                eos_id=self.eos_id if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
             mask = truncate(
                 tokens=mask,
                 max_seq_len=self.max_seq_len,
-                eos_id=True if add_eos else None,
+                eos_id=True if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [x] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
1. tokenize_message() method is not defined for phi3, Instead encode method is used directly. I have not used add_start_tokens as the model card definition of tokenizer is different for phi 3 & 4 compared to Llama3.

2. Used add_end_tokens in tokenize_messages(). Referred this: https://github.com/pytorch/torchtune/pull/1494 as mentioned in  #2480 

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
