### PR TITLE
Add assert for missing parameters

### DIFF
--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -341,6 +341,7 @@ def load_from_full_model_state_dict(
         sharded_sd = {}
         for param_name, full_tensor in full_sd.items():
             sharded_meta_param = meta_sharded_sd.get(param_name)
+            assert sharded_meta_param is not None, f"{param_name} not found in model"
             full_tensor = full_tensor.to(sharded_meta_param.dtype).to(device)
             if hasattr(sharded_meta_param, "_local_tensor") and isinstance(
                 sharded_meta_param._local_tensor, NF4Tensor


### PR DESCRIPTION
Summary: This will make it easier to identify which parameter is missing when loading a dictionary. Otherwise you'll get a `'None type' object has no attribute 'dtype'` error which isn't super helpful.

Differential Revision: D74202965


