### PR TITLE
Fix compile optimizer when using an LR scheduler

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -349,11 +349,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 else None
             ),
         )
-        if self._compile_optimizer_step:
-            self._optimizer.step = torch.compile(
-                self._optimizer.step,
-                backend=self._compile_backend,
-            )
 
         if self._resume_from_checkpoint:
             # If async checkpointing is enabled, intermediate checkpoints are saved asynchronously
@@ -436,6 +431,11 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             num_training_steps=self.total_epochs * self._steps_per_epoch,
             last_epoch=self.global_step - 1,
         )
+        if self._compile_optimizer_step:
+            self._optimizer.step = torch.compile(
+                self._optimizer.step,
+                backend=self._compile_backend,
+            )
 
         # Set up profiler, returns DummyProfiler (nullcontext object with no-op `step` method)
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`


### PR DESCRIPTION
#### Context

- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#2659 added an option to compile the optimizer, however doing so causes a crash when setting up an LR scheduler if a non-constant LR scheduler is used.
<details>
<summary> Crash log:</summary>

```
[rank0]: Traceback (most recent call last):                                                                                                                           
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/full_finetune_distributed.py", line 1094, in <module>                                                       
[rank0]:     sys.exit(recipe_main())                                                                                                                                  
[rank0]:              ~~~~~~~~~~~^^                                                                                                                                   
[rank0]:   File "/home/r/soft/torchtune/torchtune/torchtune/config/_parse.py", line 99, in wrapper                                                                    
[rank0]:     sys.exit(recipe_main(conf))                                                                                                                              
[rank0]:              ~~~~~~~~~~~^^^^^^                                                                                                                               
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/full_finetune_distributed.py", line 1088, in recipe_main                                                    
[rank0]:     recipe.setup(cfg=cfg)                                                                                                                                    
[rank0]:     ~~~~~~~~~~~~^^^^^^^^^                                                                                                                                    
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/full_finetune_distributed.py", line 434, in setup                                                           
[rank0]:     self._lr_scheduler = self._setup_lr_scheduler(                                                                                                           
[rank0]:                          ~~~~~~~~~~~~~~~~~~~~~~~~^                                                                                                           
[rank0]:         cfg_lr_scheduler=cfg.get("lr_scheduler", None),                                                                                                      
[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                      
[rank0]:         num_training_steps=self.total_epochs * self._steps_per_epoch,                                                                                        
[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                        
[rank0]:         last_epoch=self.global_step - 1,                                                                                                                     
[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                     
[rank0]:     )                                                                                                                                                        
[rank0]:     ^  
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/full_finetune_distributed.py", line 484, in _setup_lr_scheduler                                             
[rank0]:     lr_scheduler = config.instantiate(                                                                                                                       
[rank0]:         cfg_lr_scheduler,                                                                                                                                    
[rank0]:     ...<2 lines>...                                                                                                                                          
[rank0]:         last_epoch=last_epoch,                                                                                                                               
[rank0]:     )                                                                                                                                                        
[rank0]:   File "/home/r/soft/torchtune/torchtune/torchtune/config/_instantiate.py", line 163, in instantiate                                                         
[rank0]:     return _instantiate_node(                                                                                                                                
[rank0]:         OmegaConf.to_container(config, resolve=True),                                                                                                        
[rank0]:         caller_globals=caller_globals,                                                                                                                       
[rank0]:         *args,                                                                                                                                               
[rank0]:     )                                                                                                                                                        
[rank0]:   File "/home/r/soft/torchtune/torchtune/torchtune/config/_instantiate.py", line 62, in _instantiate_node                                                    
[rank0]:     return _create_component(_component_, args, kwargs)                                                                                                      
[rank0]:   File "/home/r/soft/torchtune/torchtune/torchtune/config/_instantiate.py", line 24, in _create_component                                                    
[rank0]:     return _component_(*args, **kwargs)                                                                                                                      
[rank0]:   File "/home/r/soft/torchtune/torchtune/torchtune/training/lr_schedulers.py", line 58, in get_cosine_schedule_with_warmup                                   
[rank0]:     return LambdaLR(optimizer, lr_lambda, last_epoch)                                                                                                        
[rank0]:   File "/home/r/soft/torchtune/tt/lib/python3.13/site-packages/torch/optim/lr_scheduler.py", line 286, in __init__                                           
[rank0]:     super().__init__(optimizer, last_epoch)                                                                                                                  
[rank0]:     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                  
[rank0]:   File "/home/r/soft/torchtune/tt/lib/python3.13/site-packages/torch/optim/lr_scheduler.py", line 131, in __init__                                           
[rank0]:     patch_track_step_called(self.optimizer)                                                                                                                  
[rank0]:     ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^                                                                                                                  
[rank0]:   File "/home/r/soft/torchtune/tt/lib/python3.13/site-packages/torch/optim/lr_scheduler.py", line 129, in patch_track_step_called                            
[rank0]:     opt.step = wrap_step(opt.step)  # type: ignore[method-assign]                                                                                            
[rank0]:                ~~~~~~~~~^^^^^^^^^^                                                                                                                           
[rank0]:   File "/home/r/soft/torchtune/tt/lib/python3.13/site-packages/torch/optim/lr_scheduler.py", line 118, in wrap_step                                          
[rank0]:     func = step_fn.__func__                                                                                                                                  
[rank0]:            ^^^^^^^^^^^^^^^^                                                                                                                                  
[rank0]: AttributeError: 'function' object has no attribute '__func__'. Did you mean: '__doc__'?
```
</details>

#### Changelog
Moved optimizer compilation step after learning rate scheduler setup. This seems to resolve the issue, training launches and completes successfully when both optimizer compilation and LR scheduler are enabled.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
