### PR TITLE
Fix grad scaling in Tensor Parallelism

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -944,7 +944,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
                         # Manually scale the gradients from unnormalized loss by total # of tokens
                         self._grad_scaler(
-                            self._model.parameters(), self.dp_degree / num_tokens
+                            self._model.parameters(),
+                            self.world_size / num_tokens,
+                            not self.parallel_dims.tp_enabled,
                         )
 
                         if self._clip_grad_norm is not None:

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -946,7 +946,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                         self._grad_scaler(
                             self._model.parameters(),
                             self.world_size / num_tokens,
-                            not self.parallel_dims.tp_enabled,
+                            False if self.parallel_dims.tp_enabled else None,
                         )
 
                         if self._clip_grad_norm is not None:

--- a/torchtune/training/_grad_scaler.py
+++ b/torchtune/training/_grad_scaler.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import torch
 from torch import nn, Tensor
+from torch.distributed.tensor import DTensor
 from torch.nn.utils.clip_grad import _no_grad, _tensor_or_tensors
 from torch.utils._foreach_utils import _device_has_foreach_support, _has_foreach_support
 from torchtune.utils._logging import deprecated

--- a/torchtune/training/_grad_scaler.py
+++ b/torchtune/training/_grad_scaler.py
@@ -102,4 +102,7 @@ def _scale_grad_(
         else:
             scaler_device = scaler.to(device)
             for g in device_grads:
-                g.mul_(scaler_device)
+                if isinstance(g, DTensor):
+                    g[:] = g * scaler_device
+                else:
+                    g.mul_(scaler_device)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

[Please link to any issues this PR addresses.](https://github.com/pytorch/torchtune/issues/2641)

#### Changelog
What are the changes made in this PR?
* Forcefully disallows using `foreach` grad scaling implementation with TP
* If not using `foreach`, check grad type, and do not use inplace `mul_` on DTensor
* Rescale grads by world size, not DP size (not sure why this is required but it aligned loss and grad norms across all distributed setups)

<img width="716" alt="image" src="https://github.com/user-attachments/assets/d226e465-a7d8-4dfd-b54d-2882710a7c8e" />

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
