### PR TITLE
[FSDP2][DCP] remove unsued broadcast_from_rank0 from get_full_optimizer_state_dict

### DIFF
--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -496,7 +496,7 @@ def get_full_optimizer_state_dict(
     Returning non-empty cpu state dict on rank 0
     """
     options = StateDictOptions(
-        full_state_dict=True, broadcast_from_rank0=True, cpu_offload=True
+        full_state_dict=True, cpu_offload=True
     )
     full_state_dict = get_optimizer_state_dict(
         model=model, optimizers=opt, options=options


### PR DESCRIPTION
remove unsued `broadcast_from_rank0` from get_full_optimizer_state_dict. `broadcast_from_rank0` is only useful when loading state dict


#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] better engineering

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [x] I have added an example to docs or docstrings
