### PR TITLE
Explicitly import SFTLoss in recipes

### DIFF
--- a/recipes/dev/lora_finetune_distributed_multi_dataset.py
+++ b/recipes/dev/lora_finetune_distributed_multi_dataset.py
@@ -26,6 +26,7 @@ from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
 from torchtune.data._utils import get_dataloader, get_multi_dataset, load_hf_dataset
 from torchtune.datasets._sft import SFTTransform
+from torchtune.modules.loss import SFTLoss
 from torchtune.modules.peft import (
     AdapterModule,
     get_adapter_params,
@@ -317,7 +318,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-        if isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
 
         if self._compile:
@@ -835,7 +836,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     outputs = self._model(**batch)
 
                 # post process for third party loss functions
-                if not isinstance(self._loss_fn, modules.loss.SFTLoss):
+                if not isinstance(self._loss_fn, SFTLoss):
                     labels = labels.reshape(-1)
                     outputs = outputs.reshape(-1, outputs.size(-1))
                     if isinstance(outputs, DTensor):

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -27,6 +27,7 @@ from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
 from torchtune.datasets import ConcatDataset
+from torchtune.modules.loss import SFTLoss
 from torchtune.recipe_interfaces import FTRecipeInterface
 from torchtune.training import (
     DummyProfiler,
@@ -389,7 +390,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-        if isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
 
         if self._compile_loss:
@@ -826,7 +827,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             outputs = self._model(**batch)
 
         # post process for third party loss functions
-        if not isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if not isinstance(self._loss_fn, SFTLoss):
             labels = labels.reshape(-1)
             outputs = outputs.reshape(-1, outputs.size(-1))
             if isinstance(outputs, DTensor):

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -21,6 +21,7 @@ from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
 from torchtune.datasets import ConcatDataset
+from torchtune.modules.loss import SFTLoss
 from torchtune.recipe_interfaces import FTRecipeInterface
 from torchtune.training import DummyProfiler, PROFILER_KEY
 from torchtune.training.lr_schedulers import get_lr
@@ -287,7 +288,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-        if isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
 
         if self._compile:
@@ -628,7 +629,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             outputs = self._model(**batch)
 
         # post process for third party loss functions
-        if not isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if not isinstance(self._loss_fn, SFTLoss):
             labels = labels.reshape(-1)
             outputs = outputs.reshape(-1, outputs.size(-1))
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -25,6 +25,7 @@ from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
 from torchtune.datasets import ConcatDataset
+from torchtune.modules.loss import SFTLoss
 from torchtune.modules.peft import (
     AdapterModule,
     get_adapter_params,
@@ -328,7 +329,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-        if isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
 
         if self._compile:
@@ -926,7 +927,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             outputs = self._model(**batch)
 
         # post process for third party loss functions
-        if not isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if not isinstance(self._loss_fn, SFTLoss):
             labels = labels.reshape(-1)
             outputs = outputs.reshape(-1, outputs.size(-1))
             if isinstance(outputs, DTensor):

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -23,6 +23,7 @@ from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
 from torchtune.datasets import ConcatDataset
+from torchtune.modules.loss import SFTLoss
 from torchtune.modules.peft import (
     get_adapter_params,
     get_adapter_state_dict,
@@ -293,7 +294,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-        if isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
 
         if self._compile:
@@ -638,7 +639,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
             outputs = self._model(**batch)
 
         # post process for third party loss functions
-        if not isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if not isinstance(self._loss_fn, SFTLoss):
             labels = labels.reshape(-1)
             outputs = outputs.reshape(-1, outputs.size(-1))
 

--- a/recipes/qat_distributed.py
+++ b/recipes/qat_distributed.py
@@ -25,6 +25,7 @@ from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
 from torchtune.datasets import ConcatDataset
+from torchtune.modules.loss import SFTLoss
 from torchtune.recipe_interfaces import FTRecipeInterface
 from torchtune.training import (
     DummyProfiler,
@@ -324,7 +325,7 @@ class QATRecipeDistributed(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-        if isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
 
         if self._compile:
@@ -827,7 +828,7 @@ class QATRecipeDistributed(FTRecipeInterface):
                     outputs = self._model(**batch)
 
                 # post process for third party loss functions
-                if not isinstance(self._loss_fn, modules.loss.SFTLoss):
+                if not isinstance(self._loss_fn, SFTLoss):
                     labels = labels.reshape(-1)
                     outputs = outputs.reshape(-1, outputs.size(-1))
                     if isinstance(outputs, DTensor):

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -25,6 +25,7 @@ from torchtune import config, modules, training, utils
 from torchtune.config._utils import _get_component_from_path
 from torchtune.data import padded_collate_packed
 from torchtune.datasets import ConcatDataset
+from torchtune.modules.loss import SFTLoss
 from torchtune.modules.peft import (
     AdapterModule,
     DoRALinear,
@@ -338,7 +339,7 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-        if isinstance(self._loss_fn, modules.loss.SFTLoss):
+        if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
 
         if self._compile:
@@ -853,7 +854,7 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     outputs = self._model(**batch)
 
                 # post process for third party loss functions
-                if not isinstance(self._loss_fn, modules.loss.SFTLoss):
+                if not isinstance(self._loss_fn, SFTLoss):
                     labels = labels.reshape(-1)
                     outputs = outputs.reshape(-1, outputs.size(-1))
                     if isinstance(outputs, DTensor):


### PR DESCRIPTION
Before this change, e.g. 

```
tune run full_finetune_single_device --config llama3_2/1B_full_single_device loss=torch.nn.CrossEntropyLoss
```

fails with the error 

```
    if isinstance(self._loss_fn, modules.loss.SFTLoss):
                                 ^^^^^^^^^^^^
AttributeError: module 'torchtune.modules' has no attribute 'loss'
```