### PR TITLE
Cleanup usage of optimizer / optimizer in backwards

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -333,7 +333,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         lr_scheduler_cfg = cfg.get("lr_scheduler", None)
         if lr_scheduler_cfg is not None:
             self._lr_scheduler = self._setup_lr_scheduler(
-                cfg_lr_scheduler=cfg.get("lr_scheduler", None),
+                cfg_lr_scheduler=lr_scheduler_cfg,
                 num_training_steps=self.total_epochs * self._steps_per_epoch,
                 last_epoch=self.global_step - 1,
             )
@@ -532,9 +532,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             # dropping last avoids shape issues with compile + flex attention
             drop_last=True,
         )
-
-        if dataloader_state_dict:
-            dataloader.load_state_dict(dataloader_state_dict)
 
         return dataloader
 

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -15,6 +15,7 @@ from omegaconf import DictConfig, ListConfig
 
 from torch import nn
 from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LambdaLR
 from torchdata.stateful_dataloader import StatefulDataLoader
 from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
 from torchtune import config, modules, training, utils
@@ -25,6 +26,7 @@ from torchtune.modules.loss import SFTLoss
 from torchtune.recipe_interfaces import FTRecipeInterface
 from torchtune.training import DummyProfiler, PROFILER_KEY
 from torchtune.training.lr_schedulers import get_lr
+from torchtune.training.memory import OptimizerInBackwardWrapper
 
 from tqdm import tqdm
 
@@ -286,7 +288,6 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             ),
         )
 
-        # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
         if isinstance(self._loss_fn, SFTLoss):
             self._loss_fn.set_model_output(self._model)
@@ -328,12 +329,16 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             self._steps_per_epoch = self.max_steps_per_epoch
         self.global_step = self.epochs_run * self._steps_per_epoch
 
-        # Setup lr scheduler
-        self._lr_scheduler = self._setup_lr_scheduler(
-            cfg_lr_scheduler=cfg.get("lr_scheduler", None),
-            num_training_steps=self.total_epochs * self._steps_per_epoch,
-            last_epoch=self.global_step - 1,
-        )
+        # Setup lr scheduler if a component is included in the config
+        lr_scheduler_cfg = cfg.get("lr_scheduler", None)
+        if lr_scheduler_cfg is not None:
+            self._lr_scheduler = self._setup_lr_scheduler(
+                cfg_lr_scheduler=cfg.get("lr_scheduler", None),
+                num_training_steps=self.total_epochs * self._steps_per_epoch,
+                last_epoch=self.global_step - 1,
+            )
+        else:
+            self._lr_scheduler = None
 
         # Set up profiler, returns DummyProfiler (nullcontext object with no-op `step` method)
         # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
@@ -418,7 +423,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         cfg_optimizer: DictConfig,
         optimizer_in_bwd: bool = False,
         opt_state_dict: Optional[Dict[str, Any]] = None,
-    ) -> Optional[Optimizer]:
+    ) -> Union[Optimizer, OptimizerInBackwardWrapper]:
         """
         Set up the optimizer. This method also handles loading the optimizer state_dict, if specified.
         """
@@ -433,63 +438,35 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 model=self._model, optim_dict=optim_dict
             )
             # Create a wrapper for checkpoint save/load of optimizer states when running in backward.
-            self._optim_ckpt_wrapper = training.create_optim_in_bwd_wrapper(
+            optimizer = training.create_optim_in_bwd_wrapper(
                 model=self._model, optim_dict=optim_dict
             )
-            # Load optimizer states. If optimizer states are being restored in an optimizer in backward
-            # run, these need to have been saved with the same setting. Cannot restore from runs that did not
-            # use optimizer in backward.
-            if opt_state_dict is not None:
-                try:
-                    self._optim_ckpt_wrapper.load_state_dict(opt_state_dict)
-                except BaseException as e:
-                    raise RuntimeError(
-                        "Failed loading in-backward optimizer checkpoints."
-                        "Please make sure run being restored from was using in-backward optimizer."
-                    ) from e
-            self._logger.info("In-backward optimizers are set up.")
-            return None
         else:
             optimizer = config.instantiate(cfg_optimizer, self._model.parameters())
 
-            if opt_state_dict:
-                optimizer.load_state_dict(opt_state_dict)
-            self._logger.info("Optimizer is initialized.")
-            return optimizer
+        if opt_state_dict:
+            optimizer.load_state_dict(opt_state_dict)
+
+        self._logger.info("Optimizer is initialized.")
+        return optimizer
 
     def _setup_lr_scheduler(
         self,
-        cfg_lr_scheduler: Optional[DictConfig],
+        cfg_lr_scheduler: DictConfig,
         num_training_steps: int,
         last_epoch: int,
-    ) -> Optional[Optimizer]:
+    ) -> LambdaLR:
         """
         Set up the learning rate scheduler based on the provided configuration.
         It handles both standard optimization and optimizer-in-backward cases, and supports
         schedulers from both torchtune.modules and torch.optim.
-
-        Args:
-            cfg_lr_scheduler (Optional[DictConfig]): The learning rate scheduler configuration.
-            num_training_steps (int): The total number of training steps.
-            last_epoch (int): The index of the last epoch.
-
-        Returns:
-            lr_scheduler (Optional[Optimizer]): The learning rate scheduler.
         """
-        if cfg_lr_scheduler is None:
-            self._logger.info(
-                "No learning rate scheduler configured. Using constant learning rate."
-            )
-            return None
-
-        if self._optimizer_in_bwd:
+        if isinstance(self._optimizer, OptimizerInBackwardWrapper):
             # Use the first optimizer from the wrapper to represent the learning rate
-            optimizer = next(iter(self._optim_ckpt_wrapper.optim_map.values()))
+            optimizer = next(iter(self._optimizer.optim_map.values()))
         else:
-            # Standard case: use the single optimizer
             optimizer = self._optimizer
 
-        # Instantiate the learning rate scheduler
         lr_scheduler = config.instantiate(
             cfg_lr_scheduler,
             optimizer,
@@ -497,9 +474,8 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             last_epoch=last_epoch,
         )
 
-        if self._optimizer_in_bwd:
-            # Modify the scheduler for optimizer_in_bwd case
-            self._optim_ckpt_wrapper.set_lr_scheduler(lr_scheduler)
+        if isinstance(self._optimizer, OptimizerInBackwardWrapper):
+            self._optimizer.set_lr_scheduler(lr_scheduler)
 
         self._logger.info("Learning rate scheduler is initialized.")
         return lr_scheduler
@@ -557,6 +533,9 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             drop_last=True,
         )
 
+        if dataloader_state_dict:
+            dataloader.load_state_dict(dataloader_state_dict)
+
         return dataloader
 
     def save_checkpoint(self, epoch: int) -> None:
@@ -564,8 +543,8 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         Save state dict to file. The recipe save_checkpoint method is responsible for
         correctly creating the checkpoint dict and passing to the checkpointer.
         """
-        ckpt_dict = {training.MODEL_KEY: self._model.state_dict()}
-        # if training is in-progress, checkpoint the optimizer state as well
+        ckpt_dict: dict[str, Any] = {training.MODEL_KEY: self._model.state_dict()}
+        # If training is in-progress, checkpoint recipe state information as well
         if epoch + 1 < self.total_epochs:
             ckpt_dict.update(
                 {
@@ -574,12 +553,9 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                     training.TOTAL_EPOCHS_KEY: self.total_epochs,
                     training.MAX_STEPS_KEY: self.max_steps_per_epoch,
                     training.DATALOADER_KEY: self._dataloader.state_dict(),
+                    training.OPT_KEY: self._optimizer.state_dict(),
                 }
             )
-            if not self._optimizer_in_bwd:
-                ckpt_dict[training.OPT_KEY] = self._optimizer.state_dict()
-            else:
-                ckpt_dict[training.OPT_KEY] = self._optim_ckpt_wrapper.state_dict()
         self._checkpointer.save_checkpoint(
             ckpt_dict,
             epoch=epoch,
@@ -611,12 +587,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         The core training loop. Supports training on subsets of the dataset using the
         ``max_steps_per_epoch``.
         """
-        if self._compile:
-            self._logger.info(
-                "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."
-            )
-        # zero out the gradients before starting training
-        if not self._optimizer_in_bwd:
+        if not isinstance(self._optimizer, OptimizerInBackwardWrapper):
             self._optimizer.zero_grad()
 
         # Initialize tokens count and running loss (for grad accumulation)
@@ -653,9 +624,9 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                 running_loss += current_loss
                 current_loss.backward()
 
-                # Step with optimizer
                 if (idx + 1) % self._gradient_accumulation_steps == 0:
-                    if not self._optimizer_in_bwd:
+                    # If we're not using optimizer in backwards, we step the optimizer like normal
+                    if not isinstance(self._optimizer, OptimizerInBackwardWrapper):
                         training.scale_grads(self._model, 1 / num_tokens)
                         if self._clip_grad_norm is not None:
                             grad_norm = torch.nn.utils.clip_grad_norm_(
@@ -676,20 +647,13 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
                         f"{curr_epoch + 1}|{self.global_step}|Loss: {loss_to_log}"
                     )
 
-                    # Log per-step metrics
                     if self.global_step % self._log_every_n_steps == 0:
                         time_per_step = time.perf_counter() - t0
                         log_dict = {
                             "loss": loss_to_log,
-                            # NOTE: for optim in backward, this assumes all optimizers have the same LR. This is currently
+                            # For optim in backward, this assumes all optimizers have the same LR. This is currently
                             # true since we don't expose the ability to configure this yet.
-                            "lr": get_lr(
-                                (
-                                    self._optimizer
-                                    if not self._optimizer_in_bwd
-                                    else self._optim_ckpt_wrapper
-                                ),
-                            ),
+                            "lr": get_lr(self._optimizer),
                             "tokens_per_second_per_gpu": num_tokens / time_per_step,
                         }
                         if self._device.type != "cpu" and self._log_peak_memory_stats:

--- a/torchtune/modules/loss/loss_types.py
+++ b/torchtune/modules/loss/loss_types.py
@@ -11,7 +11,7 @@ import torch
 from torch import nn
 
 
-class SFTLoss(ABC):
+class SFTLoss(ABC, nn.Module):
     """Interface for loss functions in torchtune used in sft recipes."""
 
     def apply_compile_strategy(self, *args, **kwargs):

--- a/torchtune/modules/loss/loss_types.py
+++ b/torchtune/modules/loss/loss_types.py
@@ -11,7 +11,7 @@ import torch
 from torch import nn
 
 
-class SFTLoss(ABC, nn.Module):
+class SFTLoss(ABC):
     """Interface for loss functions in torchtune used in sft recipes."""
 
     def apply_compile_strategy(self, *args, **kwargs):


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (please add here)

#### Changelog
What are the changes made in this PR?
* Optimizer and OptimizerInBwdWrapper both have similar APIs and can be used as such
* Instead of having a function that sets up the lr scheduler OR returns None if there's no config value, we just only call the function if there is a config value. Duh
* Other various cleanup like checking based on isinstance instead of a variable set at the top - this is more accurate

This removes 35 LOC from our recipe. If these changes look good, I'll open an issue to migrate these to the rest of the recipes.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
