### PR TITLE
Add QAT single-device recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ You can also run e.g. ``tune ls full_dpo_distributed`` for a full list of availa
 
 | Type of Weight Update | 1 Device | >1 Device | >1 Node |
 |-----------------------|:--------:|:---------:|:-------:|
-| [Full](https://pytorch.org/torchtune/stable/recipes/qat_distributed.html)                  |    ❌    |     ✅    |    ❌    |
+| [Full](https://pytorch.org/torchtune/stable/recipes/qat_distributed.html)                  |    ✅     |     ✅    |    ❌    |
 | LoRA/QLoRA            |    ❌    |     ✅    |    ❌    |
 
 Example: ``tune run qat_distributed --config llama3_1/8B_qat_lora`` <br />
-You can also run e.g. ``tune ls qat_distributed`` for a full list of available configs.
+You can also run e.g. ``tune ls qat_distributed`` or ``tune ls qat_single_device`` for a full list of available configs.
 
 The above configs are just examples to get you started. The full list of recipes can be found [here](recipes/). If you'd like to work on one of the gaps you see, please submit a PR! If there's a entirely new post-training method you'd like to see implemented in torchtune, feel free to open an Issue.
 

--- a/recipes/configs/llama2/1B_qat_single_device.yaml
+++ b/recipes/configs/llama2/1B_qat_single_device.yaml
@@ -1,0 +1,100 @@
+# Config for single device QAT finetuning in qat_single_device.py
+# using a Llama 1B/TinyLlama_v1.1 model.
+#
+# This config assumes that you've run the following command before launching:
+#   tune download TinyLlama/TinyLlama_v1.1 --output-dir /tmp/TinyLlama_v1.1/
+#
+# To launch on a single device, run (from root):
+#   tune run qat_single_device --config llama2/1B_full_qat_single_device
+
+output_dir: /tmp/torchtune/llama1b/qat_single_device # /tmp may be deleted by your system. Adjust if needed.
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama2.llama2_tokenizer
+  path: /tmp/TinyLlama_v1.1/tokenizer.model
+  max_seq_len: 2048
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  packed: False
+
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama2.llama2
+  vocab_size: 32000
+  num_layers: 22
+  num_heads: 32
+  num_kv_heads: 4
+  embed_dim: 2048
+  max_seq_len: 2048
+  intermediate_dim: 5632
+  attn_dropout: 0.0
+  norm_eps: 1e-5
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/TinyLlama_v1.1/
+  checkpoint_files: [pytorch_model.bin]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: LLAMA2
+
+resume_from_checkpoint: False
+
+# Fine-tuning arguments
+batch_size: 1
+epochs: 1
+optimizer:
+  _component_: bitsandbytes.optim.PagedAdamW
+  lr: 5e-6
+optimizer_in_bwd: True            # True saves memory, requires gradient_accumulation_steps=1
+loss:
+  _component_: torchtune.modules.loss.LinearCrossEntropyLoss
+max_steps_per_epoch: null
+gradient_accumulation_steps: 1   # Use to increase effective batch size
+clip_grad_norm: null
+compile: False                   # torch.compile the model+loss, can increase speed+decrease memory
+
+# QAT arguments
+quantizer:
+  _component_: torchtune.training.quantization.Int8DynActInt4WeightQATQuantizer
+  groupsize: 256
+
+# Training environment
+device: cuda
+
+# Memory management
+enable_activation_checkpointing: True   # True reduces memory
+enable_activation_offloading: False     # True reduces memory
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO
+
+# Profiler
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+  output_dir: ${output_dir}/profiling_outputs
+  cpu: True
+  cuda: True
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/qwen2_5/1.5B_qat_single_device.yaml
+++ b/recipes/configs/qwen2_5/1.5B_qat_single_device.yaml
@@ -1,0 +1,112 @@
+# Config for single device QAT finetuning in qat_single_device.py
+# using a Qwen2.5 1.5B
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download Qwen/Qwen2.5-1.5B-Instruct --output-dir /tmp/Qwen2.5-1.5B-Instruct
+#
+# The default config uses an optimizer from bitsandbytes. If you do not have it installed,
+# you can install it with
+#   pip install bitsandbytes
+#
+# To launch on a single device, run the following command from root:
+#   tune run qat_single_device --config qwen2_5/1.5B_qat_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run qat_single_device --config qwen2_5/1.5B_qat_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+output_dir: /tmp/torchtune/qwen2_5_1_5B/qat_single_device # /tmp may be deleted by your system. Change it to your preference.
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.qwen2_5.qwen2_5_tokenizer
+  path: /tmp/Qwen2.5-1.5B-Instruct/vocab.json
+  merges_file: /tmp/Qwen2.5-1.5B-Instruct/merges.txt
+  max_seq_len: null
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  packed: False  # True increases speed
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: torchtune.models.qwen2_5.qwen2_5_1_5b_instruct
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Qwen2.5-1.5B-Instruct
+  checkpoint_files: [model.safetensors]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN2
+resume_from_checkpoint: False
+
+# Fine-tuning arguments
+batch_size: 1
+epochs: 1
+optimizer:
+  _component_: bitsandbytes.optim.PagedAdamW
+  lr: 5e-6
+optimizer_in_bwd: True  # True saves memory. Requires gradient_accumulation_steps=1
+loss:
+  _component_: torchtune.modules.loss.LinearCrossEntropyLoss
+max_steps_per_epoch: null
+gradient_accumulation_steps: 1  # Use to increase effective batch size
+clip_grad_norm: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+
+# QAT arguments
+quantizer:
+  _component_: torchtune.training.quantization.Int8DynActInt4WeightQATQuantizer
+  groupsize: 256
+
+# Training environment
+device: cuda
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/qwen2_5/3B_qat_single_device.yaml
+++ b/recipes/configs/qwen2_5/3B_qat_single_device.yaml
@@ -1,0 +1,115 @@
+# Config for single device QAT finetuning in qat_single_device.py
+# using a Qwen2.5 3B
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download Qwen/Qwen2.5-3B-Instruct --output-dir /tmp/Qwen2.5-3B-Instruct
+#
+# The default config uses an optimizer from bitsandbytes. If you do not have it installed,
+# you can install it with
+#   pip install bitsandbytes
+#
+# To launch on a single device, run the following command from root:
+#   tune run qat_single_device --config qwen2_5/3B_qat_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run qat_single_device --config qwen2_5/3B_qat_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+output_dir: /tmp/torchtune/qwen2_5_3B/full_single_device # /tmp may be deleted by your system. Change it to your preference.
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.qwen2_5.qwen2_5_tokenizer
+  path: /tmp/Qwen2.5-3B-Instruct/vocab.json
+  merges_file: /tmp/Qwen2.5-3B-Instruct/merges.txt
+  max_seq_len: null
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  packed: False  # True increases speed
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: torchtune.models.qwen2_5.qwen2_5_3b
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Qwen2.5-3B-Instruct
+  checkpoint_files: [
+    model-00001-of-00002.safetensors,
+    model-00002-of-00002.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN2
+resume_from_checkpoint: False
+
+# Fine-tuning arguments
+batch_size: 2
+epochs: 1
+optimizer:
+  _component_: bitsandbytes.optim.PagedAdamW
+  lr: 5e-6
+optimizer_in_bwd: True  # True saves memory. Requires gradient_accumulation_steps=1
+loss:
+  _component_: torchtune.modules.loss.LinearCrossEntropyLoss
+max_steps_per_epoch: null
+gradient_accumulation_steps: 1  # Use to increase effective batch size
+clip_grad_norm: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+
+# QAT arguments
+quantizer:
+  _component_: torchtune.training.quantization.Int8DynActInt4WeightQATQuantizer
+  groupsize: 256
+
+# Training environment
+device: cuda
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/qat_single_device.py
+++ b/recipes/qat_single_device.py
@@ -1,0 +1,289 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+from typing import Any, Dict  # List, Optional, Union
+from warnings import warn
+
+import torch
+from omegaconf import DictConfig  # ListConfig
+
+from torchtune import training, utils  # config, modules,
+from torchtune.modules.loss import SFTLoss
+from torchtune.recipe_interfaces import FTRecipeInterface
+
+from tqdm import tqdm
+
+
+class QATRecipeSingleDevice(FTRecipeInterface):
+    """
+    Quantization-aware training (QAT) recipe for dense transformer-based LLMs such as Llama2.
+    This recipe only supports single device training. Only compatible with PyTorch 2.4+.
+    """
+
+    def __init__(self, cfg: DictConfig) -> None:
+        self._device = utils.get_device(device=cfg.device)
+        self._dtype = training.get_dtype(cfg.dtype, device=self._device)
+
+        if self._dtype == torch.float16:
+            raise ValueError(
+                "fp16 precision is not supported in this recipe. Please use fp32 or bf16."
+            )
+
+        # logging attributes
+        self._output_dir = cfg.output_dir
+        self._log_every_n_steps = cfg.get("log_every_n_steps", 1)
+        self._log_peak_memory_stats = cfg.get("log_peak_memory_stats", False)
+        self._logger = utils.get_logger(cfg.log_level)
+
+        if self._log_peak_memory_stats and self._device.type == "cpu":
+            self._logger.info(
+                "log_peak_memory_stats was set to True, however, training uses cpu. Setting log_peak_memory_stats=False."
+            )
+            self._log_peak_memory_stats = False
+
+        # Training cfg
+        self._resume_from_checkpoint = cfg.resume_from_checkpoint
+        self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
+        self._optimizer_in_bwd = cfg.get("optimizer_in_bwd", False)
+        self._clip_grad_norm = cfg.get("clip_grad_norm", None)
+        self._fake_quant_after_n_steps = cfg.get("fake_quant_after_n_steps", None)
+        self._quantizer_mode = None
+
+        # Optimizer in backward is not compatible with gradient accumulation or gradient clipping
+        if self._optimizer_in_bwd:
+            if self._clip_grad_norm is not None:
+                raise RuntimeError(
+                    "Gradient clipping is not supported with optimizer in bwd."
+                    "Please set clip_grad_norm=None, or optimizer_in_bwd=False."
+                )
+            if self._gradient_accumulation_steps > 1:
+                raise RuntimeError(
+                    "Gradient accumulation is not supported with optimizer in bwd."
+                    "Please set gradient_accumulation_steps=1, or optimizer_in_bwd=False."
+                )
+
+        # activation checkpointing/offloading
+        self._enable_activation_checkpointing = cfg.get(
+            "enable_activation_checkpointing", False
+        )
+        self._enable_activation_offloading = cfg.get(
+            "enable_activation_offloading", False
+        )
+        if self._enable_activation_offloading:
+            if self._device.type != "cuda":
+                raise RuntimeError(
+                    "enable_activation_offloading should only be True when training on CUDA"
+                )
+            if not self._enable_activation_checkpointing:
+                raise RuntimeError(
+                    "enable_activation_offloading should only be True when enable_activation_checkpointing is True"
+                )
+        elif (
+            self._enable_activation_checkpointing
+            and cfg.checkpointer.model_type != "LLAMA3_VISION"
+        ):
+            utils.log_rank_zero(
+                self._logger,
+                "Hint: enable_activation_checkpointing is True, but enable_activation_offloading isn't. "
+                "Enabling activation offloading should reduce memory further.",
+            )
+
+        # These are public properties which are updated by the checkpoint loader
+        # when ``resume_from_checkpoint`` is `True` or validated in tests
+        self.seed = training.set_seed(
+            seed=cfg.seed, debug_mode=cfg.get("cudnn_deterministic_mode", None)
+        )
+        self.epochs_run = 0
+        self.total_epochs = cfg.epochs
+        self.max_steps_per_epoch = cfg.max_steps_per_epoch
+        self.global_step = 0
+
+    def load_checkpoint(self, **kwargs) -> None:
+        """
+        Responsible for loading ALL of the state for the recipe from the
+        checkpoint file, including state for the model, optimizer, dataloader and training
+        parameters such as the epoch and seed.
+        """
+        return
+
+    def _update_recipe_state(self, ckpt_dict: Dict[str, Any]) -> None:
+        """
+        Updates the recipe state from checkpoint.
+        """
+        try:
+            self.epochs_run = ckpt_dict[training.EPOCHS_KEY]
+
+            # on mismatch, warn the user and prevent the override
+            if self.seed != ckpt_dict[training.SEED_KEY]:
+                warn(
+                    message=(
+                        "Config value for seed does not match the checkpoint value, "
+                        f"using the checkpoint value: {ckpt_dict[training.SEED_KEY]}"
+                    )
+                )
+                self.seed = ckpt_dict[training.SEED_KEY]
+            if self.max_steps_per_epoch != ckpt_dict[training.MAX_STEPS_KEY]:
+                warn(
+                    message=(
+                        "Config value for max_steps_per_epoch does not match the checkpoint value, "
+                        f"using the checkpoint value: {ckpt_dict[training.MAX_STEPS_KEY]}"
+                    )
+                )
+                self.max_steps_per_epoch = ckpt_dict[training.MAX_STEPS_KEY]
+
+            # on mismatch, warn the user but allow the override
+            if self.total_epochs != ckpt_dict[training.TOTAL_EPOCHS_KEY]:
+                warn(
+                    message=(
+                        "Config value for total_epochs does not match the checkpoint value, "
+                        f"using the config value: {self.total_epochs}"
+                    )
+                )
+
+        except KeyError as e:
+            raise KeyError(
+                "Checkpoint does not contain the required keys needed for updating recipe state. "
+                "Are you sure you passed in the right recipe checkpoint?"
+            ) from e
+
+    def setup(self, **kwargs) -> None:
+        """
+        Responsible for setting up all of the components necessary for training. This includes
+        model, optimizer, loss function and dataloader.
+        """
+        return
+
+    def train(self, **kwargs) -> None:
+        """
+        The core training loop
+        """
+
+        # zero out the gradients before starting training
+        if not self._optimizer_in_bwd:
+            self._optimizer.zero_grad()
+        else:
+            for opt in self._optim_ckpt_wrapper.optim_map.values():
+                opt.zero_grad()
+
+        # Initialize tokens count and running loss (for grad accumulation)
+        t0 = time.perf_counter()
+        running_loss = 0
+        num_tokens = 0
+
+        self._profiler.start()
+
+        # self.epochs_run should be non-zero when we're resuming from a checkpoint
+        for curr_epoch in range(self.epochs_run, self.total_epochs):
+            # Update the sampler to ensure data is correctly shuffled across epochs
+            # in case shuffle is True
+            pbar = tqdm(total=self._steps_per_epoch)
+            self._dataloader.sampler.set_epoch(curr_epoch)
+            for idx, batch in enumerate(self._dataloader):
+                if (
+                    self.max_steps_per_epoch is not None
+                    and (idx // self._gradient_accumulation_steps)
+                    == self.max_steps_per_epoch
+                ):
+                    break
+
+                # Start tracking CUDA memory for active steps for just the first epoch
+                if (
+                    curr_epoch == 0
+                    and self.profiler_profile_memory
+                    and idx == self.profiler_wait_steps + self.profiler_warmup_steps
+                    and self._device.type == "cuda"
+                ):
+                    torch.cuda.memory._record_memory_history()
+
+                # Optionally wait N steps before enabling fake quant
+                if self._fake_quant_after_n_steps is not None:
+                    if self.global_step == 0:
+                        self._logger.info(
+                            "Step 0: Disabling fake quant, will re-enable in step %s"
+                            % self._fake_quant_after_n_steps
+                        )
+                        disable_fq = training.quantization._get_disable_fake_quant(
+                            self._quantizer_mode
+                        )
+                        self._model.apply(disable_fq)
+                    elif self.global_step == self._fake_quant_after_n_steps:
+                        self._logger.info(
+                            "Step %s: Enabling fake quant"
+                            % self._fake_quant_after_n_steps
+                        )
+                        enable_fq = training.quantization._get_enable_fake_quant(
+                            self._quantizer_mode
+                        )
+                        self._model.apply(enable_fq)
+
+                utils.batch_to_device(batch, self._device)
+
+                # Calculate the number of unmasked tokens in the current batch
+                # and increment the total number of tokens seen in the step
+                current_num_tokens = (
+                    batch["labels"] != self._loss_fn.ignore_index
+                ).sum()
+                num_tokens += current_num_tokens
+
+                # Shape [b, s], needed for the loss not the model
+                labels = batch.pop("labels")
+
+                with self.activations_handling_ctx:
+                    outputs = self._model(**batch)
+                # post process for third party loss functions
+                if not isinstance(self._loss_fn, SFTLoss):
+                    labels = labels.reshape(-1)
+                    outputs = outputs.reshape(-1, outputs.size(-1))
+
+                """ ensure normalizing is correct here """
+
+                # compute loss
+                current_loss = self._loss_fn(outputs, labels)
+
+                # Loss is normalized by default so we multiply by the number of tokens
+                # This way we can normalize by the total number of tokens if we're accumulating gradients
+                current_loss = current_loss * current_num_tokens
+
+                # free outputs otherwise it peaks backward memory
+                del outputs
+
+                running_loss += current_loss
+
+                # For optimizer in backward, we need to normalize before calling backward
+                # This case and gradient accumulation are mutually exclusive
+                if self._optimizer_in_bwd:
+                    current_loss = current_loss / current_num_tokens
+
+                current_loss.backward()
+
+                if (idx + 1) % self._gradient_accumulation_steps == 0:
+                    if not self._optimizer_in_bwd:
+                        training.scale_grads(self._model, 1 / num_tokens)
+                        if self._clip_grad_norm is not None:
+                            grad_norm = torch.nn.utils.clip_grad_norm_(
+                                self._model.parameters(),
+                                max_norm=float(self._clip_grad_norm),
+                            ).full_tensor()
+                        self._optimizer.step()
+                        self._optimizer.zero_grad(set_to_none=True)
+
+        return
+
+    def save_checkpoint(self, **kwargs) -> None:
+        """
+        Responsible for saving ALL of the state for the recipe,
+        including state for the model, optimizer, dataloader and training
+        parameters such as the epoch and seed.
+        """
+        return
+
+    def cleanup(self, **kwargs) -> None:
+        """
+        Any cleaning up needed for the recipe.
+        """
+        return

--- a/recipes/qat_single_device.py
+++ b/recipes/qat_single_device.py
@@ -6,15 +6,26 @@
 import sys
 import time
 
-from typing import Any, Dict  # List, Optional, Union
+from functools import partial
+
+from typing import Any, Dict, Optional, Union
 from warnings import warn
 
 import torch
-from omegaconf import DictConfig  # ListConfig
+from omegaconf import DictConfig, ListConfig
 
-from torchtune import config, training, utils  # modules
+from torch import nn
+
+from torch.optim import Optimizer
+from torchdata.stateful_dataloader import StatefulDataLoader
+from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
+from torchtune import config, modules, training, utils
+from torchtune.config._utils import _get_component_from_path
+from torchtune.data import padded_collate_packed
+from torchtune.datasets import ConcatDataset
 from torchtune.modules.loss import SFTLoss
 from torchtune.recipe_interfaces import FTRecipeInterface
+from torchtune.training import DummyProfiler, PROFILER_KEY
 
 from torchtune.training.lr_schedulers import get_lr
 
@@ -24,7 +35,76 @@ from tqdm import tqdm
 class QATRecipeSingleDevice(FTRecipeInterface):
     """
     Quantization-aware training (QAT) recipe for dense transformer-based LLMs such as Llama2.
-    This recipe only supports single device training. Only compatible with PyTorch 2.4+.
+    This recipe supports single device training (CPU or GPU).
+    It is recommended to use PyTorch 2.4+ for optimal QAT support.
+
+    Features:
+        - Quantization-aware training (QAT): Perform fake quantization on weights and/or activations
+          during finetuning, with the goal of ultimately producing a quantized model with minimal
+          accuracy degradation. This recipe produces an unquantized model in the original dtype
+          (e.g., bf16 or fp32), which has learned to be robust to quantization effects.
+          This output model can then be quantized separately using standard post-training quantization (PTQ)
+          techniques or by applying the quantizer's convert step.
+
+        - Delayed fake quantization: Optionally specify the step after which fake quantization is enabled.
+          Empirically, allowing the model to finetune without fake quantization initially can allow
+          weight and activation values to stabilize before fake quantization is applied,
+          potentially leading to improved quantized accuracy. This can be specified
+          through the ``fake_quant_after_n_steps`` config option.
+
+        - Activation Checkpointing: Controlled using the ``enable_activation_checkpointing``
+          flag. This technique helps reduce memory footprint by recomputing activations
+          during the backward pass instead of storing them. This is beneficial for larger
+          models or batch sizes but may increase training time.
+
+        - Activation Offloading: Controlled using the ``enable_activation_offloading``
+          flag (requires ``enable_activation_checkpointing=True`` and CUDA device).
+          Activations are moved to CPU memory during the forward pass and brought back to GPU
+          during the backward pass, further reducing GPU memory usage. This can impact
+          training speed but allows for larger models/batches.
+
+        - Precision: Full fp32 and bf16 training are supported, controlled by the ``dtype``
+          flag. Using bf16 typically halves memory usage compared to fp32 with minimal
+          impact on model quality on supported hardware. fp16 precision is not supported
+          for QAT with this recipe.
+
+        - Gradient Accumulation: Simulate larger batch sizes by accumulating gradients,
+          controlled by ``gradient_accumulation_steps``.
+          Effective Batch Size = batch_size * gradient_accumulation_steps.
+          This is useful when memory-constrained.
+
+        - Optimizer in Backward: Optionally perform optimizer steps during the backward pass
+          for potential memory savings, controlled by ``optimizer_in_bwd``. This is not
+          compatible with gradient accumulation or gradient clipping.
+
+        - Checkpointing: Model weights are checkpointed at the end of each epoch and
+          at the end of training. Optimizer state and recipe state (seed, epochs run, etc.)
+          are saved with epoch checkpoints for resuming training, controlled by
+          ``resume_from_checkpoint``. For more details, see the checkpointer deepdive:
+          https://pytorch.org/torchtune/main/deep_dives/checkpointer.html
+
+        - Logging: Supports Terminal, Disk, WandB, and TensorBoard logging via the
+          ``metric_logger`` configuration.
+
+        - Gradient Clipping: Optional gradient clipping is supported using the ``clip_grad_norm``
+          flag (set to ``None`` by default).
+
+    For a full list of example configs for this recipe, run ``tune ls`` on the command line.
+    Each config has example commands for how to kick-off training.
+
+    Args:
+        cfg (DictConfig): OmegaConf object parsed from yaml file.
+
+    Raises:
+        ValueError: If ``dtype`` is set to fp16.
+        ValueError: If ``quantizer`` is not specified in the config.
+        ValueError: If the specified ``quantizer`` is not in a QAT mode.
+        RuntimeError: If ``optimizer_in_bwd`` is True and ``clip_grad_norm`` is enabled.
+        RuntimeError: If ``optimizer_in_bwd`` is True and ``gradient_accumulation_steps`` > 1.
+        RuntimeError: If ``enable_activation_offloading`` is True and the device is not CUDA.
+        RuntimeError: If ``enable_activation_offloading`` is True and ``enable_activation_checkpointing`` is False.
+        RuntimeError: If ``left_pad_sequence`` is set as the data collator for training.
+        KeyError: If resuming from a checkpoint and the checkpoint dictionary is missing required recipe state keys.
     """
 
     def __init__(self, cfg: DictConfig) -> None:
@@ -89,8 +169,7 @@ class QATRecipeSingleDevice(FTRecipeInterface):
             self._enable_activation_checkpointing
             and cfg.checkpointer.model_type != "LLAMA3_VISION"
         ):
-            utils.log_rank_zero(
-                self._logger,
+            self._logger.info(
                 "Hint: enable_activation_checkpointing is True, but enable_activation_offloading isn't. "
                 "Enabling activation offloading should reduce memory further.",
             )
@@ -105,13 +184,20 @@ class QATRecipeSingleDevice(FTRecipeInterface):
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
 
-    def load_checkpoint(self, **kwargs) -> None:
+    def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
-        Responsible for loading ALL of the state for the recipe from the
-        checkpoint file, including state for the model, optimizer, dataloader and training
-        parameters such as the epoch and seed.
+        Extract the checkpoint state from file and validate. If resume_from_checkpoint
+        is True, this also includes the recipe state.
         """
-        return
+        self._checkpointer = config.instantiate(
+            cfg_checkpointer,
+            should_load_recipe_state=self._resume_from_checkpoint,
+        )
+        checkpoint_dict = self._checkpointer.load_checkpoint()
+
+        if self._resume_from_checkpoint:
+            self._update_recipe_state(checkpoint_dict)
+        return checkpoint_dict
 
     def _update_recipe_state(self, ckpt_dict: Dict[str, Any]) -> None:
         """
@@ -153,14 +239,254 @@ class QATRecipeSingleDevice(FTRecipeInterface):
                 "Are you sure you passed in the right recipe checkpoint?"
             ) from e
 
-    def setup(self, **kwargs) -> None:
+    def setup(self, cfg: DictConfig) -> None:
         """
         Responsible for setting up all of the components necessary for training. This includes
         model, optimizer, loss function and dataloader.
         """
-        return
+        self._metric_logger = config.instantiate(cfg.metric_logger)
 
-    def train(self, **kwargs) -> None:
+        # log config with parameter override
+        self._metric_logger.log_config(cfg)
+
+        checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
+
+        self._compile = cfg.get("compile", False)
+        self._model = self._setup_model(
+            cfg_model=cfg.model,
+            enable_activation_checkpointing=self._enable_activation_checkpointing,
+            enable_activation_offloading=self._enable_activation_offloading,
+            compile_model=self._compile,
+            model_state_dict=checkpoint_dict[training.MODEL_KEY],
+            quantizer_cfg=cfg.get("quantizer", None),
+        )
+        self._tokenizer = config.instantiate(cfg.tokenizer)
+
+        self._optimizer = self._setup_optimizer(
+            cfg_optimizer=cfg.optimizer,
+            optimizer_in_bwd=self._optimizer_in_bwd,
+            opt_state_dict=(
+                checkpoint_dict[training.OPT_KEY]
+                if self._resume_from_checkpoint
+                else None
+            ),
+        )
+
+        # initialize loss
+        self._loss_fn = config.instantiate(cfg.loss)
+        if isinstance(self._loss_fn, SFTLoss):
+            self._loss_fn.set_model_output(self._model)
+
+        if self._compile:
+            training.compile_loss(self._loss_fn, verbose=True)
+
+        self._logger.info("Loss is initialized.")
+
+        # sampler and dataloader depend on the tokenizer and loss_fn and should be
+        # setup after both of these are initialized
+        collate_name = cfg.get("collate_fn", "torchtune.data.padded_collate_sft")
+        self._dataloader = self._setup_data(
+            cfg_dataset=cfg.dataset,
+            shuffle=cfg.shuffle,
+            batch_size=cfg.batch_size,
+            collate_fn=collate_name,
+        )
+
+        # Finally update the recipe state which can only be correctly set after all of the
+        # other components have been initialized and updated.
+        #
+        # Number of training steps in each epoch depends on the number of batches produced
+        # by the dataloader, the max_steps_per_epoch param set by the user and the
+        # gradient_accumulation_steps param. This value is used for logging and tracking
+        # training state. The computation should happen after the dataloader has been setup
+        self._steps_per_epoch = (
+            len(self._dataloader) // self._gradient_accumulation_steps
+        )
+        if (
+            self.max_steps_per_epoch is not None
+            and self.max_steps_per_epoch < self._steps_per_epoch
+        ):
+            self._steps_per_epoch = self.max_steps_per_epoch
+        self.global_step = self.epochs_run * self._steps_per_epoch
+
+        # Set up profiler, returns DummyProfiler (nullcontext object with no-op `step` method)
+        # if cfg is missing profiler key or if `cfg.profiler.enabled = False`
+        self._profiler = self._setup_profiler(cfg.get(PROFILER_KEY, None))
+
+    def _setup_profiler(
+        self, cfg_profiler: Optional[DictConfig] = None
+    ) -> Union[torch.profiler.profile, DummyProfiler]:
+        """
+        Parses the `profiler` section of top-level `cfg` and sets up profiler
+        """
+
+        # Missing profiler section in config, assume disabled
+        if cfg_profiler is None:
+            cfg_profiler = DictConfig({"enabled": False})
+
+        # Check that component is included and set correctly
+        if cfg_profiler.get("_component_", None) is None:
+            cfg_profiler["_component_"] = "torchtune.training.setup_torch_profiler"
+        else:
+            assert (
+                cfg_profiler.get("_component_")
+                == "torchtune.training.setup_torch_profiler"
+            ), "Only torch profiler supported currently: component must be `torchtune.training.setup_torch_profiler`"
+
+        profiler, profiler_cfg = config.instantiate(cfg_profiler)
+
+        self._logger.info(f" Profiler config after instantiation: {profiler_cfg}")
+
+        self.profiler_profile_memory = profiler_cfg.get("profile_memory", False)
+        if profiler_cfg["enabled"]:
+            self.profiler_wait_steps = profiler_cfg["wait_steps"]
+            self.profiler_warmup_steps = profiler_cfg["warmup_steps"]
+            self.profiler_active_steps = profiler_cfg["active_steps"]
+
+        return profiler
+
+    def _setup_model(
+        self,
+        cfg_model: DictConfig,
+        enable_activation_checkpointing: bool,
+        enable_activation_offloading: bool,
+        compile_model: bool,
+        model_state_dict: Dict[str, Any],
+        quantizer_cfg: Optional[DictConfig] = None,
+    ) -> nn.Module:
+        """
+        Set up the model
+        """
+        self._logger.info(
+            "Instantiating model and loading checkpoint ...",
+        )
+
+        with training.set_default_dtype(self._dtype), self._device:
+            model = config.instantiate(cfg_model)
+
+        if compile_model:
+            training.compile_model(model)
+
+        if enable_activation_checkpointing:
+            training.set_activation_checkpointing(
+                model, auto_wrap_policy={modules.TransformerSelfAttentionLayer}
+            )
+
+        # Apply quantization-aware training during finetuning
+        if quantizer_cfg is None:
+            raise ValueError("Quantizer must be specified for QAT recipe.")
+        quantizer = config.instantiate(quantizer_cfg)
+        quantizer.precision = self._dtype
+        quantizer_mode = training.quantization.get_quantizer_mode(quantizer)
+        if "qat" not in quantizer_mode:
+            raise ValueError(
+                "Quantizer mode '%s' is not supported for finetuning" % quantizer_mode
+            )
+        self._quantizer_mode = quantizer_mode
+        model = quantizer.prepare(model)
+
+        # load model state dict
+        model.load_state_dict(model_state_dict)
+
+        # Enable activation offloading
+        self.activations_handling_ctx = training.get_act_offloading_ctx_manager(
+            model, enable_activation_offloading
+        )
+        self._logger.info(
+            f"QAT Model (quantizer applied) is initialized with compute precision {self._dtype}."
+        )
+
+        if self._device.type != "cpu":
+            memory_stats = training.get_memory_stats(device=self._device)
+            training.log_memory_stats(memory_stats)
+
+        return model
+
+    def _setup_optimizer(
+        self,
+        cfg_optimizer: DictConfig,
+        optimizer_in_bwd: bool = False,
+        opt_state_dict: Optional[Dict[str, Any]] = None,
+    ) -> Union[Optimizer]:
+        """
+        Set up the optimizer. This method also handles loading the optimizer state_dict, if specified.
+        """
+        if optimizer_in_bwd:
+            # Maintain a dict of optims for every parameter.
+            optim_dict = {
+                p: config.instantiate(cfg_optimizer, [p])
+                for p in self._model.parameters()
+            }
+            # Register optimizer step hooks on the model to run optimizer in backward.
+            training.register_optim_in_bwd_hooks(
+                model=self._model, optim_dict=optim_dict
+            )
+            # Create a wrapper for checkpoint save/load of optimizer states when running in backward.
+            optimizer = training.create_optim_in_bwd_wrapper(
+                model=self._model, optim_dict=optim_dict
+            )
+        else:
+            optimizer = config.instantiate(cfg_optimizer, self._model.parameters())
+
+        if opt_state_dict:
+            optimizer.load_state_dict(opt_state_dict)
+
+        self._logger.info("Optimizer is initialized.")
+        return optimizer
+
+    def _setup_data(
+        self,
+        cfg_dataset: DictConfig,
+        shuffle: bool,
+        batch_size: int,
+        collate_fn: str,
+    ) -> StatefulDataLoader:
+        if isinstance(cfg_dataset, ListConfig):
+            datasets = [
+                config.instantiate(single_cfg_dataset, self._tokenizer)
+                for single_cfg_dataset in cfg_dataset
+            ]
+            ds = ConcatDataset(datasets=datasets)
+            packed = getattr(ds, "packed", False)
+        else:
+            ds = config.instantiate(cfg_dataset, self._tokenizer)
+            packed = cfg_dataset.get("packed", False)
+
+        # Instantiate collate_fn
+        if "left_pad_sequence" in collate_fn:
+            raise RuntimeError("left_pad_sequence collator is only for inference.")
+        collate_fn = _get_component_from_path(collate_fn)
+
+        sampler = StatefulDistributedSampler(
+            ds,
+            num_replicas=1,
+            rank=0,
+            shuffle=shuffle,
+            seed=0,
+        )
+
+        dataloader = StatefulDataLoader(
+            dataset=ds,
+            batch_size=batch_size,
+            sampler=sampler,
+            # dropping last avoids shape issues with compile + flex attention
+            drop_last=True,
+            collate_fn=(
+                partial(
+                    collate_fn,
+                    padding_idx=self._tokenizer.pad_id,
+                    ignore_idx=self._loss_fn.ignore_index,
+                )
+                if not packed
+                else padded_collate_packed
+            ),
+        )
+
+        self._logger.info("Dataset and Sampler are initialized.")
+
+        return dataloader
+
+    def train(self) -> None:
         """
         The core training loop
         """
@@ -169,7 +495,7 @@ class QATRecipeSingleDevice(FTRecipeInterface):
         if not self._optimizer_in_bwd:
             self._optimizer.zero_grad()
         else:
-            for opt in self._optim_ckpt_wrapper.optim_map.values():
+            for opt in self._optimizer.optim_map.values():
                 opt.zero_grad()
 
         # Initialize tokens count and running loss (for grad accumulation)
@@ -287,13 +613,7 @@ class QATRecipeSingleDevice(FTRecipeInterface):
                         time_per_step = time.perf_counter() - t0
                         log_dict = {
                             "loss": loss_to_log,
-                            "lr": get_lr(
-                                (
-                                    self._optimizer
-                                    if not self._optimizer_in_bwd
-                                    else self._optim_ckpt_wrapper
-                                ),
-                            ),
+                            "lr": get_lr(self._optimizer),
                             "tokens_per_second_per_gpu": num_tokens / time_per_step,
                         }
                         if self._device.type != "cpu" and self._log_peak_memory_stats:
@@ -334,19 +654,49 @@ class QATRecipeSingleDevice(FTRecipeInterface):
 
         self._profiler.stop()
 
-    def save_checkpoint(self, **kwargs) -> None:
+    def save_checkpoint(
+        self,
+        epoch: int,
+    ) -> None:
         """
         Responsible for saving ALL of the state for the recipe,
         including state for the model, optimizer, dataloader and training
         parameters such as the epoch and seed.
         """
-        return
+        self._logger.info(
+            "Saving checkpoint. This may take some time. Retrieving full model state dict...",
+        )
+        start = time.perf_counter()
 
-    def cleanup(self, **kwargs) -> None:
-        """
-        Any cleaning up needed for the recipe.
-        """
-        return
+        # get model's checkpoint dict for current epoch
+        checkpoint_dict: dict[str, Any] = {training.MODEL_KEY: self._model.state_dict()}
+        intermediate_checkpoint = epoch + 1 < self.total_epochs
+
+        # if training is in-progress, checkpoint the optimizer state and recipe state
+        # as well.
+        if intermediate_checkpoint:
+            checkpoint_dict.update(
+                {
+                    training.OPT_KEY: self._optimizer.state_dict(),
+                    training.SEED_KEY: self.seed,
+                    training.EPOCHS_KEY: self.epochs_run,
+                    training.TOTAL_EPOCHS_KEY: self.total_epochs,
+                    training.MAX_STEPS_KEY: self.max_steps_per_epoch,
+                    training.DATALOADER_KEY: self._dataloader.state_dict(),
+                }
+            )
+
+        self._checkpointer.save_checkpoint(
+            checkpoint_dict,
+            epoch=epoch,
+            intermediate_checkpoint=intermediate_checkpoint,
+        )
+        self._logger.info(
+            f"Saving checkpoint took {time.perf_counter() - start:.2f} secs"
+        )
+
+    def cleanup(self) -> None:
+        self._metric_logger.close()
 
 
 @config.parse

--- a/tests/recipes/test_qat_single_device.py
+++ b/tests/recipes/test_qat_single_device.py
@@ -1,0 +1,112 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import runpy
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from tests.common import TUNE_PATH
+
+from tests.recipes.utils import (
+    CKPT_COMPONENT_MAP,
+    dummy_alpaca_dataset_config,
+    MODEL_TEST_CONFIGS,
+    write_hf_ckpt_config,
+)
+from tests.test_utils import (
+    CKPT_MODEL_PATHS,
+    gen_log_file_name,
+    get_loss_values_from_metric_logger,
+    gpu_test,
+    TOKENIZER_PATHS,
+)
+
+
+class TestQATSingleDeviceRecipe:
+    def _get_test_config_overrides(self):
+        return [
+            "dtype=bf16",
+            "enable_activation_checkpointing=True",
+            "enable_activation_offloading=False",
+            "seed=9",
+            "epochs=2",
+            "max_steps_per_epoch=2",
+            "optimizer=torch.optim.AdamW",
+            "optimizer.lr=2e-5",
+            "log_every_n_steps=1",
+        ] + dummy_alpaca_dataset_config()
+
+    def _fetch_expected_loss_values(self, model_type, ckpt_type):
+        # logic here may need to be adjusted in the future
+        if model_type == "llama2" and ckpt_type == "hf":
+            return [
+                10.596881866455078,
+                10.715113639831543,
+                10.57275104522705,
+                10.497347831726074,
+            ]
+
+    @pytest.mark.integration_test
+    @gpu_test(gpu_count=1)
+    @pytest.mark.parametrize(
+        "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps",
+        [
+            ("llama2/1B_qat_single_device", "llama2", "hf", 1, 1),
+        ],
+    )
+    def test_loss(
+        self,
+        config,
+        model_type,
+        ckpt_type,
+        micro_batch_size,
+        gradient_accumulation_steps,
+        tmpdir,
+        monkeypatch,
+    ):
+        ckpt_component = CKPT_COMPONENT_MAP.get(
+            ckpt_type, "torchtune.training.FullModelHFCheckpointer"
+        )
+        ckpt = model_type + "_" + ckpt_type
+        ckpt_path = Path(CKPT_MODEL_PATHS.get(ckpt))
+        tokenizer_path = Path(TOKENIZER_PATHS.get(model_type))
+        ckpt_dir = ckpt_path.parent
+        log_file = gen_log_file_name(tmpdir)
+
+        # Config file needed for model conversion.
+        write_hf_ckpt_config(ckpt_dir)
+
+        cmd = f"""
+        tune run qat_single_device \
+            --config {config} \
+            output_dir={tmpdir} \
+            batch_size={micro_batch_size} \
+            gradient_accumulation_steps={gradient_accumulation_steps} \
+            checkpointer._component_={ckpt_component} \
+            checkpointer.checkpoint_dir='{ckpt_dir}' \
+            checkpointer.checkpoint_files=[{ckpt_path}] \
+            checkpointer.output_dir={tmpdir} \
+            checkpointer.model_type={model_type.upper()} \
+            tokenizer.path='{tokenizer_path}' \
+            tokenizer.prompt_template=null \
+            metric_logger.filename={log_file} \
+        """.split()
+        model_config = MODEL_TEST_CONFIGS.get(model_type)
+        cmd = cmd + self._get_test_config_overrides() + model_config
+
+        # specify intermediate_dim for test small llama2
+        if model_type == "llama2":
+            cmd.append("model.intermediate_dim=768")
+
+        monkeypatch.setattr(sys, "argv", cmd)
+        with pytest.raises(SystemExit, match=""):
+            runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        loss_values = get_loss_values_from_metric_logger(log_file)
+        expected_losses = self._fetch_expected_loss_values(model_type, ckpt_type)
+        torch.testing.assert_close(loss_values, expected_losses, rtol=1e-3, atol=1e-3)

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -585,6 +585,25 @@ _ALL_RECIPES = [
         supports_distributed=False,
     ),
     Recipe(
+        name="qat_single_device",
+        file_path="qat_single_device.py",
+        configs=[
+            Config(
+                name="qwen2_5/3B_qat_single_device",
+                file_path="qwen2_5/3B_qat_single_device.yaml",
+            ),
+            Config(
+                name="qwen2_5/1.5B_qat_single_device",
+                file_path="qwen2_5/1.5B_qat_single_device.yaml",
+            ),
+            Config(
+                name="llama2/1B_qat_single_device",
+                file_path="llama2/1B_qat_single_device.yaml",
+            ),
+        ],
+        supports_distributed=False,
+    ),
+    Recipe(
         name="qat_distributed",
         file_path="qat_distributed.py",
         configs=[


### PR DESCRIPTION
#### Context
- [x] add a new feature

This PR adds a new quantization-aware training (QAT) recipe for single-device setups. It is currently unfinished but posted as a draft for visibility and early feedback.

Addresses [#2696](https://github.com/pytorch/torchtune/issues/2696)

#### Changelog
* Core `QATRecipeSingleDevice` class scaffolded
* Finished training loop

#### TODO
- [x] Implement `setup()` to wire up model, dataloader, loss, optimizer, and profiler
- [x] Implement checkpointing (`save_checkpoint` and `load_checkpoint`)
- [x] Add optional validation loop
- [x] Test functionality end-to-end
- [x] Polish code, docstrings, and typing

#### Test plan
- [x] Ran pre-commit hooks and linters

#### UX
- [x] I did not change any public API

cc @joecummings let me know if you have any thoughts so far!