### PR TITLE
Throw error if trying to compile the opt step with optim in bwd

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -369,6 +369,10 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             ),
         )
         if self._compile_optimizer_step:
+            if self._optimizer_in_bwd:
+                raise ValueError(
+                    "optimizer_in_bwd not supported with compiling the optimizer step"
+                )
             self._optimizer.step = torch.compile(
                 self._optimizer.step,
                 backend=self._compile_backend,


### PR DESCRIPTION
You can't compile optimizer step if that step is fused into the backwards call, dummy
