### PR TITLE
Remove root logger config (basicConfig) in library code

### DIFF
--- a/torchtune/modules/_export/_position_embeddings.py
+++ b/torchtune/modules/_export/_position_embeddings.py
@@ -17,9 +17,6 @@ import torch.nn.functional as F
 from torch import nn
 from torch.distributed._tensor import distribute_tensor, DTensor
 
-FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
-logging.basicConfig(level=logging.INFO, format=FORMAT)
-
 
 class TilePositionalEmbedding(nn.Module):
     """


### PR DESCRIPTION
Calls to logging.basicConfig set the *root* logger configuration potentially interfering with user application code, which may want to set logger format strings, the logger level and more. This commit removes these lines from library-side code, which should defer to the application/user code.

#### Context

This PR fixes the bug described in #2727 

#### Changelog

What are the changes made in this PR?
- I remove [lines 20 and 21 of torchtune/modules/_export/_position_embeddings.py](https://github.com/pytorch/torchtune/blob/cbc145632a6bb58a25707ec728fcbc6c67d91056/torchtune/modules/_export/_position_embeddings.py#L20) basing this PR on commit [5bc03a9](https://github.com/pytorch/torchtune/commit/5bc03a9545ab581701e5c6e77b8c44fb3a28e0b0)

#### Test plan

Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] ~~add~~ Run [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any ~~new~~ modified functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX

If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings

#### Additional Notes

A very marginal consideration with this PR is the format string for logs might change for users. Downstream impact should be minimal. 
