### PR TITLE
Add ruff pre-commit hook to check PEP 585

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,10 @@ repos:
   hooks:
     - id: pydoclint
       args: [--config=pyproject.toml]
+
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.10
+  hooks:
+    - id: ruff-check
+    - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,4 +55,5 @@ repos:
   rev: v0.11.10
   hooks:
     - id: ruff-check
+      args: [ --fix ]
     - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,6 @@ addopts = ["--showlocals", "--import-mode=prepend", "--without-integration", "--
 # --import-mode=prepend will add the root (the parent dir of torchtune/, tests/, recipes/)
 # to `sys.path` when invoking pytest, allowing us to treat `tests` as a package within the tests.
 # --without-integration and --without-slow-integration: default to running unit tests only
+
+[tool.ruff.lint]
+select = ["UP006"]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [x] other (Adds pre-commit hook to check PEP 585)

Fixes https://github.com/pytorch/torchtune/issues/2734 Ruff can also replace other linters, but to keep this PR small, this PR only adds a single ruff rule.

#### Changelog
What are the changes made in this PR?
* Adds pre-commit hook to check PEP 585 using ruff

#### Test plan
To check this PR, you can `pre-commit run --all-files`, which shows all the errors. According to https://docs.astral.sh/ruff/rules/non-pep585-annotation/ this is a non-safe fix, so to fix it one needs to run:

```bash
ruff check . --unsafe-fixes --fix
```

This should reproduce the PR from https://github.com/pytorch/torchtune/pull/2720

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
