### PR TITLE
Add feature ligerceloss

### DIFF
--- a/docs/source/api_ref_modules.rst
+++ b/docs/source/api_ref_modules.rst
@@ -35,6 +35,7 @@ Losses
     :nosignatures:
 
     loss.LinearCrossEntropyLoss
+    loss.LigerFusedCrossEntropyLoss
     loss.ForwardKLLoss
     loss.ForwardKLWithChunkedOutputLoss
     loss.ReverseKLWithChunkedOutputLoss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ dependencies = [
 
     # Multimodal
     "Pillow>=9.4.0",
+
+    # Triton:
+    "triton>=2.3.1 ; platform_system != 'Windows'",
+
+    # Liger Kernels
+    "liger-kernel ; platform_system != 'Windows'"
 ]
 dynamic = ["version"]
 

--- a/tests/torchtune/modules/loss/test_liger_ce_loss.py
+++ b/tests/torchtune/modules/loss/test_liger_ce_loss.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn.functional as F
+from tests.test_utils import assert_expected
+from torch import nn
+from torchtune.modules.loss import LigerFusedCrossEntropyLoss
+from torchtune.training.seed import set_seed
+
+
+class Model(nn.Module):
+    def __init__(self, vocab_size, embed_dim):
+        super().__init__()
+        self.output = nn.Linear(embed_dim, vocab_size)
+
+    def forward(self, x):
+        return self.output(x)
+
+
+@pytest.fixture(autouse=True)
+def random():
+    set_seed(42)
+
+
+class TestLigerFusedCrossEntropyLoss:
+    def test_liger_fused_cross_entropy_loss(self):
+        """
+        Compares LigerFusedCrossEntropyLoss implementation vs standard F.cross_entropy
+        """
+        # Set up test parameters
+        batch_size = 2
+        seq_len = 8
+        embed_dim = 16
+        vocab_size = 100
+        ignore_index = -100
+
+        # Create dummy data
+        hidden = torch.randn(batch_size * seq_len, embed_dim, dtype=torch.float32)
+        targets = torch.randint(0, vocab_size, (batch_size * seq_len,), dtype=torch.long)
+        hidden = hidden.cuda()
+        targets = targets.cuda()
+        # Add some ignored indices
+        mask = torch.rand(batch_size * seq_len) < 0.2
+        targets[mask] = ignore_index
+
+        # Create a dummy model
+        model = Model(vocab_size, embed_dim).cuda()
+
+        # Compute fused CE loss
+        fused_ce_loss_fn = LigerFusedCrossEntropyLoss(ignore_index=ignore_index)
+        fused_ce_loss_fn.set_model_output(model)
+        fused_loss = fused_ce_loss_fn(hidden, targets)
+
+        # Compute standard cross entropy for comparison
+        logits = F.linear(hidden, model.output.weight, model.output.bias)  # [batch_size*seq_len, vocab_size]
+        standard_loss = F.cross_entropy(
+            logits, targets, reduction="sum", ignore_index=ignore_index
+        )
+
+        # Validate the results are close enough
+        assert_expected(fused_loss, standard_loss, rtol=1e-2, atol=1e-2)
+
+    def test_liger_fused_cross_entropy_loss_with_reshape(self):
+        """
+        Tests LigerFusedCrossEntropyLoss with batch x seq_len input that needs reshaping
+        """
+        # Set up test parameters
+        batch_size = 3
+        seq_len = 6
+        embed_dim = 32
+        vocab_size = 50
+        ignore_index = -100
+
+        # Create dummy data with batch x seq_len dimensions
+        hidden = torch.randn(batch_size, seq_len, embed_dim, dtype=torch.float32)
+        targets = torch.randint(0, vocab_size, (batch_size, seq_len), dtype=torch.long)
+        hidden = hidden.cuda()
+        targets = targets.cuda()
+        # Add some ignored indices
+        mask = torch.rand(batch_size, seq_len) < 0.2
+        targets[mask] = ignore_index
+
+        # Create a dummy model
+        model = Model(vocab_size, embed_dim).cuda()
+
+        # Reshape to match expected input shape for fused loss
+        hidden_reshaped = hidden.reshape(-1, embed_dim)
+        targets_reshaped = targets.reshape(-1)
+
+        # Compute fused CE loss
+        fused_ce_loss_fn = LigerFusedCrossEntropyLoss(ignore_index=ignore_index)
+        fused_ce_loss_fn.set_model_output(model)
+        fused_loss = fused_ce_loss_fn(hidden_reshaped, targets_reshaped)
+
+        # Compute standard cross entropy for comparison
+        logits = model(hidden_reshaped)  # [batch_size*seq_len, vocab_size]
+        standard_loss = F.cross_entropy(
+            logits, targets_reshaped, reduction="sum", ignore_index=ignore_index
+        )
+
+        # Validate the results are close enough
+        assert_expected(fused_loss, standard_loss, rtol=1e-2, atol=1e-2)
+

--- a/torchtune/modules/loss/__init__.py
+++ b/torchtune/modules/loss/__init__.py
@@ -7,6 +7,7 @@
 from .ce_chunked_output_loss import CEWithChunkedOutputLoss
 
 from .cross_entropy_loss import LinearCrossEntropyLoss
+from .cross_entropy_loss import LigerFusedCrossEntropyLoss
 from .kd_losses import (
     ForwardKLLoss,
     ForwardKLWithChunkedOutputLoss,
@@ -26,6 +27,7 @@ __all__ = [
     "SymmetricKLLoss",
     "SymmetricKLWithChunkedOutputLoss",
     "LinearCrossEntropyLoss",
+    "LigerFusedCrossEntropyLoss"
     "SFTLoss",
     "RLLoss",
 ]


### PR DESCRIPTION
# PR: Add LigerFusedCrossEntropyLoss

#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [x] update tests and/or documentation
- [ ] other

Closes #2692

#### Changelog
- Added new `LigerFusedCrossEntropyLoss` class that provides memory-efficient cross entropy loss using fused CUDA kernels using `liger-kernels`
- Implemented proper handling of distributed tensors (DTensor) with gradient hooks
- Added comprehensive unit tests comparing against standard PyTorch cross entropy
- Added docstrings with usage examples

#### Test plan
- [x] Added unit tests in test_liger_ce_loss.py comparing against `F.cross_entropy`
- [x] Tests verify correctness with:
  - Regular tensor inputs
  - Batched inputs requiring reshaping
  - Ignored indices
- [x] Added proper docstrings with usage examples
- [x] Tests pass locally on CUDA device
- [x] Pre-commit hooks and linters pass

#### UX
Example usage in docstring:

```python
# Initialize model and loss
model = Transformer(...)  # model with skip_output_layer=True
loss = LigerFusedCrossEntropyLoss()
loss.set_model_output(model)  # This captures model's output layer

# Forward pass
hidden_states = model(inputs)  # [batch_size, seq_len, hidden_dim]
targets = labels  # [batch_size, seq_len]

# If needed, reshape to [batch_size*seq_len, hidden_dim]
hidden_states = hidden_states.view(-1, hidden_states.size(-1))
targets = targets.view(-1)

loss_value = loss(hidden_states, targets)
```

The implementation provides better performance and memory efficiency compared to the chunked `LinearCrossEntropyLoss` by:
1. Using fused CUDA kernels
2. Combining linear projection and cross entropy in a single operation
3. Properly handling distributed tensors

All tests verify numerical correctness against PyTorch's native cross entropy within expected tolerances.

<hr>

Hi PyTorch Team,

This is my first PR to a machine learning project, and I’ve tried to ensure the code is correct and well-structured. I’ve implemented the functionality for LigerCeLoss and included a test case that verifies its behavior with both masked and reshaped inputs.

Due to hardware limitations, I wasn't able to fully validate the distributed functionality or run the entire test suite across multiple GPUs. However, I’ve implemented support for DTensor-based weights, hidden states, and targets, and included the logic for gather → fuse → scatter to handle gradient computation for sharded weights in distributed settings.

Looking forward to your feedback! @pbontrager @joecummings 