### PR TITLE
Explicitly call ray.get to trigger failure

### DIFF
--- a/.github/workflows/rl_test.yaml
+++ b/.github/workflows/rl_test.yaml
@@ -1,4 +1,4 @@
-name: GPU tests
+name: RL tests
 
 on:
   push:

--- a/tests/torchtune/dev/rl/workers/test_postprocessing.py
+++ b/tests/torchtune/dev/rl/workers/test_postprocessing.py
@@ -92,6 +92,15 @@ class TestPostProcessingWorker:
                 "temperature": 1.0,
             },
             "num_steps": 3,
+            "reward_functions": [
+                {
+                    "_component_": "torchtune.dev.rl.rewards.ThinkingAnswerFormattingReward",
+                    "think_tag": "think",
+                    "answer_tag": "answer",
+                    "positive_reward": 1.0,
+                    "negative_reward": 0.0,
+                }
+            ],
         }
         return OmegaConf.create(cfg)
 

--- a/tests/torchtune/dev/rl/workers/test_postprocessing.py
+++ b/tests/torchtune/dev/rl/workers/test_postprocessing.py
@@ -144,11 +144,15 @@ class TestPostProcessingWorker:
                 replay_buffer=replay_buffer,
             )
             actor_handles = [postprocessing_worker.run.remote()]
+            ray.get(actor_handles)
 
             # dummy trainer to wait for queue to empty
             dummy_trainer = DummyTrainer.remote(rollout_queue=rollout_queue)
             dummy_trainer_handles = [dummy_trainer.train.remote()]
             ray.get(dummy_trainer_handles)
+
+        except Exception as e:
+            raise RuntimeError("Test failed") from e
 
         finally:
             ray.shutdown()


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
