### PR TITLE
Fixing counting number of batches for accumulation through epoch

### DIFF
--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -210,6 +210,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
+        self.id_batch = 0
 
     def _load_ref_checkpoint(self, cfg_ref_checkpointer: DictConfig) -> dict[str, Any]:
         """
@@ -871,8 +872,10 @@ class FullDPORecipeDistributed(FTRecipeInterface):
 
                 loss.backward()
 
+                self.id_batch += 1
+
                 # Step with optimizer
-                if (idx + 1) % self._gradient_accumulation_steps == 0:
+                if self.id_batch % self._gradient_accumulation_steps == 0:
                     # Accumulate running metrics across all devices
                     torch.distributed.all_reduce(
                         running_loss, op=torch.distributed.ReduceOp.AVG

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -266,6 +266,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         self.total_epochs = cfg.epochs
         self.max_steps_per_epoch = cfg.max_steps_per_epoch
         self.global_step = 0
+        self.id_batch = 0
 
     def _update_recipe_state(self, ckpt_dict: dict[str, Any]) -> None:
         """
@@ -927,8 +928,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     current_loss = current_loss * (self.dp_degree / num_tokens)
 
                 current_loss.backward()
+                self.id_batch += 1
                 # Optimizer step (if not fused in backward call)
-                if (idx + 1) % self._gradient_accumulation_steps == 0:
+                if self.id_batch % self._gradient_accumulation_steps == 0:
                     if not self._optimizer_in_bwd:
                         # Get total number of tokens across all ranks to normalize gradients
                         torch.distributed.all_reduce(num_tokens)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

As I was running DPO and SFT, I noticed two surprising behaviours when running for several epochs:
![image](https://github.com/user-attachments/assets/6af6cdad-7a55-4378-9bd8-014af834c564)

1. The loss would drop at the beginning of a new epoch;
2. The accuracy (for DPO) would be >100% at the beginning of a new epoch.
I noticed that statistics accumulators re-initialization and zero-ing gradients would happen in this condition (e.g. `recipes/full_finetune_distributed.py`):
```python
for idx, batch in enumerate(self._dataloader):
    ...
    # Optimizer step (if not fused in backward call)
    if (idx+1) % self._gradient_accumulation_steps == 0:
        ...
```
Now the issue is that if your gradient accumulation parameter is set at say 8, but you only have 63 batches to process, it means that you process the last 7 batches, accumulating statistics and gradients, without re-initializing them before starting the new epoch, continuing accumulating stats and grads for the first 8 batches and then do a step.
You end up accumulating 15 batches instead of 8, messing up not only with the statistics report but also with the optimisation.
I see at least two possibilities:
1. dropping the last few batches so that `len(self._dataloader) % self._gradient_accumulation_steps == 0`;
2. counting the number of batches to accumulate not in terms of batch index but absolute number of processed batches.

#### Changelog
This PR implements the second option.
It should be done for all recipe but I thought discussing the solution first was better.

#### Test plan
- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
