### PR TITLE
Fix a crash from using an invalid logger in some recipes

### DIFF
--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -479,7 +479,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         The core training loop.
         """
         if self._model_compile:
-            log.info(
+            self._logger.info(
                 "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."
             )
 

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -323,7 +323,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                         )
                     )
                 except Exception as e:
-                    log.warning(
+                    self._logger.warning(
                         f"Failed to load distributed checkpoint: {e}. Training will start from the base checkpoint."
                     )
 
@@ -860,7 +860,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         log_dict = {"val_loss": avg_val_loss}
 
         if self._is_rank_zero:
-            log.info(f"Validation loss: {avg_val_loss:.4f}")
+            self._logger.info(f"Validation loss: {avg_val_loss:.4f}")
             self._metric_logger.log_dict(
                 log_dict,
                 step=self.global_step,


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
`lora_finetune_distributed` and `lora_dpo_single_device` recipes use `log.info`/`log.warning` instead of `self._logger` in a couple of places. This causes a crash, for example, after enabling validation in a distributed LoRA recipe.
<details>
<summary>Crash log</summary>

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/lora_finetune_distributed.py", line 906, in <module>
[rank0]:     sys.exit(recipe_main())
[rank0]:              ~~~~~~~~~~~^^
[rank0]:   File "/home/r/soft/torchtune/torchtune/torchtune/config/_parse.py", line 99, in wrapper
[rank0]:     sys.exit(recipe_main(conf))
[rank0]:              ~~~~~~~~~~~^^^^^^
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/lora_finetune_distributed.py", line 901, in recipe_main
[rank0]:     recipe.train()
[rank0]:     ~~~~~~~~~~~~^^
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/lora_finetune_distributed.py", line 793, in train
[rank0]:     self.validate()
[rank0]:     ~~~~~~~~~~~~~^^
[rank0]:   File "/home/r/soft/torchtune/torchtune/recipes/lora_finetune_distributed.py", line 863, in validate
[rank0]:     log.info(f"Validation loss: {avg_val_loss:.4f}")
[rank0]:     ^^^
[rank0]: NameError: name 'log' is not defined
```
</details>

#### Test plan

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
