### PR TITLE
Fix failing KD single device recipe

### DIFF
--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -156,7 +156,6 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         del new_cfg["checkpointer"]
         teacher_checkpoint_val = new_cfg.pop("teacher_checkpointer")
         new_cfg["checkpointer"] = teacher_checkpoint_val
-        print("new config is: ", new_cfg)
 
         teacher_checkpoint_client = CheckpointClient(
             new_cfg,

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -145,16 +145,21 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         self._checkpoint_client = CheckpointClient(cfg)
         self._enable_async_checkpointing = cfg.get("enable_async_checkpointing", False)
 
-    def load_teacher_checkpoint(self, cfg_checkpointer: DictConfig) -> dict[str, Any]:
+    def load_teacher_checkpoint(self, cfg: DictConfig) -> dict[str, Any]:
         """
         Extract the teacher checkpoint state from file.
         """
-        # add checkpointer class to config to work with checkpoint_client
-        checkpointer_dict = {"checkpointer": cfg_checkpointer}
+        # update checkpointer class to config to work with checkpoint_client
+        # by setting the teacher_checkpointer key as the checkpointer key
+        # that the checkpoint client will use to load
+        new_cfg = OmegaConf.create(cfg)
+        del new_cfg["checkpointer"]
+        teacher_checkpoint_val = new_cfg.pop("teacher_checkpointer")
+        new_cfg["checkpointer"] = teacher_checkpoint_val
+        print("new config is: ", new_cfg)
 
-        new_cfg_checkpointer = OmegaConf.create(checkpointer_dict)
         teacher_checkpoint_client = CheckpointClient(
-            new_cfg_checkpointer,
+            new_cfg,
         )
         checkpoint_dict = teacher_checkpoint_client.load_base_checkpoint()
         return checkpoint_dict
@@ -218,9 +223,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
                 "NPU does not support model compilation. Please set `compile: False` in the config."
             )
 
-        teacher_checkpoint_dict = self.load_teacher_checkpoint(
-            cfg_checkpointer=cfg.teacher_checkpointer
-        )
+        teacher_checkpoint_dict = self.load_teacher_checkpoint(cfg=cfg)
 
         common_utils._use_low_cpu_ram = cfg.get("low_cpu_ram", False)
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
Fix bug introduced in https://github.com/pytorch/torchtune/pull/2726

#### Changelog
What are the changes made in this PR?
* In the PR that caused the issue (https://github.com/pytorch/torchtune/pull/2726) we're loading the teacher checkpoint by providing the checkpoint client with only the teacher checkpoint config, but this causes it to not have the values of variables that are set like $output_dir. This PR fixes the issue by providing the checkpoint client with the whole config when loading teacher checkpoints.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [x ] run recipe tests via `pytest tests -m integration_test`
- [x ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
