### PR TITLE
Fix Tokenizer Inference

### DIFF
--- a/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
+++ b/tests/torchtune/models/qwen2/test_qwen2_tokenizer.py
@@ -99,6 +99,6 @@ class TestQwenTokenizer:
         # fmt: on
 
         expected_mask = [True] * 67 + [False] * 120
-        tokens, mask = tokenizer.tokenize_messages(messages, add_eos=False)
+        tokens, mask = tokenizer.tokenize_messages(messages, add_end_tokens=False)
         assert tokens == expected_tokens
         assert mask == expected_mask

--- a/torchtune/models/qwen2/_tokenizer.py
+++ b/torchtune/models/qwen2/_tokenizer.py
@@ -329,7 +329,7 @@ class Qwen2Tokenizer(ModelTokenizer):
         self,
         messages: list[Message],
         *,
-        add_eos: bool = True,
+        add_end_tokens: bool = True,
     ) -> tuple[list[int], list[bool]]:
         """
         Given a list of messages, return a list of tokens for the concatenated
@@ -337,8 +337,8 @@ class Qwen2Tokenizer(ModelTokenizer):
 
         Args:
             messages (list[Message]): The message list to tokenize.
-            add_eos (bool): Wether to add the tokenizer's eos_id at the end of the
-                sequence of messages. Default is True.
+            add_end_tokens (bool): Wether to add the tokenizer's end of message
+                tokens, such as  eos_id. Default is True.
 
         Returns:
             tuple[list[int], list[bool]]: The list of token ids and the list of masks.
@@ -398,7 +398,7 @@ class Qwen2Tokenizer(ModelTokenizer):
                 break
 
         # Add the End-Of-Sequence token
-        if add_eos:
+        if add_end_tokens:
             tokenized_messages.append(self.eos_id)
             mask.append(mask[-1])
 
@@ -407,13 +407,13 @@ class Qwen2Tokenizer(ModelTokenizer):
             tokenized_messages = truncate(
                 tokens=tokenized_messages,
                 max_seq_len=self.max_seq_len,
-                eos_id=self.eos_id if add_eos else None,
+                eos_id=self.eos_id if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
             mask = truncate(
                 tokens=mask,
                 max_seq_len=self.max_seq_len,
-                eos_id=True if add_eos else None,
+                eos_id=True if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
 
@@ -436,7 +436,7 @@ class Qwen2Tokenizer(ModelTokenizer):
             inference (bool): Whether the template is being used for inference or not.
         """
         messages = sample.pop("messages")
-        tokens, mask = self.tokenize_messages(messages)
+        tokens, mask = self.tokenize_messages(messages, add_end_tokens=not inference)
         sample["tokens"] = tokens
         sample["mask"] = mask
         return sample

--- a/torchtune/models/qwen2_5/_tokenizer.py
+++ b/torchtune/models/qwen2_5/_tokenizer.py
@@ -124,7 +124,7 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
         self,
         messages: list[Message],
         *,
-        add_eos: bool = True,
+        add_end_tokens: bool = True,
     ) -> tuple[list[int], list[bool]]:
         """
         Given a list of messages, return a list of tokens for the concatenated
@@ -132,8 +132,8 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
 
         Args:
             messages (list[Message]): The message list to tokenize.
-            add_eos (bool): Wether to add the tokenizer's eos_id at the end of the
-                sequence of messages. Default is True.
+            add_end_tokens (bool): Wether to add the tokenizer's end of message
+                tokens, such as  eos_id. Default is True.
 
         Returns:
             tuple[list[int], list[bool]]: The list of token ids and the list of masks.
@@ -183,7 +183,7 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
                 break
 
         # Add the End-Of-Sequence token
-        if add_eos:
+        if add_end_tokens:
             tokenized_messages.append(self.eos_id)
             mask.append(mask[-1])
 
@@ -192,13 +192,13 @@ class Qwen2_5Tokenizer(Qwen2Tokenizer):  # noqa: N801
             tokenized_messages = truncate(
                 tokens=tokenized_messages,
                 max_seq_len=self.max_seq_len,
-                eos_id=self.eos_id if add_eos else None,
+                eos_id=self.eos_id if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
             mask = truncate(
                 tokens=mask,
                 max_seq_len=self.max_seq_len,
-                eos_id=True if add_eos else None,
+                eos_id=True if add_end_tokens else None,
                 truncation_type=self.truncation_type,
             )
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Qwen base tokenizer __call__ method didn't pass the inference flag into tokenize_messages. This affected all Qwen models. Issue reported on [discord](https://discord.com/channels/1216353675241590815/1216353675744641096/1374658007878598699).

#### Changelog
Update __call__ to not add_end_tokens when inference==True. Update naming in tokenizer to use add_end_tokens instead of add_eos.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

Ran user provided config for Qwen2, Qwen2.5, and Qwen3:
```
output_dir: ./ # Not needed
base_model_dir: /tmp/Qwen2.5-0.5B-Instruct

# Model arguments
model:
  _component_: torchtune.models.qwen2_5.qwen2_5_0_5b

checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: ${base_model_dir}
  checkpoint_files: [model.safetensors]
  recipe_checkpoint: null
  output_dir: ${output_dir}
  model_type: QWEN2

device: cuda
dtype: bf16

seed: 1234

# Tokenizer arguments
tokenizer:
  _component_: torchtune.models.qwen2_5.qwen2_5_tokenizer
  path: ${base_model_dir}/vocab.json
  merges_file: ${base_model_dir}/merges.txt
  max_seq_len: null

# Generation arguments; defaults taken from gpt-fast
prompt:
  system: null
  user: "Tell me a joke."
max_new_tokens: 300
temperature: 0.6 # 0.8 and 0.6 are popular values to try
top_k: 300

enable_kv_cache: True
quantizer: null
```