### PR TITLE
Fix TP, enable test, silence noisy logs

### DIFF
--- a/.github/workflows/gpu_test.yaml
+++ b/.github/workflows/gpu_test.yaml
@@ -30,9 +30,8 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
         torch-version: ["stable", "nightly"]
         # Do not run against nightlies on PR
-        # TODO: REMOVE (just for debug)
-        # exclude:
-        #   - torch-version: ${{ github.event_name == 'pull_request' && 'nightly' }}
+        exclude:
+          - torch-version: ${{ github.event_name == 'pull_request' && 'nightly' }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/gpu_test.yaml
+++ b/.github/workflows/gpu_test.yaml
@@ -30,8 +30,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
         torch-version: ["stable", "nightly"]
         # Do not run against nightlies on PR
-        exclude:
-          - torch-version: ${{ github.event_name == 'pull_request' && 'nightly' }}
+        # TODO: REMOVE (just for debug)
+        # exclude:
+        #   - torch-version: ${{ github.event_name == 'pull_request' && 'nightly' }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -231,7 +231,11 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         self._activation_offloading_use_streams = cfg.get(
             "activation_offloading_use_streams", True
         )
-        if self._activation_offloading_use_streams and self.parallel_dims.tp_enabled:
+        if (
+            self._enable_activation_offloading
+            and self._activation_offloading_use_streams
+            and self.parallel_dims.tp_enabled
+        ):
             warn(
                 message=(
                     "Using activation offloading with streams is not advised in tensor parallel, and may "

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 import torch
+from packaging import version
 from tests.common import TUNE_PATH
 
 from tests.recipes.utils import (
@@ -130,7 +131,8 @@ class TestFullFinetuneDistributedRecipe:
         )
 
     @pytest.mark.skipif(
-        torch.__version__ < "2.8.0", reason="2D parallel test requires PyTorch >= 2.8"
+        version.parse(torch.__version__).base_version < "2.8.0",
+        reason="2D parallel test requires PyTorch >= 2.8",
     )
     @pytest.mark.integration_test
     @pytest.mark.parametrize(

--- a/torchtune/models/llama3/_parallelism.py
+++ b/torchtune/models/llama3/_parallelism.py
@@ -37,8 +37,8 @@ def _get_base_llama_tp_training_plan(
         "norm": SequenceParallel(),
         "output": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
         "layers.*.attn": layerwise_prepare_module_input_cls(
-            input_layouts=(Shard(1), None),
-            desired_input_layouts=(Replicate(), None),
+            input_layouts=(Shard(1), Shard(1)),
+            desired_input_layouts=(Replicate(), Replicate()),
         ),
         "layers.*.mlp": layerwise_prepare_module_input_cls(
             input_layouts=(Shard(1),),

--- a/torchtune/models/llama4/_parallelism.py
+++ b/torchtune/models/llama4/_parallelism.py
@@ -63,8 +63,8 @@ def decoder_only_tp_training_plan(model: nn.Module) -> dict[str, ParallelStyle]:
         layer_plan = {
             f"decoder.layers.{layer_id}.sa_norm": SequenceParallel(),
             f"decoder.layers.{layer_id}.attn": PrepareModuleInput(
-                input_layouts=(Shard(1), None),
-                desired_input_layouts=(Replicate(), None),
+                input_layouts=(Shard(1), Shard(1)),
+                desired_input_layouts=(Replicate(), Replicate()),
             ),
             f"decoder.layers.{layer_id}.attn.q_proj": ColwiseParallel(),
             f"decoder.layers.{layer_id}.attn.k_proj": ColwiseParallel(),


### PR DESCRIPTION
Fixing a few things:

1) Our TP training has been broken since https://github.com/pytorch/pytorch/pull/149764. We were not correctly redistributing the tensors on their way into our attention layers: since we pass both x and y [here](https://github.com/pytorch/torchtune/blob/fa92c96ffcc79aff3a91dcb542788f3206906406/torchtune/modules/attention.py#L183-L184), we also need to convert `y` from sharded on sequence dim to replicated.
2) We didn't catch this because of how we were checking PyTorch version in our TP test. Doing direct comparison we will actually get `torch.__version__ < "2.8.0"` on 2.8 nightlies. So instead we can use base_version to get this test to run on nightlies again.
3) Also along the way I got a bunch of angry logs yelling at me about using activation offloading with streams even though I wasn't. So fixing the check 

Test plan: 

On latest nightlies:

```
pytest tests -m integration_test tests/recipes/test_full_finetune_distributed.py -k 'test_loss_2d_parallel'
...
========== 2 passed, 14 deselected in 40.54s ========
```

Also patched our CI job to run against nightlies just to ensure everything works on the CI runners:

<img width="1203" alt="Screenshot 2025-05-22 at 5 31 14 PM" src="https://github.com/user-attachments/assets/7b5ae643-d3ad-4a31-9c42-cdbbf6144e7a" />


```
tune run --nproc_per_node 4 full_finetune_distributed --config llama3/8B_full \
tensor_parallel_plan._component_=torchtune.models.llama3.base_llama_tp_plan tensor_parallel_dim=4 \
metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=test-tp \
metric_logger.name=llama3-8b max_steps_per_epoch=50
```
<img width="1643" alt="Screenshot 2025-05-22 at 4 10 57 PM" src="https://github.com/user-attachments/assets/699524b9-53b0-4590-89be-7eadf52eaffa" />

```
tune run --nproc_per_node 8 full_finetune_distributed --config llama4/scout_17B_16E_full \
metric_logger=torchtune.training.metric_logging.WandBLogger metric_logger.project=test-tp \
metric_logger.name=llama4-scout max_steps_per_epoch=50
```

<img width="1651" alt="Screenshot 2025-05-22 at 5 04 55 PM" src="https://github.com/user-attachments/assets/e95bcfb9-e076-4844-8886-c6b321f6104c" />


Note that our generation TP plans do not use `PrepareModuleInput` for attention layers so we don't need to make any analogous changes to those.