### PR TITLE
[compile] Fix compile producing NaNs

### DIFF
--- a/torchtune/models/llama4/_chunked_attention.py
+++ b/torchtune/models/llama4/_chunked_attention.py
@@ -17,9 +17,6 @@ if _SUPPORTS_FLEX_ATTENTION:
     from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 
 
-# Compilation graph breaks here can result in NaNs.
-# This is suboptimal to not compile create_block_mask,
-# TODO: Enable once it compiles without graph breaks.
 def get_chunked_attention_mask(
     mask: Optional[_MaskType],
     chunk_size: int,

--- a/torchtune/models/llama4/_chunked_attention.py
+++ b/torchtune/models/llama4/_chunked_attention.py
@@ -20,7 +20,6 @@ if _SUPPORTS_FLEX_ATTENTION:
 # Compilation graph breaks here can result in NaNs.
 # This is suboptimal to not compile create_block_mask,
 # TODO: Enable once it compiles without graph breaks.
-@torch._dynamo.disable(recursive=True)
 def get_chunked_attention_mask(
     mask: Optional[_MaskType],
     chunk_size: int,

--- a/torchtune/models/llama4/_chunked_attention.py
+++ b/torchtune/models/llama4/_chunked_attention.py
@@ -17,6 +17,10 @@ if _SUPPORTS_FLEX_ATTENTION:
     from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 
 
+# Compilation graph breaks here can result in NaNs.
+# This is suboptimal to not compile create_block_mask,
+# TODO: Enable once it compiles without graph breaks.
+@torch._dynamo.disable(recursive=True)
 def get_chunked_attention_mask(
     mask: Optional[_MaskType],
     chunk_size: int,

--- a/torchtune/modules/attention_utils.py
+++ b/torchtune/modules/attention_utils.py
@@ -24,7 +24,7 @@ if _SUPPORTS_FLEX_ATTENTION:
 
     def compile_flex_attention():
         try:
-            return torch.compile(flex_attention, dynamic=False)
+            return torch.compile(flex_attention)
         except Exception as e:
             # It may fail on some combinations of hardware/versions. Using max-autotune fixes this issue.
             # Context: https://github.com/pytorch/torchtune/issues/2113
@@ -32,7 +32,7 @@ if _SUPPORTS_FLEX_ATTENTION:
                 f"Compiling flex_attention failed with error '{e}'. Retrying with mode='max-autotune'."
             )
             try:
-                return torch.compile(flex_attention, dynamic=False, mode="max-autotune")
+                return torch.compile(flex_attention, mode="max-autotune")
             except Exception as e:
                 _log.info(
                     f"Compiling flex_attention failed with error: '{e}', "

--- a/torchtune/modules/moe/experts.py
+++ b/torchtune/modules/moe/experts.py
@@ -50,6 +50,8 @@ class GroupedExperts(nn.Module):
     # TODO: force no inference mode as a hack to get around
     # "Cannot set version_counter for inference tensor"
     @torch.inference_mode(mode=False)
+    # TODO: remove once compilation is fixed
+    @torch._dynamo.disable(recursive=False)
     def forward(
         self,
         x: torch.Tensor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2765


1/ moe/experts.py - dynamo compilation fails because of unbacked symints from tolist().

This results in IllegalMemoryAccess in flex_attention - disabling it for now, until the compilation is fixed to avoid hard failure

2/ flex_attention supports dynamic shapes compilation, and this also gives perf wins.

In my test for llama4 (+grouped_mm) on 4 gpus I got 
tps_per_gpu 471 -> 530

Running llama4 distributed compile for 50 iterations, no NaNs

![Screenshot 2025-05-28 at 19 06 58](https://github.com/user-attachments/assets/02f98642-2d55-4c21-896d-9358c0b027cd)
