### PR TITLE
Improve torch.compile log message in compile_model

### DIFF
--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -608,8 +608,6 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         The core training loop.
         """
 
-        
-
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()
         running_class_loss = 0

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -570,7 +570,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
 
     def _loss_step(
         self, batch: dict[str, torch.Tensor]
-    ) ->tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # Both are shape [b, s]
         tokens, labels = batch["tokens"], batch["labels"]
 

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 from functools import partial
-from typing import Any, Optional, Union, Tuple
+from typing import Any, Optional, Union
 from warnings import warn
 
 import torch
@@ -570,7 +570,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
 
     def _loss_step(
         self, batch: dict[str, torch.Tensor]
-    ) ->Tuple[torch.Tensor, torch.Tensor]:
+    ) ->tuple[torch.Tensor, torch.Tensor]:
         # Both are shape [b, s]
         tokens, labels = batch["tokens"], batch["labels"]
 

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 from functools import partial
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Tuple
 from warnings import warn
 
 import torch
@@ -570,7 +570,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
 
     def _loss_step(
         self, batch: dict[str, torch.Tensor]
-    ) -> (torch.Tensor, torch.Tensor):
+    ) ->Tuple[torch.Tensor, torch.Tensor]:
         # Both are shape [b, s]
         tokens, labels = batch["tokens"], batch["labels"]
 
@@ -608,10 +608,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         The core training loop.
         """
 
-        if self._compile:
-            self._logger.info(
-                "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."
-            )
+        
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -478,10 +478,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         """
         The core training loop.
         """
-        if self._model_compile:
-            self._logger.info(
-                "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."
-            )
+        
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -478,7 +478,6 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         """
         The core training loop.
         """
-        
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -583,10 +583,7 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         The core training loop.
         """
 
-        if self._compile:
-            self._logger.info(
-                "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."
-            )
+        
 
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -583,8 +583,6 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
         The core training loop.
         """
 
-        
-
         # Initialize tokens count and running loss (for grad accumulation)
         t0 = time.perf_counter()
         running_loss = 0

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -929,11 +929,7 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
         """
         The core training loop."""
 
-        if self.compile:
-            self._logger.info(
-                "NOTE: torch.compile is enabled and model is compiled in first forward."
-                "Expect a relatively slow first iteration."
-            )
+        
         # zero out the gradients before starting training
         if not self._optimizer_in_bwd:
             self._optimizer.zero_grad()

--- a/recipes/ppo_full_finetune_single_device.py
+++ b/recipes/ppo_full_finetune_single_device.py
@@ -929,7 +929,6 @@ class PPOFullFinetuneRecipeSingleDevice(FTRecipeInterface):
         """
         The core training loop."""
 
-        
         # zero out the gradients before starting training
         if not self._optimizer_in_bwd:
             self._optimizer.zero_grad()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,6 @@ import pytest
 
 import torch
 from torch import nn
-import logging
 from torchtune.data import Message, PromptTemplate, truncate
 from torchtune.modules.transforms import Transform
 from torchtune.modules.transforms.tokenizers import ModelTokenizer
@@ -387,23 +386,4 @@ def rl_test() -> bool:
     return pytest.mark.skipif(
         "not config.getoption('--run-rl-tests')",
         reason="Only run when --run-rl-tests is given",
-    )
-
-class DummyTransformer(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.layer = nn.Linear(10, 10)
-
-    def modules(self):
-        return [self.layer]
-
-def test_compile_model_logs_message(caplog):
-    model = DummyTransformer()
-
-    with caplog.at_level(logging.INFO):
-        compile_model(model, verbose=True)
-
-    assert any(
-        "Compiling model layers with torch.compile. Expect a relatively slower first step."
-        in message for message in caplog.messages
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,9 +18,11 @@ import pytest
 
 import torch
 from torch import nn
+import logging
 from torchtune.data import Message, PromptTemplate, truncate
 from torchtune.modules.transforms import Transform
 from torchtune.modules.transforms.tokenizers import ModelTokenizer
+from torchtune.training._compile import compile_model
 
 
 CKPT_MODEL_PATHS = {
@@ -385,4 +387,23 @@ def rl_test() -> bool:
     return pytest.mark.skipif(
         "not config.getoption('--run-rl-tests')",
         reason="Only run when --run-rl-tests is given",
+    )
+
+class DummyTransformer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Linear(10, 10)
+
+    def modules(self):
+        return [self.layer]
+
+def test_compile_model_logs_message(caplog):
+    model = DummyTransformer()
+
+    with caplog.at_level(logging.INFO):
+        compile_model(model, verbose=True)
+
+    assert any(
+        "Compiling model layers with torch.compile. Expect a relatively slower first step."
+        in message for message in caplog.messages
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,6 @@ from torch import nn
 from torchtune.data import Message, PromptTemplate, truncate
 from torchtune.modules.transforms import Transform
 from torchtune.modules.transforms.tokenizers import ModelTokenizer
-from torchtune.training._compile import compile_model
 
 
 CKPT_MODEL_PATHS = {

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -43,7 +43,7 @@ def compile_model(
         model = model.decoder
     # Per-layer compilation by default
     if verbose:
-        log.info("Compiling model layers with torch.compile...")
+        log.info("Compiling model layers with torch.compile. Expect a relatively slower first step.")
     for m in reversed(list(model.modules())):
         if isinstance(m, TransformerSelfAttentionLayer) or isinstance(
             m, TransformerCrossAttentionLayer

--- a/torchtune/training/_compile.py
+++ b/torchtune/training/_compile.py
@@ -43,7 +43,9 @@ def compile_model(
         model = model.decoder
     # Per-layer compilation by default
     if verbose:
-        log.info("Compiling model layers with torch.compile. Expect a relatively slower first step.")
+        log.info(
+            "Compiling model layers with torch.compile. Expect a relatively slower first step."
+        )
     for m in reversed(list(model.modules())):
         if isinstance(m, TransformerSelfAttentionLayer) or isinstance(
             m, TransformerCrossAttentionLayer


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.
Closes https://github.com/pytorch/torchtune/issues/2717

#### Changelog
What are the changes made in this PR?
-Updated the log message in torchtune/utils/compile_model.py to read:
   `"Compiling model layers with torch.compile. Expect a relatively slower first step."`

-Removed similar/sprinkled references elsewhere in the codebase to centralize this message.

*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
