### PR TITLE
Fix typing in _grad_scaler.py for nightly compatibility

### DIFF
--- a/torchtune/training/_grad_scaler.py
+++ b/torchtune/training/_grad_scaler.py
@@ -10,9 +10,15 @@ from typing import Optional
 import torch
 from torch import nn, Tensor
 from torch.distributed.tensor import DTensor
-from torch.nn.utils.clip_grad import _no_grad, _TensorOrTensors
+from torch.nn.utils.clip_grad import _no_grad
 from torch.utils._foreach_utils import _device_has_foreach_support, _has_foreach_support
 from torchtune.utils._logging import deprecated
+
+
+if torch.__version__ < "2.8.0.dev20250601":
+    from torch.nn.utils.clip_grad import _tensor_or_tensors as TensorOrTensors
+else:
+    from torch.nn.utils.clip_grad import _TensorOrTensors as TensorOrTensors
 
 
 @deprecated(msg="Please use `scale_grads_` instead.")
@@ -41,7 +47,7 @@ def scale_grads(model: nn.Module, scaler: torch.Tensor) -> None:
 
 @_no_grad
 def scale_grads_(
-    parameters: _TensorOrTensors,
+    parameters: TensorOrTensors,
     scaler: torch.Tensor,
     foreach: Optional[bool] = None,
 ) -> None:
@@ -51,7 +57,7 @@ def scale_grads_(
     Gradients are modified in-place, multiplying by specified scaler.
 
     Args:
-        parameters (_TensorOrTensors): an iterable of Tensors or a
+        parameters (TensorOrTensors): an iterable of Tensors or a
             single Tensor that will have gradients scaled
         scaler (torch.Tensor): multiplier to scale gradients
         foreach (Optional[bool]): use the faster foreach-based implementation.
@@ -80,7 +86,7 @@ def _group_tensors_by_device(
 
 @_no_grad
 def _scale_grad_(
-    parameters: _TensorOrTensors,
+    parameters: TensorOrTensors,
     scaler: torch.Tensor,
     foreach: Optional[bool] = None,
 ) -> None:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
Fixes the typing changes introduced in https://github.com/pytorch/pytorch/pull/154801

If we need `main` working with the stable pytorch 2.7.0 release, we will have to either not type and selectively disable type checking, or define the type in the file rather than importing.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
