### PR TITLE
Enable loss parallel, Ungate FP8

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -1037,7 +1037,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                                 num_tokens / self.parallel_dims.non_data_parallel_size
                             )
                             / (time_per_step * self.world_size),
-                            "num_tokens": num_tokens,
                         }
                         if self._log_peak_memory_stats:
                             log_dict.update(

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -627,6 +627,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                     self.tp_plan,
                     model=model,
                     loss_parallel=self.parallel_dims.loss_parallel_enabled,
+                    enable_fp8_training=self._enable_fp8_training,
                 )
             parallelize_module(
                 model,

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -365,8 +365,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             )
 
         # Whether to use the ctx manager. If the loss fn has the property, use that. Otherwise, assume it is not supported.
-        # Currently our TP plans assume replicating on the output of `output` so without a custom loss class, there is
-        # no memory benefit to the ctx manager
+        # Currently our TP plans assume replicating on the output of `output` so without a custom loss class patching the
+        # TP plan, there is no memory benefit to the ctx manager
         self.use_loss_parallel_ctx_manager = (
             self.parallel_dims.loss_parallel_enabled
             and getattr(

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -357,10 +357,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)
-
-        # Whether to use the ctx manager. If the loss fn has the property, use that. Otherwise, assume it is not supported.
-        # Currently our TP plans assume replicating on the output of `output` so without a custom loss class patching the
-        # TP plan, there is no memory benefit to the ctx manager
         self.use_loss_parallel_ctx_manager = self.parallel_dims.tp_enabled and getattr(
             self._loss_fn,
             "tp_requires_loss_parallel_ctx_manager",

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -364,14 +364,15 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 self.parallel_dims.loss_parallel_enabled
             )
 
-        # Whether to use the ctx manager. If the loss fn has the property, use that. Otherwise, assume it is supported.
-        # Useful if, for example, user opts to use the basic CrossEntropyLoss() instead of an SFTLoss subclass.
+        # Whether to use the ctx manager. If the loss fn has the property, use that. Otherwise, assume it is not supported.
+        # Currently our TP plans assume replicating on the output of `output` so without a custom loss class, there is
+        # no memory benefit to the ctx manager
         self.use_loss_parallel_ctx_manager = (
             self.parallel_dims.loss_parallel_enabled
             and getattr(
                 self._loss_fn,
                 "use_loss_parallel_ctx_manager",
-                True,
+                False,
             )
         )
 

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -701,7 +701,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             model, enable_activation_offloading, activation_offloading_use_streams
         )
         # context parallel
-        self.optional_context_parallel_manager = training.get_context_parallel_manager(
+        self.context_parallel_manager = training.get_context_parallel_manager(
             enabled=self.cp_degree > 1,
             world_mesh=self.world_mesh,
             model=model,
@@ -944,7 +944,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 num_tokens += current_num_tokens
 
                 with self.train_context(
-                    self.optional_context_parallel_manager(list(batch.values()))
+                    self.context_parallel_manager(list(batch.values()))
                 ):
                     # Loss is normalized by default so we multiply by the number of tokens
                     # This way we can normalize by the total number of tokens if we're accumulating gradients

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -347,6 +347,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             self._compile_loss = compile.get("loss", True)
             self._compile_optimizer_step = compile.get("optimizer_step", False)
             self._compile_scale_grads = compile.get("scale_grads", True)
+            self._compile_autograd = compile.get("autograd", False)
         if self._compile_model:
             # Capture scalar outputs is required to compile MoE
             torch._dynamo.config.capture_scalar_outputs = True

--- a/tests/torchtune/training/test_quantization.py
+++ b/tests/torchtune/training/test_quantization.py
@@ -10,8 +10,7 @@ import torch
 
 from torchao.float8.float8_linear import Float8Linear
 
-from torchtune.models.llama3 import base_llama_tp_plan
-from torchtune.models.llama3._parallelism import _fp8_llama_tp_plan
+from torchtune.models.llama3 import base_llama_tp_plan, fp8_llama_tp_plan
 from torchtune.training.quantization import (
     _validate_float8_tp_plan,
     convert_to_float8_training,
@@ -54,12 +53,12 @@ class TestFloat8:
         """
         _validate_float8_tp_plan(base_llama_tp_plan())
         _validate_float8_tp_plan(base_llama_tp_plan(), "anything")
-        _validate_float8_tp_plan(_fp8_llama_tp_plan())
-        _validate_float8_tp_plan(_fp8_llama_tp_plan(), "tensorwise")
+        _validate_float8_tp_plan(fp8_llama_tp_plan())
+        _validate_float8_tp_plan(fp8_llama_tp_plan(), "tensorwise")
         with pytest.raises(ValueError):
-            _validate_float8_tp_plan(_fp8_llama_tp_plan(), "rowwise")
+            _validate_float8_tp_plan(fp8_llama_tp_plan(), "rowwise")
         with pytest.raises(ValueError):
-            _validate_float8_tp_plan(_fp8_llama_tp_plan(), "rowwise_with_gw_hp")
+            _validate_float8_tp_plan(fp8_llama_tp_plan(), "rowwise_with_gw_hp")
 
     def test_is_fp8_tensorwise_scaling(self):
         """

--- a/tests/torchtune/training/test_quantization.py
+++ b/tests/torchtune/training/test_quantization.py
@@ -10,7 +10,8 @@ import torch
 
 from torchao.float8.float8_linear import Float8Linear
 
-from torchtune.models.llama3 import base_llama_tp_plan, fp8_llama_tp_plan
+from torchtune.models.llama3 import base_llama_tp_plan
+from torchtune.models.llama3._parallelism import _get_fp8_llama_tp_training_plan
 from torchtune.training.quantization import (
     _validate_float8_tp_plan,
     convert_to_float8_training,
@@ -53,12 +54,14 @@ class TestFloat8:
         """
         _validate_float8_tp_plan(base_llama_tp_plan())
         _validate_float8_tp_plan(base_llama_tp_plan(), "anything")
-        _validate_float8_tp_plan(fp8_llama_tp_plan())
-        _validate_float8_tp_plan(fp8_llama_tp_plan(), "tensorwise")
+        _validate_float8_tp_plan(_get_fp8_llama_tp_training_plan())
+        _validate_float8_tp_plan(_get_fp8_llama_tp_training_plan(), "tensorwise")
         with pytest.raises(ValueError):
-            _validate_float8_tp_plan(fp8_llama_tp_plan(), "rowwise")
+            _validate_float8_tp_plan(_get_fp8_llama_tp_training_plan(), "rowwise")
         with pytest.raises(ValueError):
-            _validate_float8_tp_plan(fp8_llama_tp_plan(), "rowwise_with_gw_hp")
+            _validate_float8_tp_plan(
+                _get_fp8_llama_tp_training_plan(), "rowwise_with_gw_hp"
+            )
 
     def test_is_fp8_tensorwise_scaling(self):
         """

--- a/torchtune/models/llama3/__init__.py
+++ b/torchtune/models/llama3/__init__.py
@@ -15,7 +15,7 @@ from ._model_builders import (  # noqa
     qlora_llama3_70b,
     qlora_llama3_8b,
 )
-from ._parallelism import base_llama_tp_plan
+from ._parallelism import base_llama_tp_plan, fp8_llama_tp_plan
 from ._tokenizer import Llama3Tokenizer
 
 __all__ = [
@@ -30,4 +30,5 @@ __all__ = [
     "qlora_llama3_8b",
     "qlora_llama3_70b",
     "base_llama_tp_plan",
+    "fp8_llama_tp_plan",
 ]

--- a/torchtune/models/llama3/__init__.py
+++ b/torchtune/models/llama3/__init__.py
@@ -15,7 +15,7 @@ from ._model_builders import (  # noqa
     qlora_llama3_70b,
     qlora_llama3_8b,
 )
-from ._parallelism import base_llama_tp_plan, fp8_llama_tp_plan
+from ._parallelism import base_llama_tp_plan
 from ._tokenizer import Llama3Tokenizer
 
 __all__ = [
@@ -30,5 +30,4 @@ __all__ = [
     "qlora_llama3_8b",
     "qlora_llama3_70b",
     "base_llama_tp_plan",
-    "fp8_llama_tp_plan",
 ]

--- a/torchtune/models/llama4/_parallelism.py
+++ b/torchtune/models/llama4/_parallelism.py
@@ -161,7 +161,10 @@ def decoder_only_tp_inference_plan(model: nn.Module) -> dict[str, ParallelStyle]
 
 
 def decoder_only_tp_plan(
-    model: nn.Module, inference: bool = False
+    model: nn.Module,
+    *,
+    inference: bool = False,
+    enable_fp8_training: bool = False,
 ) -> dict[str, ParallelStyle]:
     """
     Helper function to get the base tensor parallel plan for Llama3 model, which will also be shared with 3.1, 3.2, and 3.3 models
@@ -169,10 +172,16 @@ def decoder_only_tp_plan(
     Args:
         model (nn.Module): Model to generate plan for (no-op)
         inference (bool): Whether running inference or not.
+        enable_fp8_training (bool): Whether to enable float8 training. Currently not supported for Llama4.
 
     Returns:
         dict[str, Any]: The tensor parallel plan for Llama3 model.
+
+    Raises:
+        ValueError: if FP8 training is enabled.
     """
+    if enable_fp8_training:
+        raise ValueError("FP8 training is not supported for Llama4")
     return (
         decoder_only_tp_inference_plan(model)
         if inference

--- a/torchtune/modules/loss/cross_entropy_loss.py
+++ b/torchtune/modules/loss/cross_entropy_loss.py
@@ -134,8 +134,6 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
             - The indexed hidden states
             - The indexed targets
         """
-        # slicing requires both tensors to be same type
-        # since hidden is sharded on the feature dim, slicing on seq dim is possible
         if isinstance(hidden, DTensor):
             device_mesh = hidden.device_mesh
             hidden = hidden.to_local().index_select(0, indices)
@@ -174,7 +172,6 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
                 placements=[Shard(-1)] * outputs.device_mesh.ndim,
             )
 
-        # forcefully reshaping ensures same dim tensor, even if mask is all True
         targets = targets.reshape(-1)
         outputs = outputs.reshape(-1, outputs.shape[-1])
 

--- a/torchtune/modules/loss/cross_entropy_loss.py
+++ b/torchtune/modules/loss/cross_entropy_loss.py
@@ -54,7 +54,7 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
     def apply_compile_strategy(self, *args, **kwargs):
         """Applies compile only to the compute_cross_entropy function.
         If compiling CE + chunking operation together, memory requirement is higher."""
-        # we might be able to compile in TP case if masking is disabled?
+        # compiling with loss parallelism appears to work without masking
         if not self.loss_parallel_enabled or not self.mask_ignored:
             self.compute_cross_entropy = torch.compile(
                 self.compute_cross_entropy, *args, **kwargs
@@ -125,8 +125,8 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Args:
-            hidden (torch.Tensor): Hidden state of the model, pre projection. Shape ``[bsz, seq_len, emb_dim]``
-            target (torch.Tensor): Labels for the model. Shape ``[bsz, seq_len]``
+            hidden (torch.Tensor): Hidden state of the model, pre projection. Shape ``[bsz*seq_len, emb_dim]``
+            target (torch.Tensor): Labels for the model. Shape ``[bsz*seq_len]``
             indices (torch.Tensor): Indices of the valid tokens. Shape ``[num_valid]``
 
         Returns:

--- a/torchtune/modules/loss/cross_entropy_loss.py
+++ b/torchtune/modules/loss/cross_entropy_loss.py
@@ -102,8 +102,6 @@ class LinearCrossEntropyLoss(nn.Module, SFTLoss):
         if self.linear_projection is None:
             raise AttributeError("forward called before update_model")
         logits = self.linear_projection(hidden_chunk)  # [num_valid, vocab_size]
-        if isinstance(logits, DTensor) and not self.loss_parallel:
-            logits = logits.full_tensor()
 
         loss = F.cross_entropy(
             logits.float(),

--- a/torchtune/modules/loss/cross_entropy_loss.py
+++ b/torchtune/modules/loss/cross_entropy_loss.py
@@ -105,6 +105,10 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
         Raises:
             AttributeError: if called before update_model
         """
+        # this explicit flattening ensures same tensor dimension, regardless of if mask is all true
+        target_chunk = target_chunk.reshape(-1)
+        hidden_chunk = hidden_chunk.reshape(-1, hidden_chunk.shape[-1])
+
         mask_chunk = target_chunk != self.ignore_index
         if mask_chunk.sum() == 0:
             # Unmask 1 token to allow loss to sync with all data parallel workers

--- a/torchtune/modules/loss/cross_entropy_loss.py
+++ b/torchtune/modules/loss/cross_entropy_loss.py
@@ -105,20 +105,17 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
         Raises:
             AttributeError: if called before update_model
         """
-        # target_chunk = target_chunk.flatten(0, 1)
-        # hidden_chunk = hidden_chunk.flatten(0, 1)
         mask_chunk = target_chunk != self.ignore_index
         if mask_chunk.sum() == 0:
             # Unmask 1 token to allow loss to sync with all data parallel workers
             mask_chunk[0] = True
-        target_chunk = target_chunk[mask_chunk]
 
+        target_chunk = target_chunk[mask_chunk]  # [num_valid]
         if isinstance(hidden_chunk, DTensor):
             local_hidden_chunk = hidden_chunk.to_local()[mask_chunk]
             hidden_chunk = DTensor.from_local(
                 local_hidden_chunk, original_mesh, original_placements
             )  # [num_valid, embed_dim]
-
         else:
             hidden_chunk = hidden_chunk[mask_chunk]  # [num_valid, embed_dim]
 

--- a/torchtune/modules/loss/cross_entropy_loss.py
+++ b/torchtune/modules/loss/cross_entropy_loss.py
@@ -38,7 +38,7 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
         tp_enabled: bool = False,
         mask_ignored_tokens: bool = True,
     ):
-        super().__init__(tp_enabled=tp_enabled)
+        super().__init__()
         """
         Args:
             num_output_chunks (int): Number of chunks to split the output tensor into. Default is 8.
@@ -69,7 +69,7 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
         model.skip_output_layer = True
         self.linear_projection = model.output
 
-    def patch_tp_plan(self, tp_plan) -> bool:
+    def patch_tp_plan(self, tp_plan) -> dict:
         if "output" not in tp_plan:
             raise KeyError("`tp_plan` requires `output` key")
 

--- a/torchtune/modules/loss/cross_entropy_loss.py
+++ b/torchtune/modules/loss/cross_entropy_loss.py
@@ -115,13 +115,14 @@ class LinearCrossEntropyLoss(SFTLoss, nn.Module):
         return loss
 
     def mask_inputs(
-        self, hidden: torch.Tensor, target: torch.Tensor, indices: torch.Tensor
+        self,
+        hidden: torch.Tensor,
+        target: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Args:
             hidden (torch.Tensor): Hidden state of the model, pre projection. Shape ``[bsz*seq_len, emb_dim]``
             target (torch.Tensor): Labels for the model. Shape ``[bsz*seq_len]``
-            indices (torch.Tensor): Indices of the valid tokens. Shape ``[num_valid]``
 
         Returns:
             tuple[torch.Tensor, torch.Tensor]: returns a tuple of

--- a/torchtune/modules/loss/loss_types.py
+++ b/torchtune/modules/loss/loss_types.py
@@ -14,6 +14,14 @@ from torch import nn
 class SFTLoss(ABC):
     """Interface for loss functions in torchtune used in sft recipes."""
 
+    # makes subclasses with multiple inheritance including nn.Module play nicely
+    # https://github.com/pytorch/pytorch/pull/91819
+    call_super_init = True
+
+    def __init__(self, *, enable_loss_parallel: bool = False):
+        super().__init__()
+        self.enable_loss_parallel = enable_loss_parallel
+
     def apply_compile_strategy(self, *args, **kwargs):
         """Compile the loss function for inference."""
         self.forward = torch.compile(self.forward, *args, **kwargs)
@@ -35,6 +43,49 @@ class SFTLoss(ABC):
             torch.Tensor: loss tensor
         """
         pass
+
+    @property
+    @abstractmethod
+    def supports_loss_parallel(self) -> bool:
+        """
+        Whether the loss function supports loss parallel.
+        Set to loss if loss parallelism isn't tested with your loss class.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def loss_parallel_requires_ctx_manager(self) -> bool:
+        """
+        Whether to use the loss parallel context manager for loss parallelism. Can be
+        used if the function relies on the standard cross_entropy() or CrossEntropyLoss.
+        Set to false if loss parallelism isn't tested with your loss class, or your loss
+        parallelism doesn't require the context manager..
+        """
+        pass
+
+    def patch_tp_plan(self, tp_plan) -> bool:
+        """Whether the loss function supports loss parallel. Defaults to a noop."""
+        return tp_plan
+
+    @property
+    def loss_parallel_enabled(self) -> bool:
+        """
+        The `enable_loss_parallel` flag is a directive from the user.
+        This property also validates that it is supported, or raises an error.
+        """
+        if self.enable_loss_parallel and not self.supports_loss_parallel:
+            raise ValueError(
+                f"Loss function is enabled, but {self.__class__.__name__} does not support loss parallelism"
+            )
+        return self.enable_loss_parallel
+
+    @property
+    def use_loss_parallel_ctx_manager(self) -> bool:
+        """
+        Whether to enable the loss parallelism ctx manager for this instance of the class.
+        """
+        return self.loss_parallel_enabled and self.loss_parallel_requires_ctx_manager
 
 
 class RLLoss(ABC):

--- a/torchtune/modules/loss/loss_types.py
+++ b/torchtune/modules/loss/loss_types.py
@@ -15,7 +15,7 @@ class SFTLoss(ABC):
     """Interface for loss functions in torchtune used in sft recipes."""
 
     # makes subclasses with multiple inheritance including nn.Module play nicely
-    # https://docs.pytorch.org/docs/stable/distributed.tensor.parallel.html#torch.distributed.tensor.parallel.loss_parallel
+    # https://github.com/pytorch/pytorch/pull/91819
     call_super_init = True
 
     def __init__(self, *, tp_enabled: bool = False):
@@ -47,8 +47,8 @@ class SFTLoss(ABC):
     @property
     def tp_requires_loss_parallel_ctx_manager(self) -> bool:
         """
-        Whether to use the loss parallel context manager for loss parallelism. Can be
-        used if the function relies on the standard cross_entropy() or CrossEntropyLoss.
+        Whether to use the loss parallel context manager for loss parallelism.
+        https://docs.pytorch.org/docs/stable/distributed.tensor.parallel.html#torch.distributed.tensor.parallel.loss_parallel
         """
         return False
 

--- a/torchtune/modules/loss/loss_types.py
+++ b/torchtune/modules/loss/loss_types.py
@@ -14,14 +14,6 @@ from torch import nn
 class SFTLoss(ABC):
     """Interface for loss functions in torchtune used in sft recipes."""
 
-    # makes subclasses with multiple inheritance including nn.Module play nicely
-    # https://github.com/pytorch/pytorch/pull/91819
-    call_super_init = True
-
-    def __init__(self, *, tp_enabled: bool = False):
-        super().__init__()
-        self.tp_enabled = tp_enabled
-
     def apply_compile_strategy(self, *args, **kwargs):
         """Compile the loss function for inference."""
         self.forward = torch.compile(self.forward, *args, **kwargs)
@@ -52,7 +44,7 @@ class SFTLoss(ABC):
         """
         return False
 
-    def patch_tp_plan(self, tp_plan) -> bool:
+    def patch_tp_plan(self, tp_plan) -> dict:
         """Whether the loss function supports loss parallel. Defaults to a noop."""
         return tp_plan
 

--- a/torchtune/modules/loss/loss_types.py
+++ b/torchtune/modules/loss/loss_types.py
@@ -15,7 +15,7 @@ class SFTLoss(ABC):
     """Interface for loss functions in torchtune used in sft recipes."""
 
     # makes subclasses with multiple inheritance including nn.Module play nicely
-    # https://github.com/pytorch/pytorch/pull/91819
+    # https://docs.pytorch.org/docs/stable/distributed.tensor.parallel.html#torch.distributed.tensor.parallel.loss_parallel
     call_super_init = True
 
     def __init__(self, *, tp_enabled: bool = False):

--- a/torchtune/modules/loss/loss_types.py
+++ b/torchtune/modules/loss/loss_types.py
@@ -49,7 +49,7 @@ class SFTLoss(ABC):
     def supports_loss_parallel(self) -> bool:
         """
         Whether the loss function supports loss parallel.
-        Set to loss if loss parallelism isn't tested with your loss class.
+        Set to false if loss parallelism isn't tested with your loss class.
         """
         pass
 
@@ -60,7 +60,7 @@ class SFTLoss(ABC):
         Whether to use the loss parallel context manager for loss parallelism. Can be
         used if the function relies on the standard cross_entropy() or CrossEntropyLoss.
         Set to false if loss parallelism isn't tested with your loss class, or your loss
-        parallelism doesn't require the context manager..
+        parallelism doesn't require the context manager.
         """
         pass
 

--- a/torchtune/training/__init__.py
+++ b/torchtune/training/__init__.py
@@ -15,6 +15,7 @@ from torchtune.training._distributed import (
     get_distributed_backend,
     get_full_optimizer_state_dict,
     get_shard_conditions,
+    get_train_context,
     get_world_size_and_rank,
     init_distributed,
     is_distributed,
@@ -147,4 +148,5 @@ __all__ = [
     "disable_dropout",
     "DATALOADER_KEY",
     "get_context_parallel_manager",
+    "get_train_context",
 ]

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -886,19 +886,12 @@ def get_context_parallel_manager(
     return context
 
 
-def get_train_context(
-    enable_loss_parallel: bool, enable_compiled_autograd: bool
-) -> Generator[None, None, None]:
+def get_train_context(enable_loss_parallel: bool) -> Generator[None, None, None]:
     @contextlib.contextmanager
     def context(cp_context: Generator[None, None, None] | None = None):
         with contextlib.ExitStack() as stack:
             if enable_loss_parallel:
                 stack.enter_context(torch.distributed.tensor.parallel.loss_parallel())
-
-            if enable_compiled_autograd:
-                stack.enter_context(
-                    torch._dynamo.utils.maybe_enable_compiled_autograd(True)
-                )
 
             # because we create a noop ctx manager, this is never None in actual recipes
             # leave condition so this can be used separately

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from functools import cached_property
 from itertools import chain
-from typing import Any, Callable, cast, Generator, Optional, Union
+from typing import Any, Callable, cast, Generator, Optional
 
 import torch
 import torch.distributed as dist
@@ -785,7 +785,7 @@ def _get_sdpa_context() -> (
     """
 
     @contextlib.contextmanager
-    def context(cp_context: Union[Generator[None, None, None], None] = None):
+    def context(cp_context: Optional[Generator[None, None, None]] = None):
         with contextlib.ExitStack() as stack:
             if cp_context is not None:
                 stack.enter_context(
@@ -883,7 +883,7 @@ def get_context_parallel_manager(
 
 def get_train_context(enable_loss_parallel: bool) -> Generator[None, None, None]:
     @contextlib.contextmanager
-    def context(cp_context: Generator[None, None, None] | None = None):
+    def context(cp_context: Optional[Generator[None, None, None]] = None):
         with contextlib.ExitStack() as stack:
             if enable_loss_parallel:
                 stack.enter_context(torch.distributed.tensor.parallel.loss_parallel())

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -65,7 +65,6 @@ class ParallelDims:
     tp: int
     cp: int
     world_size: int
-    enable_loss_parallel: bool
 
     def __post_init__(self):
         self._validate()
@@ -153,10 +152,6 @@ class ParallelDims:
     @property
     def tp_enabled(self):
         return self.tp > 1
-
-    @property
-    def loss_parallel_enabled(self):
-        return self.enable_loss_parallel and self.tp > 1
 
     @cached_property
     def non_data_parallel_size(self):


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
What are the changes made in this PR?
* Ungate FP8 + TP, and clean up LLaMA-3 TP plans
* Enables loss parallel
* Enables compiling autograd
    * Note that I have not been able to get this working so default to False, but leave it in for debugging purposes

Loss parallelism is the main feature. Loss curves look healthy, but memory utilisation is significantly lower now. This is also compatible (tested) with FP8.

## Peak active memory usage scales aggressively (linearly) has tensor parallelism increases without loss parallelism

<img width="995" alt="image" src="https://github.com/user-attachments/assets/0d22b701-81ee-41ed-ad7a-36a0d3afb125" />

## Peak active memory usage scales much more generously (still linear) with loss parallelism enabled

<img width="995" alt="image" src="https://github.com/user-attachments/assets/d3d4fe05-f2c1-4ef4-8132-c649b0cc9bc8" />

In the tp8 case (bs=8, seq len=8192), loss parallelism decreases active memory peak by about 30GB, about 35%. TPS remains the same.

## ~Compiling autograd doesn't work~ (removed autograd compile for now)

Unfortunately compiling autograd doesn't seem to work and throws an FSDP error that I don't know how to debug. The error seems to indicate it's caused by some graph break during checkpointing. We can remove this from the PR, or leave it in for future debugging, defaulted to `false`. Running with `TORCHDYNAMO_VERBOSE=1 TORCHINDUCTOR_AUTOGRAD_CACHE=0` yielded:

<details>

```
[rank7]: Traceback (most recent call last):
[rank7]:   File "/workspace/torchtune/recipes/full_finetune_distributed.py", line 1118, in <module>
[rank7]:     sys.exit(recipe_main())
[rank7]:              ^^^^^^^^^^^^^
[rank7]:   File "/workspace/torchtune/torchtune/config/_parse.py", line 99, in wrapper
[rank7]:     sys.exit(recipe_main(conf))
[rank7]:              ^^^^^^^^^^^^^^^^^
[rank7]:   File "/workspace/torchtune/recipes/full_finetune_distributed.py", line 1113, in recipe_main
[rank7]:     recipe.train()
[rank7]:   File "/workspace/torchtune/recipes/full_finetune_distributed.py", line 957, in train
[rank7]:     current_loss.backward()
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_tensor.py", line 648, in backward
[rank7]:     torch.autograd.backward(
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/autograd/__init__.py", line 354, in backward
[rank7]:     _engine_run_backward(
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/autograd/graph.py", line 829, in _engine_run_backward
[rank7]:     return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/compiled_autograd.py", line 1041, in runtime_wrapper
[rank7]:     out = compiled_fn(
[rank7]:           ^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 372, in __call__
[rank7]:     return super().__call__(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1767, in _wrapped_call_impl
[rank7]:     return self._call_impl(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1778, in _call_impl
[rank7]:     return forward_call(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 699, in compile_wrapper
[rank7]:     return fn(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/fx/graph_module.py", line 840, in call_wrapped
[rank7]:     return self._wrapped_call(self, *args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/fx/graph_module.py", line 416, in __call__
[rank7]:     raise e
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/fx/graph_module.py", line 403, in __call__
[rank7]:     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1767, in _wrapped_call_impl
[rank7]:     return self._call_impl(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1778, in _call_impl
[rank7]:     return forward_call(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 1469, in __call__
[rank7]:     return self._torchdynamo_orig_callable(
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 625, in __call__
[rank7]:     return _compile(
[rank7]:            ^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 1092, in _compile
[rank7]:     guarded_code = compile_inner(code, one_graph, hooks, transform)
[rank7]:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_utils_internal.py", line 97, in wrapper_function
[rank7]:     return function(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 779, in compile_inner
[rank7]:     return _compile_inner(code, one_graph, hooks, transform)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 818, in _compile_inner
[rank7]:     out_code = transform_code_object(code, transform)
[rank7]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/bytecode_transformation.py", line 1424, in transform_code_object
[rank7]:     transformations(instructions, code_options)
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 265, in _fn
[rank7]:     return fn(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 743, in transform
[rank7]:     tracer.run()
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 3484, in run
[rank7]:     super().run()
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 1359, in run
[rank7]:     while self.step():
[rank7]:           ^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 1263, in step
[rank7]:     self.dispatch_table[inst.opcode](self, inst)
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 831, in wrapper
[rank7]:     return inner_fn(self, inst)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 2903, in CALL
[rank7]:     self._call(inst)
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 2897, in _call
[rank7]:     self.call_function(fn, args, kwargs)
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 1189, in call_function
[rank7]:     self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
[rank7]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/variables/lazy.py", line 201, in realize_and_forward
[rank7]:     return getattr(self.realize(), name)(*args, **kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/variables/functions.py", line 516, in call_function
[rank7]:     return super().call_function(tx, args, kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/variables/functions.py", line 291, in call_function
[rank7]:     return tx.inline_user_function_return(self, [*self.self_args(), *args], kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 1206, in inline_user_function_return
[rank7]:     return InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 3678, in inline_call
[rank7]:     return tracer.inline_call_()
[rank7]:            ^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 3881, in inline_call_
[rank7]:     self.run()
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 1359, in run
[rank7]:     while self.step():
[rank7]:           ^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 1263, in step
[rank7]:     self.dispatch_table[inst.opcode](self, inst)
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 831, in wrapper
[rank7]:     return inner_fn(self, inst)
[rank7]:            ^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 2221, in CALL_FUNCTION_EX
[rank7]:     self.call_function(fn, argsvars.items, kwargsvars)
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/symbolic_convert.py", line 1189, in call_function
[rank7]:     self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
[rank7]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/variables/functions.py", line 1477, in call_function
[rank7]:     unimplemented_v2(
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/exc.py", line 521, in unimplemented_v2
[rank7]:     raise Unsupported(msg)
[rank7]: torch._dynamo.exc.Unsupported: Attempted to call function marked as skipped
[rank7]:   Explanation: Dynamo developers have intentionally marked that the function `_checkpoint_hook.__init__.<locals>.unpack_hook` in file `/opt/conda/lib/python3.11/site-packages/torch/utils/checkpoint.py` should not be traced.
[rank7]:   Hint: Avoid calling the function `_checkpoint_hook.__init__.<locals>.unpack_hook`.
[rank7]:   Hint: Apply `@torch._dynamo.dont_skip_tracing` to the function `_checkpoint_hook.__init__.<locals>.unpack_hook` to force tracing into the function. More graph breaks may occur as a result of attempting to trace into the function.
[rank7]:   Hint: Please file an issue to PyTorch.

[rank7]:   Developer debug context: module: torch.utils.checkpoint, qualname: _checkpoint_hook.__init__.<locals>.unpack_hook, skip reason: <missing reason>


[rank7]: from user code:
[rank7]:    File "<eval_with_key>.35", line 1818, in forward
[rank7]:     call_hook_2 = torch__dynamo_external_utils_call_hook(getitem_13144, getitem_13145, hook_type = 'unpack_hook');  getitem_13144 = getitem_13145 = None
[rank7]:   File "/opt/conda/lib/python3.11/site-packages/torch/_dynamo/external_utils.py", line 81, in call_hook
[rank7]:     result = hook(*args)
```

</details>


#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
