### PR TITLE
Revert "Fix typing in _grad_scaler.py for nightly compatibility (#2778)"

### DIFF
--- a/torchtune/training/_grad_scaler.py
+++ b/torchtune/training/_grad_scaler.py
@@ -10,15 +10,9 @@ from typing import Optional
 import torch
 from torch import nn, Tensor
 from torch.distributed.tensor import DTensor
-from torch.nn.utils.clip_grad import _no_grad
+from torch.nn.utils.clip_grad import _no_grad, _tensor_or_tensors
 from torch.utils._foreach_utils import _device_has_foreach_support, _has_foreach_support
 from torchtune.utils._logging import deprecated
-
-
-if torch.__version__ < "2.8.0.dev20250601":
-    from torch.nn.utils.clip_grad import _tensor_or_tensors as TensorOrTensors
-else:
-    from torch.nn.utils.clip_grad import _TensorOrTensors as TensorOrTensors
 
 
 @deprecated(msg="Please use `scale_grads_` instead.")
@@ -47,7 +41,7 @@ def scale_grads(model: nn.Module, scaler: torch.Tensor) -> None:
 
 @_no_grad
 def scale_grads_(
-    parameters: TensorOrTensors,
+    parameters: _tensor_or_tensors,
     scaler: torch.Tensor,
     foreach: Optional[bool] = None,
 ) -> None:
@@ -57,7 +51,7 @@ def scale_grads_(
     Gradients are modified in-place, multiplying by specified scaler.
 
     Args:
-        parameters (TensorOrTensors): an iterable of Tensors or a
+        parameters (_tensor_or_tensors): an iterable of Tensors or a
             single Tensor that will have gradients scaled
         scaler (torch.Tensor): multiplier to scale gradients
         foreach (Optional[bool]): use the faster foreach-based implementation.
@@ -86,7 +80,7 @@ def _group_tensors_by_device(
 
 @_no_grad
 def _scale_grad_(
-    parameters: TensorOrTensors,
+    parameters: _tensor_or_tensors,
     scaler: torch.Tensor,
     foreach: Optional[bool] = None,
 ) -> None:


### PR DESCRIPTION
They reverted the change in core here: https://github.com/pytorch/pytorch/pull/154801

This will likely be re-reverted at some point, but we'll cross that bridge when we come to it.