### PR TITLE
Integrate SFTLoss functions into forward pass

### DIFF
--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -153,7 +153,12 @@ class CheckpointClient:
         ckpt_dict = {}
         ckpt_dict.update(training_progress.state_dict())
 
-        ckpt_dict[training.MODEL_KEY] = model.state_dict()
+        model_state_dict = model.state_dict()
+        loss_fn_keys = [k for k in model_state_dict.keys() if k.startswith("loss_fn")]
+        for k in loss_fn_keys:
+            model_state_dict.pop(k)
+
+        ckpt_dict[training.MODEL_KEY] = model_state_dict
         ckpt_dict[training.OPT_KEY] = optimizer.state_dict()
 
         if adapter_config is not None:
@@ -259,6 +264,10 @@ class CheckpointClient:
             model_state_dict = {k: v.cpu() for k, v in model.state_dict().items()}
         else:
             model_state_dict = model.state_dict()
+
+        loss_fn_keys = [k for k in model_state_dict.keys() if k.startswith("loss_fn")]
+        for k in loss_fn_keys:
+            model_state_dict.pop(k)
 
         if intermediate_checkpoint:
             if self._is_rank_zero:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

FSDP with SFTLoss classes is broken in nightlies due to a change in how resharding is handled at the root level.

#### Changelog

This PR nests the loss class under the root model. Checkpointing is altered to remove any modules under `loss_fn` before saving.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

I have tested this works with FSDP and FSDP + TP.

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
