### PR TITLE
Fix tests for full DPO distributed

### DIFF
--- a/tests/recipes/test_full_dpo_distributed.py
+++ b/tests/recipes/test_full_dpo_distributed.py
@@ -56,8 +56,6 @@ class TestFullDPODistributedRecipe:
             - Train a model for 2 epochs
             - Resume training after epoch 1
             - Make sure final loss matches the expected value of a model successfully resumed from a ckpt
-        Unlike `tests.recipes.test_lora_finetune_single_device`, this test does not use pre-computed loss
-        values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
 
         ckpt = "llama3_tune"
@@ -141,16 +139,7 @@ class TestFullDPODistributedRecipe:
     def test_training_state_on_resume_with_async_checkpointing(
         self, tmpdir, monkeypatch
     ):
-        """Test whether the recipe state is correctly updated on resume. Since this
-        is model agnostic, we should run this on the small model only. The test
-        consists of three stages:
-            - Train a model for 2 epochs
-            - Resume training after epoch 1
-            - Make sure final loss matches the expected value of a model successfully resumed from a ckpt
-        Unlike `tests.recipes.test_lora_finetune_single_device`, this test does not use pre-computed loss
-        values to benchmark against. This test just ensures the loss values are identical when resuming.
-        """
-
+        """Same as above test but with async checkpointing."""
         ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent


### PR DESCRIPTION
## Problem

In our ``test_full_dpo_distributed.py`` tests, we set the ``max_seq_len=256``. The prompt for our example
stack exchange paired datasets were always longer than 256, therefore the model never learned anything. Because it
never learned anything, our ``resume_from_checkpoint`` tests ALWAYS passed b/c the loss was the same every single time.

## Solution

1. Actually compare to loss values
2. Increase max seq len so that the model learns
3. Fix the tests now that they correctly fail

## Open questions

* You'll notice that the first step does not update the loss value. I don't exactly know why this is
except that maybe the gradient updates from the first batch aren't enough to meaningfully change the loss calculation
for batch two, but that feels a little flimsy. I ran the full recipe and loss seemed to decrease in a normal fashion, 
so I'm timeboxing this Issue for now. 
* Could this be happening with other tests? The other DPO tests also do not compare to loss values and have a small max_seq_len so those would be prime candidates for this kind of bug.
