### PR TITLE
Fix mesh mismatch in LinearCE

### DIFF
--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -705,7 +705,9 @@ def shard_model(
     # Finally shard the entire model to account for any stragglers
     root_kwargs = deepcopy(fsdp_kwargs)
     root_kwargs["reshard_after_forward"] = False
-    fully_shard(model, root_kwargs)
+    # TODO: we should actually use reshard_after_forward=None
+    # on latest nightlies: https://github.com/pytorch/pytorch/pull/155319
+    fully_shard(model, **root_kwargs)
 
 
 def prepare_mha_for_tp(


### PR DESCRIPTION
Thanks to @weifengpy for helping debug and landing the fix in core. Also thanks to @nathan-az for surfacing this and helping brainstorm different fixes in torchtune.

Full context in [this thread](https://discord.com/channels/1216353675241590815/1380061722055802960). Prior to https://github.com/pytorch/pytorch/pull/154704 FSDP did not actually reshard the root module after forward. Now that they do, it breaks our linear cross-entropy loss. This is because we patch the model's output layer into the loss [here](https://github.com/pytorch/torchtune/blob/e7b2f9b9913d3296cd31ea43de85300c2866f879/torchtune/modules/loss/cross_entropy_loss.py#L60-L61). Now that FSDP actually reshards after forward on the root, we wind up with an output projection weight that's a DTensor, while the model outputs are not. As a fix, we can just hackily tell the top-level model class not to reshard after forward. Since https://github.com/pytorch/pytorch/pull/155319 has landed in core, I've added a TODO to directly use the new argument provided there (though we need to gate on nightlies).

## Test plan

We test three cases: (1) pure FSDP, (2) FSDP+TP, (3) FSDP with custom sharding of output layer


For pure FSDP run
```
tune run --nproc_per_node 2 full_finetune_distributed --config llama3_1/8B_full
```
, for FSDP+TP run
```
tune run --nproc_per_node 4 full_finetune_distributed --config llama3_1/8B_full tensor_parallel_dim=2
```
, for custom sharded FSDP run
```
tune run --nproc_per_node 2 full_finetune_distributed --config llama3_1/8B_full custom_sharded_layers=['output']
```

In all three cases, we can see that the memory is identical to what we saw on previous nightlies, and tokens/second is very similar ([full WandB workspace](https://wandb.ai/ebs/test-2800)):

<img width="1374" alt="Screenshot 2025-06-06 at 2 29 40 PM" src="https://github.com/user-attachments/assets/254d8b7a-bfc9-430a-a8cf-80ffee87824e" />

