### PR TITLE
[BE] Remove Llama2 references from recipe tests

### DIFF
--- a/recipes/configs/llama2/1B_qat_single_device.yaml
+++ b/recipes/configs/llama2/1B_qat_single_device.yaml
@@ -32,7 +32,6 @@ model:
   num_kv_heads: 4
   embed_dim: 2048
   max_seq_len: 2048
-  intermediate_dim: 5632
   attn_dropout: 0.0
   norm_eps: 1e-5
 

--- a/tests/recipes/dev/test_generate_v2.py
+++ b/tests/recipes/dev/test_generate_v2.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests.common import TUNE_PATH
 from tests.recipes.utils import MODEL_TEST_CONFIGS, write_hf_ckpt_config
-from tests.test_utils import CKPT_MODEL_PATHS, mps_ignored_test, TOKENIZER_PATHS
+from tests.test_utils import CKPT_MODEL_PATHS, mps_ignored_test
 
 
 class TestGenerateV2:
@@ -20,10 +20,9 @@ class TestGenerateV2:
 
     @pytest.mark.integration_test
     @mps_ignored_test()
-    def test_llama2_generate_results(self, caplog, monkeypatch, tmpdir):
-        ckpt = "llama2_tune"
+    def test_llama3_generate_results(self, caplog, monkeypatch, tmpdir):
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
-        tokenizer_path = Path(TOKENIZER_PATHS["llama2"])
         ckpt_dir = ckpt_path.parent
 
         # Config file needed for model conversion.
@@ -37,15 +36,16 @@ class TestGenerateV2:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer._component_=torchtune.models.llama3.llama3_tokenizer \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             device=cpu \
             dtype=fp32 \
             max_new_tokens=10 \
             seed=123 \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2"]
+        model_config = MODEL_TEST_CONFIGS["llama3"]
         cmd = cmd + model_config
 
         monkeypatch.setattr(sys, "argv", cmd)
@@ -55,15 +55,13 @@ class TestGenerateV2:
         # this is gibberish b/c the model is random weights, but it's
         # the expected value for what we currently have in V2
         # this test should catch any changes to the generate recipe that affect output
-        expected_output = (
-            "restricted chap Пав Frenchisto porqueноello ignor ambientQuery"
-        )
+        expected_output = "janinya.sort ATT_Max opi bruarrivalτυblinkửi"
 
         logs = caplog.text
         assert expected_output in logs
 
     @pytest.mark.integration_test
-    def test_llama2_fail_on_bad_input(self, capsys, monkeypatch, tmpdir):
+    def test_llama3_fail_on_bad_input(self, capsys, monkeypatch, tmpdir):
         """Should fail when user passes in a bad input:
         - No prompt provided
         - Prompt has multiple entries in content and no image

--- a/tests/recipes/test_eleuther_eval.py
+++ b/tests/recipes/test_eleuther_eval.py
@@ -14,8 +14,8 @@ import pytest
 
 from tests.common import TUNE_PATH
 from tests.recipes.utils import (
-    llama2_test_config,
     llama3_2_vision_test_config,
+    llama3_test_config,
     write_hf_ckpt_config,
     write_hf_vision_ckpt_config,
 )
@@ -50,8 +50,8 @@ class TestEleutherEval:
     @pytest.mark.parametrize(
         "eval_name, expected_acc, bsz",
         [
-            ("truthfulqa_gen", 0.1, 4),
-            ("truthfulqa_mc2", 0.4, 4),
+            ("truthfulqa_gen", 0.1818, 4),
+            ("truthfulqa_mc2", 0.3015, 4),
         ],
     )
     @pytest.mark.integration_test
@@ -59,7 +59,7 @@ class TestEleutherEval:
     def test_torchtune_checkpoint_eval_results(
         self, caplog, monkeypatch, tmpdir, eval_name, expected_acc, bsz
     ):
-        ckpt = "llama2_tune"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
 
@@ -73,8 +73,9 @@ class TestEleutherEval:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer._component_=torchtune.models.llama3.llama3_tokenizer \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             limit=11 \
             dtype=fp32 \
@@ -82,7 +83,7 @@ class TestEleutherEval:
             batch_size={bsz} \
         """.split()
 
-        model_config = llama2_test_config()
+        model_config = llama3_test_config()
         cmd = cmd + model_config
 
         monkeypatch.setattr(sys, "argv", cmd)
@@ -108,7 +109,7 @@ class TestEleutherEval:
     @pytest.mark.usefixtures("hide_correct_version_number")
     @gpu_test(gpu_count=1)
     def test_eval_recipe_errors_without_lm_eval(self, monkeypatch, tmpdir):
-        ckpt = "llama2_tune"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
 
@@ -120,14 +121,15 @@ class TestEleutherEval:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer._component_=torchtune.models.llama3.llama3_tokenizer \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             limit=1 \
             dtype=fp32 \
         """.split()
 
-        model_config = llama2_test_config()
+        model_config = llama3_test_config()
         cmd = cmd + model_config
 
         monkeypatch.setattr(sys, "argv", cmd)
@@ -143,7 +145,7 @@ class TestEleutherEval:
     def test_eval_recipe_errors_with_quantization_hf_checkpointer(
         self, monkeypatch, tmpdir
     ):
-        ckpt = "llama2_hf"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
 
@@ -158,8 +160,9 @@ class TestEleutherEval:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer._component_=torchtune.models.llama3.llama3_tokenizer \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             limit=1 \
             dtype=fp32 \
@@ -167,7 +170,7 @@ class TestEleutherEval:
             quantizer.groupsize=256 \
         """.split()
 
-        model_config = llama2_test_config()
+        model_config = llama3_test_config()
         cmd = cmd + model_config
 
         monkeypatch.setattr(sys, "argv", cmd)
@@ -181,7 +184,7 @@ class TestEleutherEval:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=1)
     def test_eval_recipe_errors_with_qat_quantizer(self, monkeypatch, tmpdir):
-        ckpt = "llama2_tune"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
 
@@ -193,8 +196,9 @@ class TestEleutherEval:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer._component_=torchtune.models.llama3.llama3_tokenizer \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             limit=1 \
             dtype=fp32 \
@@ -202,7 +206,7 @@ class TestEleutherEval:
             quantizer.groupsize=32\
         """.split()
 
-        model_config = llama2_test_config()
+        model_config = llama3_test_config()
         cmd = cmd + model_config
 
         monkeypatch.setattr(sys, "argv", cmd)

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -52,14 +52,12 @@ class TestFullFinetuneDistributedRecipe:
 
     def _fetch_expected_loss_values_multi_rank(self, model_type):
         loss_values_map = {
-            "llama2": [10.5209, 10.5217, 10.4945, 10.5136],
             "llama3": [11.9839, 11.9684, 11.9596, 11.93656],
         }
         return loss_values_map[model_type]
 
     def _fetch_expected_loss_values_single_rank(self, model_type):
         loss_values_map = {
-            "llama2": [10.5051, 10.5572, 10.4780, 10.5678],
             "llama3": [11.9742, 12.0049, 11.9382, 12.0464],
         }
         return loss_values_map[model_type]
@@ -68,7 +66,6 @@ class TestFullFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps, optim_in_bwd",
         [
-            ("llama2/7B_full", "llama2", "hf", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 4, 1, True),
         ],
@@ -216,7 +213,6 @@ class TestFullFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps, optim_in_bwd",
         [
-            ("llama2/7B_full", "llama2", "hf", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 4, 1, True),
         ],
@@ -390,7 +386,6 @@ class TestFullFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps, optim_in_bwd",
         [
-            ("llama2/7B_full", "llama2", "hf", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 4, 1, True),
         ],
@@ -511,7 +506,6 @@ class TestFullFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps, optim_in_bwd",
         [
-            ("llama2/7B_full", "llama2", "hf", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 1, 4, False),
             ("llama3/8B_full", "llama3", "tune", 4, 1, True),
         ],

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -38,7 +38,7 @@ from torchtune.training.checkpointing._utils import (
 class TestLoRADPODistributedRecipe:
     def _get_test_config_overrides(self, dtype_str: str = "fp32", epochs: int = 2):
         return [
-            "batch_size=8",
+            "batch_size=1",
             "device=cuda",
             f"dtype={dtype_str}",
             "dataset.train_on_input=False",
@@ -47,7 +47,7 @@ class TestLoRADPODistributedRecipe:
             "max_steps_per_epoch=2",
             "optimizer.lr=2e-5",
             "log_every_n_steps=1",
-            "gradient_accumulation_steps=1",
+            "gradient_accumulation_steps=8",
             "clip_grad_norm=100",
             "tokenizer.max_seq_len=512",
         ] + dummy_stack_exchange_dataset_config()

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -68,7 +68,7 @@ class TestLoRADPODistributedRecipe:
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
 
-        ckpt = "llama2_hf"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
@@ -81,16 +81,16 @@ class TestLoRADPODistributedRecipe:
         # Train for two epochs
         cmd_1 = f"""
         tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
-            --config llama2/7B_lora_dpo \
+            --config llama3_1/8B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
             metric_logger.filename={log_file} \
@@ -98,7 +98,7 @@ class TestLoRADPODistributedRecipe:
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
 
         cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd_1)
@@ -114,20 +114,20 @@ class TestLoRADPODistributedRecipe:
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         cmd_2 = f"""
         tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
-            --config llama2/7B_lora_dpo \
+            --config llama3_1/8B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
             checkpointer.recipe_checkpoint={os.path.join(tmpdir, RECIPE_STATE_DIRNAME, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
+            checkpointer.model_type=LLAMA3 \
             resume_from_checkpoint=True \
             metric_logger.filename={resumed_log_file} \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=True \
             enable_activation_offloading=False \
@@ -159,7 +159,7 @@ class TestLoRADPODistributedRecipe:
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
 
-        ckpt = "llama2_hf"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
@@ -172,17 +172,17 @@ class TestLoRADPODistributedRecipe:
         # Train for two epochs
         cmd_1 = f"""
         tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
-            --config llama2/7B_lora_dpo \
+            --config llama3_1/8B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
+            checkpointer.model_type=LLAMA3 \
             enable_async_checkpointing=True \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
             metric_logger.filename={log_file} \
@@ -190,7 +190,7 @@ class TestLoRADPODistributedRecipe:
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
 
         cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd_1)
@@ -206,21 +206,21 @@ class TestLoRADPODistributedRecipe:
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         cmd_2 = f"""
         tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
-            --config llama2/7B_lora_dpo \
+            --config llama3_1/8B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
             checkpointer.recipe_checkpoint={os.path.join(tmpdir, RECIPE_STATE_DIRNAME, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
+            checkpointer.model_type=LLAMA3 \
             resume_from_checkpoint=True \
             enable_async_checkpointing=True \
             metric_logger.filename={resumed_log_file} \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=True \
             enable_activation_offloading=False \
@@ -239,13 +239,13 @@ class TestLoRADPODistributedRecipe:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=2)
     def test_save_and_load_merged_weights(self, tmpdir, monkeypatch):
-        ckpt = "llama2_tune"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
 
         cmd = f"""
-        tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
-            --config llama2/7B_lora_dpo \
+        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
+            --config llama3_1/8B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
@@ -253,20 +253,20 @@ class TestLoRADPODistributedRecipe:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=False \
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
 
         cmd = cmd + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd)
         runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        # Next load both the merged weights in a Llama2 base model
+        # Next load both the merged weights in a Llama3 base model
         # and the base model weights + trained adapter weights in the LoRA Llama 2 model
         # The results of calling forward on dummy inputs should be the same.
         inputs = torch.randint(low=0, high=32_000, size=(2, 100))
@@ -274,10 +274,10 @@ class TestLoRADPODistributedRecipe:
         # Build LoRA model for loading base + adapter weights separately
         lora_model = config.instantiate(OmegaConf.from_dotlist(model_config).model)
 
-        # Build base llama2 model for loading merged weights
-        base_llama2_config = MODEL_TEST_CONFIGS["llama2"]
-        llama2_model = config.instantiate(
-            OmegaConf.from_dotlist(base_llama2_config).model
+        # Build base llama3 model for loading merged weights
+        base_llama3_config = MODEL_TEST_CONFIGS["llama3"]
+        llama3_model = config.instantiate(
+            OmegaConf.from_dotlist(base_llama3_config).model
         )
 
         # Load base model and trained adapter weights into LoRA model and call fwd
@@ -291,7 +291,7 @@ class TestLoRADPODistributedRecipe:
         lora_model.load_state_dict(base_model_sd, strict=False)
         baseline_out = lora_model(inputs)
 
-        # Load merged final ckpt directly into llama2 and call fwd
+        # Load merged final ckpt directly into llama3 and call fwd
         suffix = ".bin"
         model_ckpt_fname = (
             SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5)) + suffix
@@ -299,6 +299,6 @@ class TestLoRADPODistributedRecipe:
         model_path = os.path.join(tmpdir, epoch_folder, model_ckpt_fname)
         sd = safe_torch_load(model_path, weights_only=True)
 
-        llama2_model.load_state_dict(sd)
-        merged_ckpt_out = llama2_model(inputs)
+        llama3_model.load_state_dict(sd)
+        merged_ckpt_out = llama3_model(inputs)
         torch.testing.assert_close(baseline_out, merged_ckpt_out, rtol=1e-5, atol=1e-5)

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -129,6 +129,7 @@ class TestLoRADPODistributedRecipe:
             metric_logger.filename={resumed_log_file} \
             tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
+            save_adapter_weights_only={save_adapter_weights_only} \
             enable_activation_checkpointing=True \
             enable_activation_offloading=False \
         """.split()

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -53,7 +53,7 @@ class TestLoRADPODistributedRecipe:
         ] + dummy_stack_exchange_dataset_config()
 
     @pytest.mark.parametrize("save_adapter_weights_only", [False, True])
-    @gpu_test(gpu_count=4)
+    @gpu_test(gpu_count=2)
     @pytest.mark.integration_test
     def test_training_state_on_resume(
         self, tmpdir, monkeypatch, save_adapter_weights_only
@@ -80,7 +80,7 @@ class TestLoRADPODistributedRecipe:
 
         # Train for two epochs
         cmd_1 = f"""
-        tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
+        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
             --config llama3_1/8B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
@@ -113,7 +113,7 @@ class TestLoRADPODistributedRecipe:
         epoch_folder = get_largest_iter_folder(tmpdir)
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         cmd_2 = f"""
-        tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
+        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
             --config llama3_1/8B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \

--- a/tests/recipes/test_lora_dpo_single_device.py
+++ b/tests/recipes/test_lora_dpo_single_device.py
@@ -66,8 +66,6 @@ class TestLoRADPOSingleDeviceRecipe:
         Unlike `tests.recipes.test_lora_finetune_single_device`, this test does not use pre-computed loss
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
-        torch.cuda.empty_cache()
-
         ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
@@ -159,8 +157,6 @@ class TestLoRADPOSingleDeviceRecipe:
         Unlike `tests.recipes.test_lora_finetune_single_device`, this test does not use pre-computed loss
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
-        torch.cuda.empty_cache()
-
         ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
@@ -243,8 +239,6 @@ class TestLoRADPOSingleDeviceRecipe:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=1)
     def test_save_and_load_merged_weights(self, tmpdir, monkeypatch):
-        torch.cuda.empty_cache()
-
         ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent

--- a/tests/recipes/test_lora_dpo_single_device.py
+++ b/tests/recipes/test_lora_dpo_single_device.py
@@ -67,7 +67,7 @@ class TestLoRADPOSingleDeviceRecipe:
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
 
-        ckpt = "llama2_hf"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
@@ -80,16 +80,16 @@ class TestLoRADPOSingleDeviceRecipe:
         # Train for two epochs
         cmd_1 = f"""
         tune run lora_dpo_single_device \
-            --config llama2/7B_lora_dpo_single_device \
+            --config llama3_1/8B_lora_dpo_single_device \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
             metric_logger.filename={log_file} \
@@ -97,7 +97,7 @@ class TestLoRADPOSingleDeviceRecipe:
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
 
         cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd_1)
@@ -114,20 +114,20 @@ class TestLoRADPOSingleDeviceRecipe:
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         cmd_2 = f"""
         tune run lora_dpo_single_device \
-            --config llama2/7B_lora_dpo_single_device \
+            --config llama3_1/8B_lora_dpo_single_device \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
             checkpointer.recipe_checkpoint={os.path.join(tmpdir, RECIPE_STATE_DIRNAME, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
+            checkpointer.model_type=LLAMA3 \
             resume_from_checkpoint=True \
             metric_logger.filename={resumed_log_file} \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=True \
             enable_activation_offloading=False \
@@ -159,7 +159,7 @@ class TestLoRADPOSingleDeviceRecipe:
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
 
-        ckpt = "llama2_hf"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
@@ -172,16 +172,16 @@ class TestLoRADPOSingleDeviceRecipe:
         # Train for two epochs
         cmd_1 = f"""
         tune run lora_dpo_single_device \
-            --config llama2/7B_lora_dpo_single_device \
+            --config llama3_1/8B_lora_dpo_single_device \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
             metric_logger.filename={log_file} \
@@ -190,7 +190,7 @@ class TestLoRADPOSingleDeviceRecipe:
             enable_async_checkpointing=True \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
 
         cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd_1)
@@ -207,20 +207,20 @@ class TestLoRADPOSingleDeviceRecipe:
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         cmd_2 = f"""
         tune run lora_dpo_single_device \
-            --config llama2/7B_lora_dpo_single_device \
+            --config llama3_1/8B_lora_dpo_single_device \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelHFCheckpointer \
+            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
             checkpointer.recipe_checkpoint={os.path.join(tmpdir, RECIPE_STATE_DIRNAME, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
+            checkpointer.model_type=LLAMA3 \
             resume_from_checkpoint=True \
             metric_logger.filename={resumed_log_file} \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=True \
             enable_activation_offloading=False \
@@ -241,13 +241,13 @@ class TestLoRADPOSingleDeviceRecipe:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=1)
     def test_save_and_load_merged_weights(self, tmpdir, monkeypatch):
-        ckpt = "llama2_tune"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
 
         cmd = f"""
         tune run lora_dpo_single_device \
-            --config llama2/7B_lora_dpo_single_device \
+            --config llama3_1/8B_lora_dpo_single_device \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
@@ -255,21 +255,21 @@ class TestLoRADPOSingleDeviceRecipe:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            checkpointer.model_type=LLAMA3 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=False \
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
 
         cmd = cmd + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd)
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        # Next load both the merged weights in a Llama2 base model
+        # Next load both the merged weights in a Llama3 base model
         # and the base model weights + trained adapter weights in the LoRA Llama 2 model
         # The results of calling forward on dummy inputs should be the same.
         inputs = torch.randint(low=0, high=32_000, size=(2, 100))
@@ -277,10 +277,10 @@ class TestLoRADPOSingleDeviceRecipe:
         # Build LoRA model for loading base + adapter weights separately
         lora_model = config.instantiate(OmegaConf.from_dotlist(model_config).model)
 
-        # Build base llama2 model for loading merged weights
-        base_llama2_config = MODEL_TEST_CONFIGS["llama2"]
-        llama2_model = config.instantiate(
-            OmegaConf.from_dotlist(base_llama2_config).model
+        # Build base llama3 model for loading merged weights
+        base_llama3_config = MODEL_TEST_CONFIGS["llama3"]
+        llama3_model = config.instantiate(
+            OmegaConf.from_dotlist(base_llama3_config).model
         )
 
         # Load base model and trained adapter weights into LoRA model and call fwd
@@ -294,7 +294,7 @@ class TestLoRADPOSingleDeviceRecipe:
         lora_model.load_state_dict(base_model_sd, strict=False)
         baseline_out = lora_model(inputs)
 
-        # Load merged final ckpt directly into llama2 and call fwd
+        # Load merged final ckpt directly into llama3 and call fwd
         suffix = ".bin"
         model_ckpt_fname = (
             SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5)) + suffix
@@ -302,6 +302,6 @@ class TestLoRADPOSingleDeviceRecipe:
         model_path = os.path.join(tmpdir, epoch_folder, model_ckpt_fname)
         sd = safe_torch_load(model_path, weights_only=True)
 
-        llama2_model.load_state_dict(sd)
-        merged_ckpt_out = llama2_model(inputs)
+        llama3_model.load_state_dict(sd)
+        merged_ckpt_out = llama3_model(inputs)
         torch.testing.assert_close(baseline_out, merged_ckpt_out, rtol=1e-5, atol=1e-5)

--- a/tests/recipes/test_lora_dpo_single_device.py
+++ b/tests/recipes/test_lora_dpo_single_device.py
@@ -38,7 +38,7 @@ from torchtune.training.checkpointing._utils import (
 class TestLoRADPOSingleDeviceRecipe:
     def _get_test_config_overrides(self, dtype_str: str = "fp32", epochs: int = 2):
         return [
-            "batch_size=8",
+            "batch_size=1",
             f"dtype={dtype_str}",
             "dataset.train_on_input=False",
             "seed=9",
@@ -46,7 +46,7 @@ class TestLoRADPOSingleDeviceRecipe:
             "max_steps_per_epoch=2",
             "optimizer.lr=2e-5",
             "log_every_n_steps=1",
-            "gradient_accumulation_steps=1",
+            "gradient_accumulation_steps=8",
             "clip_grad_norm=100",
             "tokenizer.max_seq_len=512",
         ] + dummy_stack_exchange_dataset_config()

--- a/tests/recipes/test_lora_dpo_single_device.py
+++ b/tests/recipes/test_lora_dpo_single_device.py
@@ -66,6 +66,7 @@ class TestLoRADPOSingleDeviceRecipe:
         Unlike `tests.recipes.test_lora_finetune_single_device`, this test does not use pre-computed loss
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
+        torch.cuda.empty_cache()
 
         ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
@@ -158,6 +159,7 @@ class TestLoRADPOSingleDeviceRecipe:
         Unlike `tests.recipes.test_lora_finetune_single_device`, this test does not use pre-computed loss
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
+        torch.cuda.empty_cache()
 
         ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
@@ -241,6 +243,8 @@ class TestLoRADPOSingleDeviceRecipe:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=1)
     def test_save_and_load_merged_weights(self, tmpdir, monkeypatch):
+        torch.cuda.empty_cache()
+
         ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent

--- a/tests/recipes/test_lora_finetune_distributed.py
+++ b/tests/recipes/test_lora_finetune_distributed.py
@@ -54,7 +54,6 @@ class TestLoRAFinetuneDistributedRecipe:
         # These values have been validated against single device recipe test via
         # https://gist.github.com/ebsmothers/f1c3db7c66655a23a91e0290360960c4
         loss_values_map = {
-            "llama2": [10.5209, 10.5269, 10.5130, 10.5242],
             "llama3": [11.9839, 11.9691, 11.9617, 11.9383],
         }
         return loss_values_map[model_type]
@@ -73,13 +72,13 @@ class TestLoRAFinetuneDistributedRecipe:
         tmpdir,
         monkeypatch,
     ):
-        ckpt = "llama2_tune"
+        ckpt = "llama3_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
         cmd = f"""
         tune run --nnodes 1 --nproc_per_node 2 lora_finetune_distributed
-            --config llama2/7B_lora \
+            --config llama3/8B_lora \
             batch_size={micro_batch_size} \
             gradient_accumulation_steps={gradient_accumulation_steps} \
             output_dir={tmpdir} \
@@ -89,22 +88,22 @@ class TestLoRAFinetuneDistributedRecipe:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA2 \
+            checkpointer.model_type=LLAMA3 \
             metric_logger.filename={log_file} \
-            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
+            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
             tokenizer.prompt_template=null \
             reshard_after_forward={reshard_after_forward} \
             enable_activation_checkpointing=False \
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
 
         cmd = cmd + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd)
         runpy.run_path(TUNE_PATH, run_name="__main__")
         loss_values = get_loss_values_from_metric_logger(log_file)
-        expected_loss_values = self._fetch_expected_loss_values("llama2")
+        expected_loss_values = self._fetch_expected_loss_values("llama3")
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
         )
@@ -114,9 +113,7 @@ class TestLoRAFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, save_adapter_weights_only",
         [
-            ("llama2/7B_lora", "llama2", "hf", False),
             ("llama3/8B_lora", "llama3", "tune", False),
-            ("llama2/7B_lora", "llama2", "hf", True),
         ],
     )
     def test_training_state_on_resume(
@@ -217,9 +214,7 @@ class TestLoRAFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, save_adapter_weights_only",
         [
-            ("llama2/7B_lora", "llama2", "hf", False),
             ("llama3/8B_lora", "llama3", "tune", False),
-            ("llama2/7B_lora", "llama2", "hf", True),
         ],
     )
     def test_training_state_on_resume_with_async_checkpointing(
@@ -317,7 +312,6 @@ class TestLoRAFinetuneDistributedRecipe:
     @pytest.mark.parametrize(
         "recipe_config, model_type, ckpt_type, use_dora",
         [
-            ("llama2/7B_lora", "llama2", "tune", True),
             ("llama3/8B_lora", "llama3", "tune", False),
         ],
     )

--- a/tests/recipes/test_qat_distributed.py
+++ b/tests/recipes/test_qat_distributed.py
@@ -45,12 +45,6 @@ class TestQATDistributedRecipe:
 
     def _fetch_expected_loss_values(self, model_type):
         loss_values_map = {
-            "llama2": [
-                10.52530574798584,
-                10.510214805603027,
-                10.505669593811035,
-                10.521836280822754,
-            ],
             "llama3": [
                 11.977460861206055,
                 11.978384017944336,
@@ -64,7 +58,6 @@ class TestQATDistributedRecipe:
     @pytest.mark.parametrize(
         "config, model_type, ckpt_type, micro_batch_size, gradient_accumulation_steps",
         [
-            ("llama2/7B_qat_full", "llama2", "hf", 4, 1),
             ("llama3/8B_qat_full", "llama3", "tune", 4, 1),
             ("llama3/8B_qat_full", "llama3", "tune", 1, 4),
         ],

--- a/tests/recipes/utils.py
+++ b/tests/recipes/utils.py
@@ -235,8 +235,9 @@ def lora_llama3_test_config(
     lora_rank: int = 8,
     lora_alpha: float = 16,
     quantize_base: bool = False,
+    use_dora: bool = False,
 ) -> list[str]:
-    return [
+    config_overrides = [
         # Note: we explicitly use _component_ so that we can also call
         # config.instantiate directly for easier comparison
         "model._component_=torchtune.models.llama3.lora_llama3",
@@ -254,7 +255,13 @@ def lora_llama3_test_config(
         f"model.lora_alpha={lora_alpha}",
         "model.lora_dropout=0.0",
         f"model.quantize_base={quantize_base}",
+        f"model.use_dora={use_dora}",
     ]
+
+    if quantize_base:
+        config_overrides.append("model.scaler_block_size=32")
+
+    return config_overrides
 
 
 def write_hf_ckpt_config(ckpt_dir: Union[str, Path]):
@@ -322,5 +329,21 @@ MODEL_TEST_CONFIGS = {
         apply_lora_to_output=False,
         lora_rank=8,
         lora_alpha=16,
+    ),
+    "llama3_qlora": lora_llama3_test_config(
+        lora_attn_modules=["q_proj", "k_proj", "v_proj", "output_proj"],
+        apply_lora_to_mlp=True,
+        apply_lora_to_output=False,
+        lora_rank=8,
+        lora_alpha=16,
+        quantize_base=True,
+    ),
+    "llama3_dora": lora_llama3_test_config(
+        lora_attn_modules=["q_proj", "k_proj", "v_proj", "output_proj"],
+        apply_lora_to_mlp=False,
+        apply_lora_to_output=False,
+        lora_rank=8,
+        lora_alpha=16,
+        use_dora=True,
     ),
 }


### PR DESCRIPTION
### Context

1. Llama2 is an old, unused model so it doesn't really help to test on it
2. Fewer useless tests means faster iteration (these tests run in X)
3. This bubbles up to step-based checkpointing b/c I need to switch over all our tests to use llama3_137M

### FAQs

1. Why did you not change the PPO tests?

I'll open an Issue for this, but I won't be touching that for step-based checkpointing right now anyways and I need a script from Salman to generate a new Llama3-based classifier model.

2. Is it really the right move to add ``scaler_block_size`` to the top level component builders for Llama3?

Fair enough, the other way to handle this would be to generate a completely new test model that was large enough to be properly quantized. I went with this approach because a) this llama3 model will be changed soon anyways and b) it's an optional param so it doesn't really affect the UX.

3. Why did you have to remove ``intermediate_dim`` from the tiny QAT model?

It's calculated if omitted anyways and it causes problems b/c the model config for Llama3 doesn't include it, therefore it throws a size mismatch upon construction.