### PR TITLE
Revert changes to lora_dpo_distributed from #2754

### DIFF
--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -26,17 +26,15 @@ from torchtune.modules.peft import (
     AdapterModule,
     disable_adapter,
     get_adapter_params,
+    get_adapter_state_dict,
     get_lora_module_names,
+    get_merged_lora_ckpt,
     set_trainable_params,
     validate_missing_and_unexpected_for_lora,
 )
 from torchtune.recipe_interfaces import FTRecipeInterface
 from torchtune.rlhf import ChosenRejectedOutputs
 from torchtune.training import VALID_BACKENDS_FOR_MEMORY_STATS
-from torchtune.training.checkpointing._checkpoint_client import (
-    CheckpointClient,
-    TrainingProgress,
-)
 from tqdm import tqdm
 
 
@@ -134,7 +132,6 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                 "full fp16 training is not supported with this recipe. Please use bf16 or fp32 instead."
             )
 
-        self._checkpoint_client = CheckpointClient(cfg)
         # Set up the backend for distributed training (NCCL, GLOO, etc.)
         self._enable_async_checkpointing = cfg.get("enable_async_checkpointing", False)
         self.fsdp_cpu_offload = cfg.get("fsdp_cpu_offload", False)
@@ -199,6 +196,31 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
 
+    def load_checkpoint(self, cfg_checkpointer: DictConfig) -> dict[str, Any]:
+        """
+        Extract the checkpoint state from file and validate. This includes the
+        base model weights. If resume_from_checkpoint is True, this also includes
+        the adapter weights and recipe state
+        """
+        self._checkpointer = config.instantiate(
+            cfg_checkpointer,
+            should_load_recipe_state=self._resume_from_checkpoint,
+        )
+        checkpoint_dict = self._checkpointer.load_checkpoint()
+
+        # When resuming from checkpoint for LoRA, the recipe expects the adapter weights
+        # and recipe state to be present. The keys should match up with what ``save_checkpoint``
+        # used to create these intermediate checkpoints
+        if self._resume_from_checkpoint:
+            if training.ADAPTER_KEY not in checkpoint_dict:
+                raise ValueError(
+                    "Adapter weights not found. Please ensure a valid adapter checkpoint is provided."
+                )
+            # _update_recipe_state will throw an exception if the recipe state is not corrctly loaded
+            # no need to check here
+            self._update_recipe_state(checkpoint_dict)
+        return checkpoint_dict
+
     def _update_recipe_state(self, ckpt_dict: dict[str, Any]) -> None:
         """
         Updates the recipe state from checkpoint.
@@ -252,7 +274,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
 
         utils.log_rank_zero(self._logger, "metric logger is initialized.")
 
-        checkpoint_dict = self._checkpoint_client.load_base_checkpoint()
+        checkpoint_dict = self.load_checkpoint(cfg_checkpointer=cfg.checkpointer)
 
         self._model = self._setup_model(
             cfg_model=cfg.model,
@@ -264,7 +286,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             base_model_state_dict=checkpoint_dict[training.MODEL_KEY],
             lora_weights_state_dict=(
                 checkpoint_dict[training.ADAPTER_KEY]
-                if training.ADAPTER_KEY in checkpoint_dict
+                if self._resume_from_checkpoint
                 else None
             ),
         )
@@ -274,37 +296,10 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             cfg_optimizer=cfg.optimizer,
             opt_state_dict=(
                 checkpoint_dict[training.OPT_KEY]
-                if training.OPT_KEY in checkpoint_dict
+                if self._resume_from_checkpoint
                 else None
             ),
         )
-
-        if self._resume_from_checkpoint:
-            # If async checkpointing is enabled, intermediate checkpoints are saved asynchronously
-            # using the DistributedCheckpointer.
-            # Therefore the recipe needs to load the distributed checkpoint to restore the training
-            # progress.
-            if self._enable_async_checkpointing:
-                try:
-                    checkpoint_dict = (
-                        self._checkpoint_client.load_distributed_checkpoint(
-                            self._model,
-                            self._optimizer,
-                            self._adapter_config,
-                        )
-                    )
-                except Exception as e:
-                    log.warning(
-                        f"Failed to load distributed checkpoint: {e}. Training will start from the base checkpoint."
-                    )
-
-            if training.ADAPTER_KEY not in checkpoint_dict:
-                raise ValueError(
-                    "Adapter weights not found. Please ensure a valid adapter checkpoint is provided."
-                )
-
-            # Update the recipe state from the checkpoint state dict.
-            self._update_recipe_state(checkpoint_dict)
 
         self._loss_fn = config.instantiate(cfg.loss)
 
@@ -367,17 +362,6 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self._lora_attn_modules = list(cfg_model.lora_attn_modules)
         self._apply_lora_to_mlp = cfg_model.apply_lora_to_mlp
         self._apply_lora_to_output = getattr(cfg_model, "apply_lora_to_output", False)
-
-        self._adapter_config = {
-            "r": self._lora_rank,
-            "lora_alpha": self._lora_alpha,
-            "target_modules": get_lora_module_names(
-                self._lora_attn_modules,
-                self._apply_lora_to_mlp,
-                self._apply_lora_to_output,
-            ),
-            "peft_type": "LORA",
-        }
 
         init_start = time.perf_counter()
 
@@ -557,20 +541,89 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self,
         epoch: int,
     ) -> None:
-        self._checkpoint_client.save_checkpoint(
-            model=self._model,
-            optimizer=self._optimizer,
-            training_progress=TrainingProgress(
-                seed=self.seed,
-                epochs_run=self.epochs_run,
-                total_epochs=self.total_epochs,
-                max_steps_per_epoch=self.max_steps_per_epoch,
-                dataloader_state_dict=self._dataloader.state_dict(),
-            ),
-            epoch=epoch,
-            adapter_config=self._adapter_config.copy(),
-            adapter_only=self._save_adapter_weights_only,
+        """
+        Checkpoint the state of the recipe. The constructed checkpoint state dict
+        contains the following information:
+        - Merged weights with key MODEL_KEY
+        - Adapter weights with key ADAPTER_KEY
+        - Relevant recipe state if training is not complete
+        - If the `self._save_adapter_weights_only` option is True, the checkpointer will save only the adapter weights
+
+        Checkpointer will save the merged weights, adapter weights and recipe state in
+        different checkpoint files. To correctly resume from training, the adapter weights
+        and recipe state must be provided along with the base model weights."""
+        # final dict passed onto the checkpointer
+        checkpoint_dict = {}
+
+        intermediate_checkpoint = epoch + 1 < self.total_epochs
+        # To prevent GPU memory from spiking during checkpoint save,
+        # we consolidate the full model and optim state dicts on CPU for rank 0
+        cpu_state_dict = training.gather_cpu_state_dict(
+            self._model,
+            self._is_rank_zero,
+            device=self._device,
+            adapter_weights_only=self._save_adapter_weights_only,
         )
+        if intermediate_checkpoint:
+            opt_state_dict = training.get_full_optimizer_state_dict(
+                self._model,
+                self._optimizer,
+                self._is_rank_zero,
+                device=self._device,
+            )
+        else:
+            opt_state_dict = None
+
+        # Now that we have the model and opt state dict, create the actual checkpoint dict
+        # to be sent to the checkpointer and ultimately written to file
+        if self._is_rank_zero:
+            if self._save_adapter_weights_only:
+                adapter_state_dict = cpu_state_dict
+            else:
+                # Filter out the adapter keys and weights from the model state dict. These will
+                # be saved separately
+                adapter_state_dict = get_adapter_state_dict(cpu_state_dict)
+
+                # merge the adapter weights and base weights to create the model checkpoint
+                merged_state_dict = get_merged_lora_ckpt(
+                    cpu_state_dict,
+                    rank=self._lora_rank,
+                    alpha=self._lora_alpha,
+                )
+                checkpoint_dict.update({training.MODEL_KEY: merged_state_dict})
+            checkpoint_dict.update({training.ADAPTER_KEY: adapter_state_dict})
+
+            # if training is in-progress, checkpoint the optimizer state and recipe state
+            # as well.
+            if intermediate_checkpoint:
+                checkpoint_dict.update(
+                    {
+                        training.OPT_KEY: opt_state_dict,
+                        training.SEED_KEY: self.seed,
+                        training.EPOCHS_KEY: self.epochs_run,
+                        training.TOTAL_EPOCHS_KEY: self.total_epochs,
+                        training.MAX_STEPS_KEY: self.max_steps_per_epoch,
+                        training.DATALOADER_KEY: self._dataloader.state_dict(),
+                    }
+                )
+
+            adapter_config = {
+                "r": self._lora_rank,
+                "lora_alpha": self._lora_alpha,
+                "target_modules": get_lora_module_names(
+                    self._lora_attn_modules,
+                    self._apply_lora_to_mlp,
+                    self._apply_lora_to_output,
+                ),
+                "peft_type": "LORA",
+            }
+            checkpoint_dict.update({training.ADAPTER_CONFIG: adapter_config})
+            self._checkpointer.save_checkpoint(
+                checkpoint_dict,
+                epoch=epoch,
+                intermediate_checkpoint=intermediate_checkpoint,
+                adapter_only=self._save_adapter_weights_only,
+            )
 
     def concatenated_forward(
         self, model: nn.Module, batch: tuple[torch.Tensor, torch.Tensor]

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -38,7 +38,7 @@ from torchtune.training.checkpointing._utils import (
 class TestLoRADPODistributedRecipe:
     def _get_test_config_overrides(self, dtype_str: str = "fp32", epochs: int = 2):
         return [
-            "batch_size=1",
+            "batch_size=8",
             "device=cuda",
             f"dtype={dtype_str}",
             "dataset.train_on_input=False",
@@ -47,13 +47,13 @@ class TestLoRADPODistributedRecipe:
             "max_steps_per_epoch=2",
             "optimizer.lr=2e-5",
             "log_every_n_steps=1",
-            "gradient_accumulation_steps=8",
+            "gradient_accumulation_steps=1",
             "clip_grad_norm=100",
             "tokenizer.max_seq_len=512",
         ] + dummy_stack_exchange_dataset_config()
 
     @pytest.mark.parametrize("save_adapter_weights_only", [False, True])
-    @gpu_test(gpu_count=2)
+    @gpu_test(gpu_count=4)
     @pytest.mark.integration_test
     def test_training_state_on_resume(
         self, tmpdir, monkeypatch, save_adapter_weights_only
@@ -68,7 +68,7 @@ class TestLoRADPODistributedRecipe:
         values to benchmark against. This test just ensures the loss values are identical when resuming.
         """
 
-        ckpt = "llama3_tune"
+        ckpt = "llama2_hf"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
         log_file = gen_log_file_name(tmpdir)
@@ -80,17 +80,17 @@ class TestLoRADPODistributedRecipe:
 
         # Train for two epochs
         cmd_1 = f"""
-        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
-            --config llama3_1/8B_lora_dpo \
+        tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
+            --config llama2/7B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
+            checkpointer=torchtune.training.FullModelHFCheckpointer \
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA3 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
+            checkpointer.model_type=LLAMA2 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
             save_adapter_weights_only={save_adapter_weights_only} \
             metric_logger.filename={log_file} \
@@ -98,7 +98,7 @@ class TestLoRADPODistributedRecipe:
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
 
         cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd_1)
@@ -113,115 +113,21 @@ class TestLoRADPODistributedRecipe:
         epoch_folder = get_largest_iter_folder(tmpdir)
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         cmd_2 = f"""
-        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
-            --config llama3_1/8B_lora_dpo \
+        tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
+            --config llama2/7B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
+            checkpointer=torchtune.training.FullModelHFCheckpointer \
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
             checkpointer.recipe_checkpoint={os.path.join(tmpdir, RECIPE_STATE_DIRNAME, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA3 \
+            checkpointer.model_type=LLAMA2 \
             resume_from_checkpoint=True \
             metric_logger.filename={resumed_log_file} \
-            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
-            tokenizer.prompt_template=null \
-            save_adapter_weights_only={save_adapter_weights_only} \
-            enable_activation_checkpointing=True \
-            enable_activation_offloading=False \
-        """.split()
-        cmd_2 = cmd_2 + self._get_test_config_overrides(epochs=3) + model_config
-        monkeypatch.setattr(sys, "argv", cmd_2)
-        runpy.run_path(TUNE_PATH, run_name="__main__")
-
-        # Second epoch only
-        resumed_loss_values = get_loss_values_from_metric_logger(resumed_log_file)
-
-        torch.testing.assert_close(
-            resumed_loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
-        )
-
-    @pytest.mark.parametrize("save_adapter_weights_only", [False, True])
-    @gpu_test(gpu_count=2)
-    @pytest.mark.integration_test
-    def test_training_state_on_resume_with_async_checkpointing(
-        self, tmpdir, monkeypatch, save_adapter_weights_only
-    ):
-        """Test whether the recipe state is correctly updated on resume with async checkpointing. Since this
-        is model agnostic, we should run this on the small model only. The test
-        consists of three stages:
-            - Train a model for 2 epochs
-            - Resume training after epoch 1
-            - Make sure final loss matches the expected value of a model successfully resumed from a ckpt
-        Unlike `tests.recipes.test_lora_finetune_single_device`, this test does not use pre-computed loss
-        values to benchmark against. This test just ensures the loss values are identical when resuming.
-        """
-
-        ckpt = "llama3_tune"
-        ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
-        ckpt_dir = ckpt_path.parent
-        log_file = gen_log_file_name(tmpdir)
-
-        # Config file needed for model conversion.
-        # Create a second copy for training resume
-        write_hf_ckpt_config(ckpt_dir)
-        write_hf_ckpt_config(tmpdir)
-
-        # Train for two epochs
-        cmd_1 = f"""
-        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
-            --config llama3_1/8B_lora_dpo \
-            output_dir={tmpdir} \
-            model.lora_attn_modules=['q_proj','v_proj'] \
-            model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
-            checkpointer.checkpoint_dir='{ckpt_dir}' \
-            checkpointer.checkpoint_files=[{ckpt_path}]\
-            checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA3 \
-            enable_async_checkpointing=True \
-            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
-            tokenizer.prompt_template=null \
-            save_adapter_weights_only={save_adapter_weights_only} \
-            metric_logger.filename={log_file} \
-            enable_activation_checkpointing=True \
-            enable_activation_offloading=False \
-        """.split()
-
-        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
-
-        cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
-        monkeypatch.setattr(sys, "argv", cmd_1)
-        runpy.run_path(TUNE_PATH, run_name="__main__")
-
-        expected_loss_values = get_loss_values_from_metric_logger(log_file)
-
-        resumed_log_dir = (tmpdir / "resumed/").mkdir()
-        resumed_log_file = gen_log_file_name(resumed_log_dir)
-
-        # Resume training
-        epoch_folder = get_largest_iter_folder(tmpdir)
-        epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
-        cmd_2 = f"""
-        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
-            --config llama3_1/8B_lora_dpo \
-            output_dir={tmpdir} \
-            model.lora_attn_modules=['q_proj','v_proj'] \
-            model.apply_lora_to_mlp=False \
-            checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
-            checkpointer.checkpoint_dir={ckpt_dir} \
-            checkpointer.checkpoint_files=[{ckpt_path}]\
-            checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(tmpdir, RECIPE_STATE_DIRNAME, "recipe_state.pt")}
-            checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA3 \
-            resume_from_checkpoint=True \
-            enable_async_checkpointing=True \
-            metric_logger.filename={resumed_log_file} \
-            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
+            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=True \
             enable_activation_offloading=False \
@@ -240,13 +146,13 @@ class TestLoRADPODistributedRecipe:
     @pytest.mark.integration_test
     @gpu_test(gpu_count=2)
     def test_save_and_load_merged_weights(self, tmpdir, monkeypatch):
-        ckpt = "llama3_tune"
+        ckpt = "llama2_tune"
         ckpt_path = Path(CKPT_MODEL_PATHS[ckpt])
         ckpt_dir = ckpt_path.parent
 
         cmd = f"""
-        tune run  --nnodes 1 --nproc_per_node 2 lora_dpo_distributed \
-            --config llama3_1/8B_lora_dpo \
+        tune run  --nnodes 1 --nproc_per_node 4 lora_dpo_distributed \
+            --config llama2/7B_lora_dpo \
             output_dir={tmpdir} \
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
@@ -254,20 +160,20 @@ class TestLoRADPODistributedRecipe:
             checkpointer.checkpoint_dir='{ckpt_dir}' \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.model_type=LLAMA3 \
-            tokenizer.path=/tmp/test-artifacts/tokenizer_llama3.model \
+            checkpointer.model_type=LLAMA2 \
+            tokenizer.path=/tmp/test-artifacts/tokenizer.model \
             tokenizer.prompt_template=null \
             enable_activation_checkpointing=False \
             enable_activation_offloading=False \
         """.split()
 
-        model_config = MODEL_TEST_CONFIGS["llama3_lora"]
+        model_config = MODEL_TEST_CONFIGS["llama2_lora"]
 
         cmd = cmd + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd)
         runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        # Next load both the merged weights in a Llama3 base model
+        # Next load both the merged weights in a Llama2 base model
         # and the base model weights + trained adapter weights in the LoRA Llama 2 model
         # The results of calling forward on dummy inputs should be the same.
         inputs = torch.randint(low=0, high=32_000, size=(2, 100))
@@ -275,10 +181,10 @@ class TestLoRADPODistributedRecipe:
         # Build LoRA model for loading base + adapter weights separately
         lora_model = config.instantiate(OmegaConf.from_dotlist(model_config).model)
 
-        # Build base llama3 model for loading merged weights
-        base_llama3_config = MODEL_TEST_CONFIGS["llama3"]
-        llama3_model = config.instantiate(
-            OmegaConf.from_dotlist(base_llama3_config).model
+        # Build base llama2 model for loading merged weights
+        base_llama2_config = MODEL_TEST_CONFIGS["llama2"]
+        llama2_model = config.instantiate(
+            OmegaConf.from_dotlist(base_llama2_config).model
         )
 
         # Load base model and trained adapter weights into LoRA model and call fwd
@@ -292,7 +198,7 @@ class TestLoRADPODistributedRecipe:
         lora_model.load_state_dict(base_model_sd, strict=False)
         baseline_out = lora_model(inputs)
 
-        # Load merged final ckpt directly into llama3 and call fwd
+        # Load merged final ckpt directly into llama2 and call fwd
         suffix = ".bin"
         model_ckpt_fname = (
             SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5)) + suffix
@@ -300,6 +206,6 @@ class TestLoRADPODistributedRecipe:
         model_path = os.path.join(tmpdir, epoch_folder, model_ckpt_fname)
         sd = safe_torch_load(model_path, weights_only=True)
 
-        llama3_model.load_state_dict(sd)
-        merged_ckpt_out = llama3_model(inputs)
+        llama2_model.load_state_dict(sd)
+        merged_ckpt_out = llama2_model(inputs)
         torch.testing.assert_close(baseline_out, merged_ckpt_out, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
This partially reverts commit 20bdf1086e947fd010dd79faf1c78600062cb162.

Ever since this commit was merged to main, `tests/recipes/test_lora_dpo_distributed.py::TestLoRADPODistributedRecipe::test_training_state_on_resume` fails consistently with one of two errors:

1. 
```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/recipes/lora_dpo_distributed.py", line 823, in <module>
[rank1]:     sys.exit(recipe_main())
[rank1]:              ^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/config/_parse.py", line 99, in wrapper
[rank1]:     sys.exit(recipe_main(conf))
[rank1]:              ^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/recipes/lora_dpo_distributed.py", line 817, in recipe_main
[rank1]:     recipe.setup(cfg=cfg)
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/recipes/lora_dpo_distributed.py", line 340, in setup
[rank1]:     self._lr_scheduler = self._setup_lr_scheduler(
[rank1]:                          ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/recipes/lora_dpo_distributed.py", line 504, in _setup_lr_scheduler
[rank1]:     lr_scheduler = config.instantiate(
[rank1]:                    ^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/config/_instantiate.py", line 163, in instantiate
[rank1]:     return _instantiate_node(
[rank1]:            ^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/config/_instantiate.py", line 62, in _instantiate_node
[rank1]:     return _create_component(_component_, args, kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/config/_instantiate.py", line 24, in _create_component
[rank1]:     return _component_(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/training/lr_schedulers.py", line 58, in get_cosine_schedule_with_warmup
[rank1]:     return LambdaLR(optimizer, lr_lambda, last_epoch)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/3/envs/test/lib/python3.11/site-packages/torch/optim/lr_scheduler.py", line 286, in __init__
[rank1]:     super().__init__(optimizer, last_epoch)
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/3/envs/test/lib/python3.11/site-packages/torch/optim/lr_scheduler.py", line 99, in __init__
[rank1]:     raise KeyError(
[rank1]: KeyError: "param 'initial_lr' is not specified in param_groups[0] when resuming an optimizer"
```

2.
```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/training/checkpointing/_utils.py", line 271, in safe_torch_load
[rank1]:     state_dict = torch.load(
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/3/envs/test/lib/python3.9/site-packages/torch/serialization.py", line 1516, in load
[rank1]:     return _load(
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/3/envs/test/lib/python3.9/site-packages/torch/serialization.py", line 1898, in _load
[rank1]:     version = zip_file.get_record(".format_version")
[rank1]: RuntimeError: PytorchStreamReader failed reading file .format_version: invalid header or archive is corrupted

[rank1]: The above exception was the direct cause of the following exception:

[rank1]: Traceback (most recent call last):
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/recipes/lora_dpo_distributed.py", line 823, in <module>
[rank1]:     sys.exit(recipe_main())
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/config/_parse.py", line 99, in wrapper
[rank1]:     sys.exit(recipe_main(conf))
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/recipes/lora_dpo_distributed.py", line 817, in recipe_main
[rank1]:     recipe.setup(cfg=cfg)
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/recipes/lora_dpo_distributed.py", line 255, in setup
[rank1]:     checkpoint_dict = self._checkpoint_client.load_base_checkpoint()
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/training/checkpointing/_checkpoint_client.py", line 388, in load_base_checkpoint
[rank1]:     return self._get_checkpointer().load_checkpoint()
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/training/checkpointing/_checkpointer.py", line 690, in load_checkpoint
[rank1]:     recipe_state = safe_torch_load(self._recipe_checkpoint, mmap=False)
[rank1]:   File "/home/ec2-user/actions-runner/_work/torchtune/torchtune/torchtune/training/checkpointing/_utils.py", line 278, in safe_torch_load
[rank1]:     raise ValueError(f"Unable to load checkpoint from {checkpoint_path}. ") from e
[rank1]: ValueError: Unable to load checkpoint from /tmp/pytest-of-ec2-user/pytest-0/test_training_state_on_resume_15/recipe_state/recipe_state.pt. 
```

***

Proof this passes locally:

```
(joe-torchtune-dev) [jrcummings@devvm4767.pnb0 ~/projects/joe-torchtune (why-dpo-fail)]$ python -m pytest tests/recipes/test_lora_dpo_distributed.py::TestLoRADPODistributedRecipe::test_training_state_on_resume --with-integration
Expected artifacts for test run are:
small-ckpt-tune-03082024.pt
small-ckpt-meta-03082024.pt
small-ckpt-hf-03082024.pt
small-ckpt-tune-llama3-05052024.pt
small-ckpt-hf-reward-07122024.pt
small-ckpt-meta-vision-10172024.pt
small-ckpt-hf-vision-10172024.pt
llama3-hf-04232025/config.json
llama3-hf-04232025/generation_config.json
llama3-hf-04232025/model.safetensors
llama3-hf-04232025/model.safetensors.index.json
llama3-hf-04232025/special_tokens_map.json
llama3-hf-04232025/tokenizer.json
llama3-hf-04232025/tokenizer_config.json
tokenizer.model
tokenizer_llama3.model
File already exists locally: /tmp/test-artifacts/small-ckpt-tune-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-meta-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-hf-03082024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-tune-llama3-05052024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-hf-reward-07122024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-meta-vision-10172024.pt
File already exists locally: /tmp/test-artifacts/small-ckpt-hf-vision-10172024.pt
File already exists locally: /tmp/test-artifacts/llama3-hf-04232025/config.json
File already exists locally: /tmp/test-artifacts/llama3-hf-04232025/generation_config.json
File already exists locally: /tmp/test-artifacts/llama3-hf-04232025/model.safetensors
File already exists locally: /tmp/test-artifacts/llama3-hf-04232025/model.safetensors.index.json
File already exists locally: /tmp/test-artifacts/llama3-hf-04232025/special_tokens_map.json
File already exists locally: /tmp/test-artifacts/llama3-hf-04232025/tokenizer.json
File already exists locally: /tmp/test-artifacts/llama3-hf-04232025/tokenizer_config.json
File already exists locally: /tmp/test-artifacts/tokenizer.model
File already exists locally: /tmp/test-artifacts/tokenizer_llama3.model
================================================================================================================ test session starts ================================================================================================================
platform linux -- Python 3.12.9, pytest-7.4.0, pluggy-1.6.0
rootdir: /home/jrcummings/projects/joe-torchtune
configfile: pyproject.toml
plugins: integration-0.2.3, anyio-4.9.0, mock-3.14.0, cov-6.1.1
collected 2 items

tests/recipes/test_lora_dpo_distributed.py ..                                                                                                                                                                                                 [100%]

=========================================================================================================== 2 passed in 80.95s (0:01:20) ============================================================================================================
```


Whereas on main, it looks like this:

```

INFO:torchtune.utils._logging:Hint: enable_activation_checkpointing is True, but enable_activation_offloading isn't. Enabling activation offloading should reduce memory further.
INFO:torchtune.utils._logging:Loading the recipe state using:
        checkpoint_paths: ['/tmp/test-artifacts/small-ckpt-tune-llama3-05052024.pt']
        recipe_checkpoint: /tmp/pytest-of-jrcummings/pytest-166/test_training_state_on_resume_1/recipe_state/recipe_state.pt
        adapter_checkpoint: /tmp/pytest-of-jrcummings/pytest-166/test_training_state_on_resume_1/epoch_0/adapter_model.pt
INFO:torchtune.utils._logging:metric logger is initialized.
INFO:torchtune.utils._logging:Loading the recipe state using:
        checkpoint_paths: ['/tmp/test-artifacts/small-ckpt-tune-llama3-05052024.pt']
        recipe_checkpoint: /tmp/pytest-of-jrcummings/pytest-166/test_training_state_on_resume_1/recipe_state/recipe_state.pt
        adapter_checkpoint: /tmp/pytest-of-jrcummings/pytest-166/test_training_state_on_resume_1/epoch_0/adapter_model.pt
INFO:torchtune.utils._logging:FSDP is enabled. Instantiating model and loading checkpoint on Rank 0 ...
/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py:452: FutureWarning: lora_attn_modules is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  validate_missing_and_unexpected_for_lora(
/home/jrcummings/projects/joe-torchtune/torchtune/utils/_logging.py:143: FutureWarning: apply_lora_to_mlp is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  return obj(*args, **kwargs)
/home/jrcummings/projects/joe-torchtune/torchtune/utils/_logging.py:143: FutureWarning: apply_lora_to_output is deprecated for validate_missing_and_unexpected_for_lora and will be removed in future versions. Please use state_dict_keys instead.
  return obj(*args, **kwargs)
INFO:torchtune.utils._logging:Instantiating model and loading checkpoint took 1.57 secs
INFO:torchtune.utils._logging:Memory stats after model init:
        GPU peak memory active: 0.06 GiB
        GPU peak memory alloc: 0.06 GiB
        GPU peak memory reserved: 0.06 GiB
INFO:torchtune.utils._logging:Optimizer and loss are initialized.
/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py:229: UserWarning: Config value for total_epochs does not match the checkpoint value, using the config value: 3
  warn
/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py:229: UserWarning: Config value for total_epochs does not match the checkpoint value, using the config value: 3
  warn(
[rank1]: Traceback (most recent call last):
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 823, in <module>
[rank1]:     sys.exit(recipe_main())
[rank1]:              ^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_parse.py", line 99, in wrapper
[rank1]:     sys.exit(recipe_main(conf))
[rank1]:              ^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 817, in recipe_main
[rank1]:     recipe.setup(cfg=cfg)
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 340, in setup
[rank1]:     self._lr_scheduler = self._setup_lr_scheduler(
[rank1]:                          ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 504, in _setup_lr_scheduler
[rank1]:     lr_scheduler = config.instantiate(
[rank1]:                    ^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_instantiate.py", line 163, in instantiate
[rank1]:     return _instantiate_node(
[rank1]:            ^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_instantiate.py", line 62, in _instantiate_node
[rank1]:     return _create_component(_component_, args, kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_instantiate.py", line 24, in _create_component
[rank1]:     return _component_(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/training/lr_schedulers.py", line 58, in get_cosine_schedule_with_warmup
[rank1]:     return LambdaLR(optimizer, lr_lambda, last_epoch)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/home/jrcummings/.conda/envs/joe-torchtune-dev/lib/python3.12/site-packages/torch/optim/lr_scheduler.py", line 303, in __init__
[rank1]:     super().__init__(optimizer, last_epoch)
[rank1]:   File "/home/jrcummings/.conda/envs/joe-torchtune-dev/lib/python3.12/site-packages/torch/optim/lr_scheduler.py", line 106, in __init__
[rank1]:     raise KeyError(
[rank1]: KeyError: "param 'initial_lr' is not specified in param_groups[0] when resuming an optimizer"
INFO:torchtune.utils._logging:Dataset and Sampler are initialized.
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 823, in <module>
[rank0]:     sys.exit(recipe_main())
[rank0]:              ^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_parse.py", line 99, in wrapper
[rank0]:     sys.exit(recipe_main(conf))
[rank0]:              ^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 817, in recipe_main
[rank0]:     recipe.setup(cfg=cfg)
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 340, in setup
[rank0]:     self._lr_scheduler = self._setup_lr_scheduler(
[rank0]:                          ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/recipes/lora_dpo_distributed.py", line 504, in _setup_lr_scheduler
[rank0]:     lr_scheduler = config.instantiate(
[rank0]:                    ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_instantiate.py", line 163, in instantiate
[rank0]:     return _instantiate_node(
[rank0]:            ^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_instantiate.py", line 62, in _instantiate_node
[rank0]:     return _create_component(_component_, args, kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/config/_instantiate.py", line 24, in _create_component
[rank0]:     return _component_(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/projects/joe-torchtune/torchtune/training/lr_schedulers.py", line 58, in get_cosine_schedule_with_warmup
[rank0]:     return LambdaLR(optimizer, lr_lambda, last_epoch)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/jrcummings/.conda/envs/joe-torchtune-dev/lib/python3.12/site-packages/torch/optim/lr_scheduler.py", line 303, in __init__
[rank0]:     super().__init__(optimizer, last_epoch)
[rank0]:   File "/home/jrcummings/.conda/envs/joe-torchtune-dev/lib/python3.12/site-packages/torch/optim/lr_scheduler.py", line 106, in __init__
[rank0]:     raise KeyError(
[rank0]: KeyError: "param 'initial_lr' is not specified in param_groups[0] when resuming an optimizer"
[rank0]:[W610 11:12:51.258448320 ProcessGroupNCCL.cpp:1535] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
W0610 11:12:52.544000 2602490 site-packages/torch/distributed/elastic/multiprocessing/api.py:900] Sending process 2641769 closing signal SIGTERM
E0610 11:12:52.960000 2602490 site-packages/torch/distributed/elastic/multiprocessing/api.py:874] failed (exitcode: 1) local_rank: 1 (pid: 2641770) of binary: /home/jrcummings/.conda/envs/joe-torchtune-dev/bin/python
============================================================================================================== short test summary info ==============================================================================================================
FAILED tests/recipes/test_lora_dpo_distributed.py::TestLoRADPODistributedRecipe::test_training_state_on_resume[False] - torch.distributed.elastic.multiprocessing.errors.ChildFailedError:
FAILED tests/recipes/test_lora_dpo_distributed.py::TestLoRADPODistributedRecipe::test_training_state_on_resume[True] - torch.distributed.elastic.multiprocessing.errors.ChildFailedError:
=========================================================================================================== 2 failed in 76.86s (0:01:16) ===========================================================
```