### PR TITLE
Changes to DCP HF integration

### DIFF
--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -536,15 +536,16 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
             # DCP load using the storage reader
             hf_storage_reader = _HuggingFaceStorageReader(path=self._checkpoint_dir)
 
-            state_dict = _load_state_dict_from_keys(storage_reader=hf_storage_reader)
             # TODO: reading the metadata isn't the best way to do this because
             # DCP can change their metadata structure and we've already read in
             # the metadata when doing _load_state_dict_from_keys
             metadata = hf_storage_reader.read_metadata()
             self._weight_map = {
-                key: os.path.basename(val.relative_path)
+                key.fqn: os.path.basename(val.relative_path)
                 for key, val in metadata.storage_data.items()
             }
+
+            state_dict = _load_state_dict_from_keys(storage_reader=hf_storage_reader)
 
             merged_state_dict = state_dict
         else:

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -531,10 +531,10 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         converted_state_dict: dict[str, dict[str, torch.Tensor]] = {}
 
         if self._enable_dcp:
-            from torch.distributed.checkpoint import _HuggingFaceStorageReader
+            from torch.distributed.checkpoint import HuggingFaceStorageReader
 
             # DCP load using the storage reader
-            hf_storage_reader = _HuggingFaceStorageReader(path=self._checkpoint_dir)
+            hf_storage_reader = HuggingFaceStorageReader(path=self._checkpoint_dir)
 
             # TODO: reading the metadata isn't the best way to do this because
             # DCP can change their metadata structure and we've already read in
@@ -808,14 +808,14 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 )
 
             if self._enable_dcp:
-                from torch.distributed.checkpoint import _HuggingFaceStorageWriter
+                from torch.distributed.checkpoint import HuggingFaceStorageWriter
 
                 # DCP save using the storage writer
                 fqn_to_file_index_mapping = {}
                 for fqn, filename in self._weight_map.items():
                     index = int(filename.split("-")[1])
                     fqn_to_file_index_mapping[fqn] = index
-                storage_writer = _HuggingFaceStorageWriter(
+                storage_writer = HuggingFaceStorageWriter(
                     path=os.path.join(self._output_dir, f"epoch_{epoch}"),
                     fqn_to_index_mapping=fqn_to_file_index_mapping,
                 )

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -535,11 +535,16 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
 
             # DCP load using the storage reader
             hf_storage_reader = _HuggingFaceStorageReader(path=self._checkpoint_dir)
-            metadata = hf_storage_reader.read_metadata()
-
-            self._weight_map = metadata.storage_data
 
             state_dict = _load_state_dict_from_keys(storage_reader=hf_storage_reader)
+            # TODO: reading the metadata isn't the best way to do this because
+            # DCP can change their metadata structure and we've already read in
+            # the metadata when doing _load_state_dict_from_keys
+            metadata = hf_storage_reader.read_metadata()
+            self._weight_map = {
+                key: os.path.basename(val.relative_path)
+                for key, val in metadata.storage_data.items()
+            }
 
             merged_state_dict = state_dict
         else:

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -531,10 +531,10 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
         converted_state_dict: dict[str, dict[str, torch.Tensor]] = {}
 
         if self._enable_dcp:
-            from torch.distributed.checkpoint import HuggingFaceStorageReader
+            from torch.distributed.checkpoint import _HuggingFaceStorageReader
 
             # DCP load using the storage reader
-            hf_storage_reader = HuggingFaceStorageReader(path=self._checkpoint_dir)
+            hf_storage_reader = _HuggingFaceStorageReader(path=self._checkpoint_dir)
             metadata = hf_storage_reader.read_metadata()
 
             self._weight_map = metadata.storage_data
@@ -802,10 +802,7 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 )
 
             if self._enable_dcp:
-                from torch.distributed.checkpoint import (
-                    _HuggingFaceSavePlanner,
-                    _HuggingFaceStorageWriter,
-                )
+                from torch.distributed.checkpoint import _HuggingFaceStorageWriter
 
                 # DCP save using the storage writer
                 fqn_to_file_index_mapping = {}
@@ -819,7 +816,6 @@ class FullModelHFCheckpointer(_CheckpointerInterface):
                 save(
                     state_dict=state_dict[training.MODEL_KEY],
                     storage_writer=storage_writer,
-                    planner=_HuggingFaceSavePlanner(),
                     no_dist=True,
                 )
             else:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* DCP expects a state_dict to be provided on load. Before, we were doing a hacky solution of creating a state_dict from the keys and then dcp was resizing the tensors to the right sizes, this is because of how DCP HF was doing loads. But now, the _load_state_dict_from_keys API will work, so we don't need to do the hacky-ness
* Also, the weight_map calculation will fail because we changed the metadata structure in DCP. We need to find a better way to get the weight_map when using DCP that isn't dependent on the metadata structure, because that can change, but just fixing so that the test passes for now
* Remove the underscore from the import of HuggingFace classes


#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ x] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x ] I did not change any public API
- [ ] I have added an example to docs or docstrings
