### PR TITLE
Add DCP async checkpointing info to docs

### DIFF
--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -293,7 +293,7 @@ flag to ``True``. The DistributedCheckpointer will be automatically used when th
 
     checkpointer:
         # checkpointer to use for final checkpoints
-        _component_: torchtune.training.FullModelMetaCheckpointer
+        _component_: torchtune.training.FullModelHFCheckpointer
 
     # Set to True to enable asynchronous distributed checkpointing for intermediate checkpoints
     enable_async_checkpointing: True
@@ -316,9 +316,8 @@ output directory.
 
 .. note::
 
-    While asynchronous checkpointing improves training throughput, it's important to note that the final
-    checkpoint at the end of training is always saved synchronously to ensure all data is properly persisted
-    in a safetensors or torch.save format before the training job completes.
+    The final checkpoint at the end of training is always saved synchronously to ensure all
+    data is properly persisted in safetensors or torch.save format before the training job completes.
 
 |
 

--- a/docs/source/deep_dives/checkpointer.rst
+++ b/docs/source/deep_dives/checkpointer.rst
@@ -266,6 +266,62 @@ for testing or for loading quantized models for generation.
 
 |
 
+:class:`DistributedCheckpointer <torchtune.training.DistributedCheckpointer>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This checkpointer reads and writes checkpoints in a distributed format using Pytorch Distributed Checkpointing (DCP).
+The output format is DCP's default format, which saves the state dict across all ranks, as seperate files for each rank. This differs
+from the other checkpointer implementations, which consolidate to rank-0 and then save the state dict as full tensors.
+The distributed checkpointer is enabled when enabling asynchronous checkpointing during training and uses DCP's async_save API.
+Async distributed checkpointing is only used for intermediate checkpoints.
+
+When asynchronous checkpointing is enabled, intermediate checkpoints are saved using the DistributedCheckpointer
+without blocking the training process. This is particularly useful for large models where saving checkpoints
+can take significant time.
+
+**Key Features:**
+
+- **Asynchronous Saving**: Allows training to continue while checkpoints are being saved in the background
+- **Distributed-Aware**: Designed to work seamlessly in multi-GPU and multi-node training setups
+
+**Configuration Example:**
+
+To enable asynchronous checkpointing in your training config, you need to set the ``enable_async_checkpointing``
+flag to ``True``. The DistributedCheckpointer will be automatically used when this flag is enabled.
+
+.. code-block:: yaml
+
+    checkpointer:
+        # checkpointer to use for final checkpoints
+        _component_: torchtune.training.FullModelMetaCheckpointer
+
+    # Set to True to enable asynchronous distributed checkpointing for intermediate checkpoints
+    enable_async_checkpointing: True
+
+**Resuming Training with DistributedCheckpointer:**
+
+If your training was interrupted and you had async checkpointing enabled, you can resume from the latest
+distributed checkpoint by setting both ``resume_from_checkpoint`` and ``enable_async_checkpointing`` to ``True``:
+
+.. code-block:: yaml
+
+    # Set to True to resume from checkpoint
+    resume_from_checkpoint: True
+
+    # Set to True to enable asynchronous checkpointing
+    enable_async_checkpointing: True
+
+The DistributedCheckpointer will automatically locate and load the latest intermediate checkpoint from the
+output directory.
+
+.. note::
+
+    While asynchronous checkpointing improves training throughput, it's important to note that the final
+    checkpoint at the end of training is always saved synchronously to ensure all data is properly persisted
+    in a safetensors or torch.save format before the training job completes.
+
+|
+
 Checkpoint Output
 ---------------------------------
 


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [x ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Add information about DCP async checkpointing to docs

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ x] I have added an example to docs or docstrings
