### PR TITLE
[Gemma2] Use nn.SDPA via MultiHeadAttention

### DIFF
--- a/tests/torchtune/models/gemma2/test_sliding_attention_mask.py
+++ b/tests/torchtune/models/gemma2/test_sliding_attention_mask.py
@@ -1,0 +1,126 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from torchtune.models.gemma2._attention_mask import get_sliding_attention_mask
+
+
+class TestGetSlidingAttentionMask:
+    @pytest.fixture
+    def basic_params(self):
+        return {"bsz": 2, "seq_len": 4, "sliding_window_size": 2, "device": None}
+
+    def test_get_sliding_attention_mask(self, basic_params):
+        """Test that when mask is None, a causal mask is created and sliding window is applied."""
+        bsz = 2
+        seq_len = 4
+        sliding_window_size = 2
+        mask = get_sliding_attention_mask(
+            mask=None,
+            sliding_window_size=basic_params["sliding_window_size"],
+            bsz=basic_params["bsz"],
+            seq_len=basic_params["seq_len"],
+            device=basic_params["device"],
+        )
+
+        assert mask.shape == (
+            basic_params["bsz"],
+            basic_params["seq_len"],
+            basic_params["seq_len"],
+        )
+        assert mask.dtype == torch.bool
+
+        # Check that the mask has the expected sliding window pattern
+        # True positions can be attended to, False positions are masked
+        expected_pattern = torch.tensor(
+            [
+                [True, False, False, False],
+                [True, True, False, False],
+                [False, True, True, False],
+                [False, False, True, True],
+            ],
+            dtype=torch.bool,
+        )
+
+        # Check first batch element
+        torch.testing.assert_close(mask[0], expected_pattern)
+        # All batch elements should be identical
+        torch.testing.assert_close(mask[0], mask[1])
+
+    def test_get_sliding_attention_mask_different_window_sizes(self):
+        """Test sliding window with different window sizes."""
+        bsz, seq_len = 1, 5
+
+        # Test window size 1 (only current position)
+        mask = get_sliding_attention_mask(
+            mask=None,
+            sliding_window_size=1,
+            bsz=bsz,
+            seq_len=seq_len,
+            device=None,
+        )
+
+        expected_window_1 = torch.tensor(
+            [
+                [True, False, False, False, False],
+                [False, True, False, False, False],
+                [False, False, True, False, False],
+                [False, False, False, True, False],
+                [False, False, False, False, True],
+            ],
+            dtype=torch.bool,
+        )
+
+        torch.testing.assert_close(mask[0], expected_window_1)
+
+        # Test window size 3
+        mask = get_sliding_attention_mask(
+            mask=None,
+            sliding_window_size=3,
+            bsz=bsz,
+            seq_len=seq_len,
+            device=None,
+        )
+
+        expected_window_3 = torch.tensor(
+            [
+                [True, False, False, False, False],
+                [True, True, False, False, False],
+                [True, True, True, False, False],
+                [False, True, True, True, False],
+                [False, False, True, True, True],
+            ],
+            dtype=torch.bool,
+        )
+
+        torch.testing.assert_close(mask[0], expected_window_3)
+
+    def test_get_sliding_attention_mask_large_window(self):
+        """Test sliding window larger than sequence length."""
+        bsz, seq_len = 1, 3
+        sliding_window_size = 5  # Larger than seq_len
+
+        mask = get_sliding_attention_mask(
+            mask=None,
+            sliding_window_size=sliding_window_size,
+            bsz=bsz,
+            seq_len=seq_len,
+            device=None,
+        )
+
+        # Should behave like a regular causal mask when window is larger than seq_len
+        expected_causal = torch.tensor(
+            [
+                [True, False, False],
+                [True, True, False],
+                [True, True, True],
+            ],
+            dtype=torch.bool,
+        )
+
+        torch.testing.assert_close(mask[0], expected_causal)

--- a/tests/torchtune/modules/test_attention_utils.py
+++ b/tests/torchtune/modules/test_attention_utils.py
@@ -122,7 +122,7 @@ class TestSDPAOrFlexAttention:
             _attention_call = _sdpa_or_flex_attention()
             _ = _attention_call(q, k, v, attn_mask, dropout_p, is_causal)
             mock_sdpa.assert_not_called()
-            mock_flex.assert_called_with(q, k, v, block_mask=attn_mask)
+            mock_flex.assert_called_with(q, k, v, block_mask=attn_mask, scale=None)
         # If mask is not a BlockMask, then we should call SDPA
         _attention_call = _sdpa_or_flex_attention()
         _ = _attention_call(q, k, v, attn_mask, dropout_p, is_causal)

--- a/torchtune/models/gemma2/_attention_mask.py
+++ b/torchtune/models/gemma2/_attention_mask.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+
+from torchtune.modules.attention_utils import _MaskType
+
+
+def get_sliding_attention_mask(
+    mask: Optional[_MaskType],
+    sliding_window_size: int,
+    bsz: int,
+    seq_len: int,
+    device: Optional[torch.device] = None,
+) -> _MaskType:
+    """
+    Args:
+        mask (Optional[_MaskType]): Mask to apply to the attention scores.
+        sliding_window_size (int): Sliding window size to apply to the attention mask.
+        bsz (int): Batch size. Argument is unused, but listed for consistency.
+        seq_len (int): Sequence length.
+        device (Optional[torch.device]): Device to use for the mask. Defaults to None.
+
+    Returns:
+        A tensor mask that applies sliding window masking.
+
+    Raises:
+        ValueError: If the input mask is not a Tensor
+    """
+
+    if mask is None:
+        mask = torch.tril(
+            torch.ones(size=(bsz, seq_len, seq_len), dtype=torch.bool).to(device)
+        )
+
+    if not isinstance(mask, torch.Tensor):
+        raise ValueError(
+            f"For non-flex attention, mask must be a Tensor. Got: {type(mask)}"
+        )
+
+    all_ones = torch.ones_like(mask, dtype=torch.bool)
+    sliding_mask = torch.triu(all_ones, -1 * sliding_window_size + 1) & torch.tril(
+        all_ones, sliding_window_size - 1
+    )
+    mask = mask & sliding_mask
+
+    return mask

--- a/torchtune/models/llama4/_chunked_attention.py
+++ b/torchtune/models/llama4/_chunked_attention.py
@@ -22,6 +22,8 @@ def get_chunked_attention_mask(
     chunk_size: int,
     bsz: int,
     seq_len: int,
+    # Unused, but listed for consistency
+    device: Optional[torch.device] = None,
 ) -> _MaskType:
     """ """
     # TODO: check this somewhere that doesn't get called every forward

--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -128,7 +128,7 @@ class TransformerSelfAttentionLayer(nn.Module):
         if self.mask_mod is not None:
             # With TP we need to use a replicated tensor here
             bsz, seq_len, *_ = h.shape
-            mask = self.mask_mod(mask=mask, bsz=bsz, seq_len=seq_len)
+            mask = self.mask_mod(mask=mask, bsz=bsz, seq_len=seq_len, device=h.device)
         attn_out = self.attn(h, h, mask=mask, input_pos=input_pos)
         # Residual connection; shape: [batch_size, seq_length, embed_dim]
         h = self.sa_scale(attn_out) + x


### PR DESCRIPTION
**Gemma2 currently uses a custom attention (`Gemma2Attention`) instead of the `MultiHeadAttention` that most models in torchtune use. This is the first of a few PR’s towards making this transition.** 

What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)



Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Utilize `nn.sdpa` via `MultiHeadAttention` instead of the custom Gemma2Attention.
  * The mask utilized by Gemma2Attention is replaced by `get_sliding_attention_mask` as a mask_mod to `TransformerSelfAttentionLayer`.
  * ⚠️ Note: `nn.sdpa` doesn’t support softcapping (which is a feature of Gemma2). It is reintroduced with FlexAttention support
* Adds `scale` as an optional arg to the Callable generated from `_sdpa_or_flex_attention`. This arg is directly exposing the same arg from underlying attention implementation (flex, nn.sdpa)

**🚧  This PR does not enable utilizing FlashAttention.** 
Note: The existing Gemma2Attention implementation will **not** be deleted until FlexAttention is supported (different PR) and can trivially be swapped back when desired.


#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [x] I have added an example to docs or docstrings
