### PR TITLE
Fix bug in Gemma2 HuggingFace weight mapping

### DIFF
--- a/torchtune/models/gemma2/_convert_weights.py
+++ b/torchtune/models/gemma2/_convert_weights.py
@@ -28,8 +28,8 @@ _GEMMA2_FROM_HF = {
     "model.layers.{}.mlp.down_proj.weight": "layers.{}.mlp.w2.weight",
     "model.layers.{}.input_layernorm.weight": "layers.{}.sa_norm.scale",
     "model.layers.{}.post_attention_layernorm.weight": "layers.{}.sa_scale.scale",
-    "model.layers.{}.post_feedforward_layernorm.weight": "layers.{}.mlp_norm.scale",
-    "model.layers.{}.pre_feedforward_layernorm.weight": "layers.{}.mlp_scale.scale",
+    "model.layers.{}.pre_feedforward_layernorm.weight": "layers.{}.mlp_norm.scale",
+    "model.layers.{}.post_feedforward_layernorm.weight": "layers.{}.mlp_scale.scale",
     "model.norm.weight": "norm.rms_norm.scale",
     "lm_head.weight": "output.weight",
 }


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

Fixes #2850

#### Changelog
What are the changes made in this PR?
* Fix bug in Gemma2 HF weight mapping (pre/post MLP weights are the wrong way round).

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

See the linked issue for full details (description and config for reproduction)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
