### PR TITLE
Save last epoch only

### DIFF
--- a/recipes/configs/llama2/7B_lora_single_device.yaml
+++ b/recipes/configs/llama2/7B_lora_single_device.yaml
@@ -46,6 +46,7 @@ checkpointer:
   model_type: LLAMA2
 resume_from_checkpoint: False
 save_adapter_weights_only: False
+save_last_epoch_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3/8B_lora_single_device.yaml
+++ b/recipes/configs/llama3/8B_lora_single_device.yaml
@@ -48,6 +48,7 @@ checkpointer:
   model_type: LLAMA3
 resume_from_checkpoint: False
 save_adapter_weights_only: False
+save_last_epoch_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_1/8B_lora_single_device.yaml
+++ b/recipes/configs/llama3_1/8B_lora_single_device.yaml
@@ -48,6 +48,7 @@ checkpointer:
   model_type: LLAMA3
 resume_from_checkpoint: False
 save_adapter_weights_only: False
+save_last_epoch_only: False
 
 # Dataset and Sampler
 dataset:

--- a/recipes/configs/llama3_2/1B_lora_single_device.yaml
+++ b/recipes/configs/llama3_2/1B_lora_single_device.yaml
@@ -44,6 +44,7 @@ checkpointer:
 resume_from_checkpoint: False
 save_adapter_weights_only: False
 save_last_epoch_only: False
+
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset

--- a/recipes/configs/llama3_2/1B_lora_single_device.yaml
+++ b/recipes/configs/llama3_2/1B_lora_single_device.yaml
@@ -43,7 +43,7 @@ checkpointer:
   model_type: LLAMA3_2
 resume_from_checkpoint: False
 save_adapter_weights_only: False
-
+save_last_epoch_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset

--- a/recipes/configs/llama3_2/3B_lora_single_device.yaml
+++ b/recipes/configs/llama3_2/3B_lora_single_device.yaml
@@ -46,6 +46,7 @@ checkpointer:
 resume_from_checkpoint: False
 save_adapter_weights_only: False
 save_last_epoch_only: False
+
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset

--- a/recipes/configs/llama3_2/3B_lora_single_device.yaml
+++ b/recipes/configs/llama3_2/3B_lora_single_device.yaml
@@ -45,7 +45,7 @@ checkpointer:
   model_type: LLAMA3_2
 resume_from_checkpoint: False
 save_adapter_weights_only: False
-
+save_last_epoch_only: False
 # Dataset and Sampler
 dataset:
   _component_: torchtune.datasets.alpaca_cleaned_dataset

--- a/recipes/configs/llama3_2_vision/11B_lora_single_device.yaml
+++ b/recipes/configs/llama3_2_vision/11B_lora_single_device.yaml
@@ -48,6 +48,7 @@ checkpointer:
   model_type: LLAMA3_VISION
 resume_from_checkpoint: False
 save_adapter_weights_only: False # PeFT formatting not available yet. This will save it in torchtune format only.
+save_last_epoch_only: False
 
 # Dataset
 dataset:

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -691,7 +691,10 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                 self.epochs_run += 1
 
                 # If self._save_last_epoch_only is true, only save checkpoint on the final epoch to save disk space
-                if not self._save_last_epoch_only or curr_epoch == self.total_epochs - 1:
+                if (
+                    not self._save_last_epoch_only
+                    or curr_epoch == self.total_epochs - 1
+                ):
                     start_save_checkpoint = time.perf_counter()
                     self._logger.info("Starting checkpoint save...")
                     self.save_checkpoint(epoch=curr_epoch)
@@ -702,7 +705,8 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     )
                 else:
                     self._logger.info(
-                        f"Skipping checkpoint save for epoch {curr_epoch + 1}..")
+                        f"Skipping checkpoint save for epoch {curr_epoch + 1}.."
+                    )
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/recipes/lora_finetune_single_device.py
+++ b/recipes/lora_finetune_single_device.py
@@ -695,13 +695,13 @@ class LoRAFinetuneRecipeSingleDevice(FTRecipeInterface):
                     start_save_checkpoint = time.perf_counter()
                     self._logger.info("Starting checkpoint save...")
                     self.save_checkpoint(epoch=curr_epoch)
-                    log.info(
+                    self._logger.info(
                         "Checkpoint saved in {:.2f} seconds.".format(
                             time.perf_counter() - start_save_checkpoint
                         )
                     )
                 else:
-                    log.info(
+                    self._logger.info(
                         f"Skipping checkpoint save for epoch {curr_epoch + 1}..")
 
     def cleanup(self) -> None:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

This PR adds the ```save_last_epoch_only``` configuration parameter to LoRA fine-tuning recipes, which allows users to save only the final epoch checkpoint instead of all intermediate checkpoints. This feature helps reduce storage usage during training while still preserving the final trained model.

#### Changelog
What are the changes made in this PR?

**Feature Implementation:**
* Added ```save_last_epoch_only``` configuration parameter to LoRA fine-tuning recipes
* Implemented checkpointing logic to skip intermediate epochs when enabled
* Feature works with both regular and async checkpointing modes

**Test Coverage:**
* Added ```test_save_last_epoch_only``` integration test for regular checkpointing mode
* Added ```test_save_last_epoch_only_with_async_checkpointing``` integration test for async checkpointing mode
* Tests verify correct epoch folder creation behavior when feature is enabled/disabled

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
