### PR TITLE
[FIX]Fix circular import in torchtune.data._messages

### DIFF
--- a/tests/torchtune/data/test_messages.py
+++ b/tests/torchtune/data/test_messages.py
@@ -579,7 +579,7 @@ class TestShareGPTToMessages:
                 column_map={"bananas": "maybe_conversations"},
             )
 
-    @mock.patch("torchtune.data._messages.load_image")
+    @mock.patch("torchtune.data._utils.load_image")
     def test_image_only_in_first_user_message(self, mock_load_image):
         mock_load_image.return_value = Image.new(mode="RGB", size=(4, 4))
         sample = {
@@ -675,7 +675,7 @@ class TestOpenAIToMessages:
             converted_messages["messages"], MESSAGE_SAMPLE_TRAIN_ON_INPUT
         )
 
-    @mock.patch("torchtune.data._messages.load_image")
+    @mock.patch("torchtune.data._utils.load_image")
     @pytest.mark.parametrize(
         "masking_strategy, is_multimodal, expected_message",
         [
@@ -745,7 +745,7 @@ class TestOpenAIToMessages:
                 column_map={"bananas": "maybe_messages"},
             )
 
-    @mock.patch("torchtune.data._messages.load_image")
+    @mock.patch("torchtune.data._utils.load_image")
     def test_convert_from_openai_content(self, mock_load_image):
         test_img = Image.new(mode="RGB", size=(4, 4))
         mock_load_image.return_value = test_img
@@ -759,7 +759,7 @@ class TestOpenAIToMessages:
         ]
         mock_load_image.assert_called_once_with("https://example.com")
 
-    @mock.patch("torchtune.data._messages.load_image")
+    @mock.patch("torchtune.data._utils.load_image")
     def test_call_image_messages(self, mock_load_image):
         test_img = Image.new(mode="RGB", size=(4, 4))
         mock_load_image.return_value = test_img

--- a/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
+++ b/tests/torchtune/datasets/multimodal/test_llava_instruct_dataset.py
@@ -28,7 +28,7 @@ class TestLLaVAInstructDataset:
         return PIL.Image.new(mode="RGB", size=(4, 4))
 
     @patch("torchtune.datasets._sft.load_dataset")
-    @patch("torchtune.data._messages.load_image")
+    @patch("torchtune.data._utils.load_image")
     def test_get_item(self, load_image, load_dataset, tokenizer, test_image_pil):
         """
         WARNING: careful with these mocks, they are applied in bottom up order

--- a/torchtune/data/_messages.py
+++ b/torchtune/data/_messages.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from typing import Any, Literal, Mapping, Optional, Union
 from warnings import warn
 
-from torchtune.data._utils import format_content_with_images, load_image
-
 from torchtune.modules.transforms import Transform
 
 Role = Literal[
@@ -243,6 +241,8 @@ class InputOutputToMessages(Transform):
         self.image_dir = image_dir
 
     def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
+        from torchtune.data._utils import load_image
+
         is_multimodal = "image" in sample or (
             "image" in self._column_map and self._column_map["image"] in sample
         )
@@ -519,6 +519,8 @@ class ShareGPTToMessages(Transform):
         Returns:
             list[Message]: A list of messages with "role" and "content" fields.
         """
+        from torchtune.data._utils import format_content_with_images, load_image
+
         role_map = {"system": "system", "human": "user", "gpt": "assistant"}
         messages = []
         if self.new_system_prompt is not None:
@@ -674,6 +676,8 @@ class OpenAIToMessages(Transform):
         self, content: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """Converts a list of content dicts from the OpenAI format to the torchtune format."""
+        from torchtune.data._utils import load_image
+
         converted_content = []
         for content_dict in content:
             if content_dict["type"] == "text":


### PR DESCRIPTION
#### What does this PR do?
Fix circular import in torchtune.data._messages by deferring or refactoring utility imports. 
When I run `tune download Qwen/Qwen3-0.6B --output-dir /home/lichenguang25/tune/Qwen3-0.6B`, the following error occurs:
```bash
03:16:51 ⬢ [Docker] ➜ tune download Qwen/Qwen3-0.6B --output-dir /home/lichenguang25/tune/Qwen3-0.6B
WARNING:torchao.kernel.intmm:Warning: Detected no triton, on systems without Triton certain kernels will not work
Traceback (most recent call last):
  File "/home/lichenguang25/miniconda3/envs/torchtune/bin/tune", line 5, in <module>
    from torchtune._cli.tune import main
  File "/home/lichenguang25/github/torchtune/torchtune/__init__.py", line 54, in <module>
    from torchtune import datasets, generation, models, modules, utils
  File "/home/lichenguang25/github/torchtune/torchtune/datasets/__init__.py", line 7, in <module>
    from torchtune.datasets import multimodal
  File "/home/lichenguang25/github/torchtune/torchtune/datasets/multimodal/__init__.py", line 7, in <module>
    from ._llava_instruct import llava_instruct_dataset
  File "/home/lichenguang25/github/torchtune/torchtune/datasets/multimodal/_llava_instruct.py", line 10, in <module>
    from torchtune.data._messages import ShareGPTToMessages
  File "/home/lichenguang25/github/torchtune/torchtune/data/__init__.py", line 16, in <module>
    from torchtune.data._messages import (
  File "/home/lichenguang25/github/torchtune/torchtune/data/_messages.py", line 12, in <module>
    from torchtune.data._utils import format_content_with_images, load_image
  File "/home/lichenguang25/github/torchtune/torchtune/data/_utils.py", line 13, in <module>
    from datasets import load_dataset
  File "/home/lichenguang25/github/torchtune/torchtune/datasets/__init__.py", line 8, in <module>
    from torchtune.datasets._alpaca import alpaca_cleaned_dataset, alpaca_dataset
  File "/home/lichenguang25/github/torchtune/torchtune/datasets/_alpaca.py", line 11, in <module>
    from torchtune.data._messages import AlpacaToMessages
ImportError: cannot import name 'AlpacaToMessages' from partially initialized module 'torchtune.data._messages' (most likely due to a circular import) (/home/lichenguang25/github/torchtune/torchtune/data/_messages.py)
```

After applying my fix, the issue was resolved successfully:
```bash
03:21:02 ⬢ [Docker] ➜ tune download Qwen/Qwen3-0.6B --output-dir /home/lichenguang25/tune/Qwen3-0.6B
WARNING:torchao.kernel.intmm:Warning: Detected no triton, on systems without Triton certain kernels will not work
Ignoring files matching the following patterns: None
.gitattributes: 1.57kB [00:00, 7.50MB/s]
README.md: 14.0kB [00:00, 41.2MB/s]
config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 726/726 [00:00<00:00, 5.61MB/s]
generation_config.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 239/239 [00:00<00:00, 1.95MB/s]
merges.txt: 1.67MB [00:00, 14.6MB/s]
model.safetensors: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.50G/1.50G [00:40<00:00, 37.2MB/s]
tokenizer.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11.4M/11.4M [00:01<00:00, 6.27MB/s]
tokenizer_config.json: 9.73kB [00:00, 36.4MB/s]
vocab.json: 2.78MB [00:00, 69.2MB/s]
Successfully downloaded model repo and wrote to the following locations:
/home/lichenguang25/tune/Qwen3-0.6B/vocab.json
/home/lichenguang25/tune/Qwen3-0.6B/.gitattributes
/home/lichenguang25/tune/Qwen3-0.6B/config.json
/home/lichenguang25/tune/Qwen3-0.6B/original_repo_id.json
/home/lichenguang25/tune/Qwen3-0.6B/.cache
/home/lichenguang25/tune/Qwen3-0.6B/generation_config.json
/home/lichenguang25/tune/Qwen3-0.6B/merges.txt
/home/lichenguang25/tune/Qwen3-0.6B/tokenizer_config.json
/home/lichenguang25/tune/Qwen3-0.6B/model.safetensors
/home/lichenguang25/tune/Qwen3-0.6B/README.md
/home/lichenguang25/tune/Qwen3-0.6B/tokenizer.json
```

#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
What are the changes made in this PR?
* Fixed a circular import between `_messages.py` and `_alpaca.py`
* Deferred the import of `format_content_with_images` and `load_image` to avoid top-level import issues
* Verified that `tune download` command works correctly with Qwen models

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
