### PR TITLE
Set expandable_segments explicitly via cuda memory API

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,20 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import sys
-import warnings
-
-# Avoid memory fragmentation and peak reserved memory increasing over time
-# To overwrite, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
-if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
-    if "torch" in sys.modules:
-        warnings.warn(
-            "The 'torch' module has already been imported. "
-            "Setting PYTORCH_CUDA_ALLOC_CONF may not have an effect."
-            "For best results, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True before importing 'torch'."
-        )
-    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 # Check at the top-level that torchao is installed.
 # This is better than doing it at every import site.

--- a/torchtune/__init__.py
+++ b/torchtune/__init__.py
@@ -8,19 +8,19 @@ __version__ = ""
 
 
 import os
-import sys
 import warnings
 
-# Avoid memory fragmentation and peak reserved memory increasing over time
-# To overwrite, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
-if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
-    if "torch" in sys.modules:
-        warnings.warn(
-            "The 'torch' module has already been imported. "
-            "Setting PYTORCH_CUDA_ALLOC_CONF may not have an effect."
-            "For best results, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True before importing 'torch'."
-        )
-    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+if torch.cuda.is_available():
+    ca_config = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", None)
+
+    if ca_config is None or "expandable_segments:False" not in ca_config:
+        try:
+            # Avoid memory fragmentation and peak reserved memory increasing over time.
+            torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+        except RuntimeError:
+            warnings.warn("Setting expandable_segments:True for CUDA allocator failed.")
 
 
 # Check at the top-level that torchao is installed.


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* This PR modifies the way torchtune by default sets `expandable_segments` to `True` for the CUDA allocator, making it more robust to the order in which torch and torchtune are imported.
* I've added an explicit check to allow the user to deactivate this option if they desire, i.e. by adding `expandable_segments:False` to the `PYTORCH_CUDA_ALLOC_CONF` environment variable. 
* This setting was similarly turned on in `tests/__init__.py` but it's unclear to me if this is necessary anymore. I can re-add this if tests are failing due to memory issues.

Note that if torchtune adds e.g. weight syncing via CUDA IPC it will be necessary to add a decorator that turns this off and on again since [IPC for expandable segment tensors is not yet implemented in torch IIUC](https://github.com/pytorch/pytorch/issues/130330).


#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
