### PR TITLE
[compile] workaround for compile error FakeTensor no op for builtin.-

### DIFF
--- a/torchtune/models/llama4/_position_embeddings.py
+++ b/torchtune/models/llama4/_position_embeddings.py
@@ -179,10 +179,14 @@ class Llama4ScaledRoPE(nn.Module):
         # tensor has shape [b, s, n_h, h_d // 2, 2]
         x_out = torch.stack(
             [
-                xshaped[..., 0] * rope_cache[..., 0]
-                - xshaped[..., 1] * rope_cache[..., 1],
-                xshaped[..., 1] * rope_cache[..., 0]
-                + xshaped[..., 0] * rope_cache[..., 1],
+                torch.sub(
+                    xshaped[..., 0] * rope_cache[..., 0],
+                    xshaped[..., 1] * rope_cache[..., 1],
+                ),
+                torch.add(
+                    xshaped[..., 1] * rope_cache[..., 0],
+                    xshaped[..., 0] * rope_cache[..., 1],
+                ),
             ],
             -1,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2891

Workaround for torch.compile to pass through:


```
Dynamo failed to run FX node with fake tensors: call_function <built-in function sub>(*(FakeTensor(..., device='cuda:0', size=(1, s27, s53, (s0//2)),
           grad_fn=<MulBackward0>), FakeTensor(..., device='cuda:0', size=(1, s27, s53, (s0//2)),
           grad_fn=<MulBackward0>)), **{}): got TypeError("unsupported operand type(s) for -: 'FakeTensor' and 'FakeTensor'")
from user code:
   File "/packages/content_understanding_projects_torchtune/main-inplace#link-tree/torchtune/models/llama4/_position_embeddings.py", line 182, in forward
    xshaped[..., 0] * rope_cache[..., 0]
```

