### PR TITLE
fix: Epoch checkpointing index off by 1

### DIFF
--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -915,8 +915,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         return log_dict
 
     def save_checkpoint(self, *, epoch: int, full_tensors: bool):
+        training_progress_epoch = epoch
         if self.global_step % self._steps_per_epoch == 0:
-            epoch += 1
+            training_progress_epoch += 1
 
         self._checkpoint_client.save_checkpoint(
             model=self._model,

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -928,7 +928,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             ),
             training_progress=TrainingProgress(
                 seed=self.seed,
-                epochs_run=epoch,
+                epochs_run=training_progress_epoch,
                 total_epochs=self.total_epochs,
                 max_steps_per_epoch=self.max_steps_per_epoch,
                 steps_run=self.global_step,

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -526,14 +526,16 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         correctly creating the checkpoint dict and passing to the checkpointer.
         """
         # Since we might save at an epoch boundary, we need to increment the epoch counter
+        training_progress_epoch = epoch
         if step % self._steps_per_epoch == 0:
-            epoch += 1
+            training_progress_epoch += 1
+
         self._checkpoint_client.save_checkpoint(
             model=self._model,
             optimizer=self.optimizer,
             training_progress=TrainingProgress(
                 seed=self.seed,
-                epochs_run=epoch,
+                epochs_run=training_progress_epoch,
                 total_epochs=self.total_epochs,
                 max_steps_per_epoch=self.max_steps_per_epoch,
                 dataloader_state_dict=self._dataloader.state_dict(),

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -397,7 +397,7 @@ class TestFullFinetuneDistributedRecipe:
 
         resumed_log_dir = (tmpdir / "resumed/").mkdir()
         resumed_log_file = gen_log_file_name(resumed_log_dir)
-        shutil.rmtree((tmpdir / "epoch_2"))
+        shutil.rmtree((tmpdir / "epoch_1"))
 
         # Resume training
         cmd_2 = f"""
@@ -504,7 +504,7 @@ class TestFullFinetuneDistributedRecipe:
 
         resumed_log_dir = (tmpdir / "resumed/").mkdir()
         resumed_log_file = gen_log_file_name(resumed_log_dir)
-        shutil.rmtree((tmpdir / "epoch_2"))
+        shutil.rmtree((tmpdir / "epoch_1"))
 
         # Resume training
         cmd_2 = f"""

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -204,8 +204,8 @@ class TestFullFinetuneSingleDeviceRecipe:
             final_ckpt_dir = "step_4"
             prev_ckpt_dir = "step_2"
         else:
-            final_ckpt_dir = "epoch_2"
-            prev_ckpt_dir = "epoch_1"
+            final_ckpt_dir = "epoch_1"
+            prev_ckpt_dir = "epoch_0"
         cmd_1 = cmd_1 + self._get_test_config_overrides() + model_config
 
         monkeypatch.setattr(sys, "argv", cmd_1)


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug - closes #2910 
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
What are the changes made in this PR?
* Separate epoch vars for training_progress and checkpoint indexing

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [x] run unit tests via `pytest tests`
- [x] run recipe tests via `pytest tests -m integration_test`
- [x] manually run any new or modified recipes with sufficient proof of correctness
- [x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
