### PR TITLE
Fix distributed GRPO Recipe

### DIFF
--- a/torchtune/dev/rl/rewards.py
+++ b/torchtune/dev/rl/rewards.py
@@ -298,8 +298,8 @@ def batched_rewards(
     for b in range(batch_size):
 
         for g in range(grpo_size):
-
-            answer = answers[b][g]
+            # print(answers)
+            answer = answers[b]
 
             text_completion = tokenizer.decode(completions[b, g].tolist())
 

--- a/torchtune/dev/rl/types.py
+++ b/torchtune/dev/rl/types.py
@@ -19,6 +19,8 @@ class GRPOTrajectory(NamedTuple):
         logprobs (torch.Tensor): Log probabilities of the generated responses with shape [B x G, L].
         ref_logprobs (torch.Tensor): Log probabilities of the generated responses using the reference policy with shape [B x G, L].
         advantages (torch.Tensor): Advantage estimates for the generated responses with shape [B x G].
+        rewards (torch.Tensor): Reward values for the generated responses with shape [B x G].
+        successes (torch.Tensor): Success indicators for the generated responses with shape [B x G].
         masks (torch.Tensor): Attention masks for input ids-generated responses pairs with shape [B x G, P+L, P+L].
         position_ids (torch.Tensor): Position IDs for input ids-generated responses pairs with shape [B x G, P+L].
         response_padding_masks (torch.Tensor): Padding masks for the truncated and padded generated responses with shape [B x G, L].
@@ -30,6 +32,8 @@ class GRPOTrajectory(NamedTuple):
     logprobs: torch.Tensor = None  # [B x G, L]
     ref_logprobs: torch.Tensor = None  # [B x G, L]
     advantages: torch.Tensor = None  # [B x G]
+    rewards: torch.Tensor = None
+    successes: torch.Tensor = None
     masks: torch.Tensor = None  # [B x G, P+L, P+L]
     position_ids: torch.Tensor = None  # [B x G, P+L]
     response_padding_masks: torch.Tensor = None  # [B x G, L]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [X] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?

1. **Fix trajectory concatenation**: Update generate_trajectory_batched to properly handle the 'answers' field which is a list of strings, not a tensor.

2. **Update reward function signature**: Modify batched_rewards call to include device parameter and handle multiple reward functions properly.

3. **Add missing fields to GRPOTrajectory**: Add rewards and successes fields to the GRPOTrajectory NamedTuple and update docstring.

4. **Fix GRPOStats concatenation**: Update the concatenation logic in the training loop to properly handle the metadata field.

5. **Fix reward indexing**: Correct the answer indexing in batched_rewards function from answers[b][g] to answers[b].

These changes ensure that distributed GRPO training works correctly with proper trajectory handling and reward computation.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [X] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [X] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [X] I did not change any public API
- [ ] I have added an example to docs or docstrings

Key contributor: @hnbnguyen