### PR TITLE
llama4 video support

### DIFF
--- a/torchtune/models/llama4/_model_builders.py
+++ b/torchtune/models/llama4/_model_builders.py
@@ -84,12 +84,14 @@ def llama4_scout_17b_16e(
     )
     return EarlyFusionModel(
         decoder,
-        encoders={"vision": vision_encoder},
+        encoders={"vision": vision_encoder, "video": vision_encoder},
         encoder_tokens={
             "vision": LLAMA4_SPECIAL_TOKENS["<|patch|>"],
+            "video": LLAMA4_SPECIAL_TOKENS["<|video|>"],
         },
         encoders_trainable={
             "vision": encoder_trainable,
+            "video": encoder_trainable,
         },
         decoder_trainable=decoder_trainable,
         fusion_trainable=fusion_trainable,
@@ -154,12 +156,14 @@ def llama4_maverick_17b_128e(
     )
     return EarlyFusionModel(
         decoder,
-        encoders={"vision": vision_encoder},
+        encoders={"vision": vision_encoder, "video": vision_encoder},
         encoder_tokens={
             "vision": LLAMA4_SPECIAL_TOKENS["<|patch|>"],
+            "video": LLAMA4_SPECIAL_TOKENS["<|video|>"],
         },
         encoders_trainable={
             "vision": encoder_trainable,
+            "video": encoder_trainable,
         },
         decoder_trainable=decoder_trainable,
         fusion_trainable=fusion_trainable,
@@ -314,12 +318,14 @@ def lora_llama4_scout_17b_16e(
     )
     return EarlyFusionModel(
         decoder,
-        encoders={"vision": vision_encoder},
+        encoders={"vision": vision_encoder, "video": vision_encoder},
         encoder_tokens={
             "vision": LLAMA4_SPECIAL_TOKENS["<|patch|>"],
+            "video": LLAMA4_SPECIAL_TOKENS["<|video|>"],
         },
         encoders_trainable={
             "vision": encoder_trainable != TrainableParams.FROZEN,
+            "video": encoder_trainable != TrainableParams.FROZEN,
         },
         decoder_trainable=decoder_trainable != TrainableParams.FROZEN,
         fusion_trainable=fusion_trainable != TrainableParams.FROZEN,


### PR DESCRIPTION
Summary:
Adds video processing support to the Llama4 model by extending the existing vision encoder infrastructure to handle video content. It introduces video-specific special tokens (<|video|>, <|vid_start|>, <|vid_end|>, <|vid_frame_separator|>) in the tokenizer, implements a new transform_video() method that processes video clips as sequences of frames through the existing image transform pipeline, and registers a "video" encoder in the EarlyFusionModel that reuses the vision encoder while maintaining separate tokenization paths for images and videos.

(Used HF implementation as a reference to ensure consistent changes in _tokenizer.py)

Differential Revision: D89577119


