### PR TITLE
Revert "Migrate internal uses of Int8DynamicActivationInt4WeightConfig to Int8DynamicActivationIntxWeightConfig"

### DIFF
--- a/docs/source/tutorials/qat_finetune.rst
+++ b/docs/source/tutorials/qat_finetune.rst
@@ -148,9 +148,9 @@ After fine-tuning, we can convert the model to get an actual quantized model:
       FromIntXQuantizationAwareTrainingConfig,
   )
   from torchao.quantization import (
-      Int8DynamicActivationIntxWeightConfig,
+      Int8DynamicActivationInt4WeightConfig,
   )
-  from torchao.quantization.granularity import PerGroup
+
   # Fine-tune as before
   train_loop(prepared_model)
 
@@ -161,7 +161,7 @@ After fine-tuning, we can convert the model to get an actual quantized model:
   # post-training quantization (PTQ), which inserts quantized activation
   # and weight tensor subclasses
   quantize_(prepared_model, FromIntXQuantizationAwareTrainingConfig())
-  quantize_(prepared_model, Int8DynamicActivationIntxWeightConfig(weight_dtype=torch.int4, weight_granularity=PerGroup(32)))
+  quantize_(prepared_model, Int8DynamicActivationInt4WeightConfig(group_size=32))
 
   converted_model = prepared_model
 

--- a/torchtune/training/quantization.py
+++ b/torchtune/training/quantization.py
@@ -20,14 +20,14 @@ from torchao.float8.float8_tensor_parallel import (
 )
 from torchao.quantization import (
     Int4WeightOnlyConfig,
-    Int8DynamicActivationIntxWeightConfig,
+    Int8DynamicActivationInt4WeightConfig,
     quantize_,
 )
 from torchao.quantization.qat import (
     Int4WeightOnlyQATQuantizer,
     Int8DynActInt4WeightQATQuantizer,
 )
-from torchao.quantization.granularity import PerGroup
+
 
 from torchtune.modules.peft.lora import LoRALinear, QATLoRALinear
 
@@ -86,7 +86,7 @@ class Int8DynActInt4WeightQuantizer:
         self.groupsize = groupsize
 
     def quantize(self, model):
-        quantize_fn = Int8DynamicActivationIntxWeightConfig(weight_dtype=torch.int4, weight_granularity=PerGroup(self.groupsize))
+        quantize_fn = Int8DynamicActivationInt4WeightConfig(self.groupsize)
         quantize_(model, quantize_fn)
         return model
 


### PR DESCRIPTION
Reverts meta-pytorch/torchtune#2951

Needs to be landed via phab, not OSS