### PR TITLE
Pin pyarrow<21.0.0 to fix AttributeError on fresh install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
 
     # Multimodal
     "Pillow>=9.4.0",
+    # Pin pyarrow to avoid breaking change in v21 (see #2890)
+    "pyarrow<21.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Fixes #2890

pyarrow v21 removed `PyExtensionType`, which breaks the `datasets` 
library on fresh installs with this error:

AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'

## Changes
- Pins `pyarrow<21.0.0` in `pyproject.toml` dependencies