### PR TITLE
docs: add custom datasets section in basics

### DIFF
--- a/docs/source/basics/custom_datasets.rst
+++ b/docs/source/basics/custom_datasets.rst
@@ -1,0 +1,71 @@
+.. _custom_dataset_usage_label:
+
+===============
+Custom Datasets
+===============
+
+If your dataset schema does not fit torchtune's built-in dataset builders, you can create
+an end-to-end custom dataset pipeline by combining:
+
+1. A custom message transform (raw sample -> ``messages``)
+2. :class:`~torchtune.datasets.SFTDataset` (messages -> tokenized training samples)
+
+This page shows the full flow in one place.
+
+Create a custom message transform
+---------------------------------
+
+Start by converting your raw sample into torchtune :class:`~torchtune.data.Message` objects.
+
+.. code-block:: python
+
+    from typing import Any, Mapping
+
+    from torchtune.data import Message
+    from torchtune.modules.transforms import Transform
+
+
+    class MyMessageTransform(Transform):
+        def __call__(self, sample: Mapping[str, Any]) -> Mapping[str, Any]:
+            return {
+                "messages": [
+                    Message(role="user", content=sample["input"], masked=True, eot=True),
+                    Message(role="assistant", content=sample["output"], masked=False, eot=True),
+                ]
+            }
+
+
+Create a custom dataset builder with ``SFTDataset``
+---------------------------------------------------
+
+Wrap the transform in a small dataset builder function.
+
+.. code-block:: python
+
+    # data/dataset.py
+    from torchtune.datasets import SFTDataset
+    from data.message_transform import MyMessageTransform
+
+
+    def custom_dataset(tokenizer, **load_dataset_kwargs) -> SFTDataset:
+        return SFTDataset(
+            source="json",
+            data_files="data/my_data.json",
+            split="train",
+            message_transform=MyMessageTransform(),
+            model_transform=tokenizer,
+            **load_dataset_kwargs,
+        )
+
+Use your custom dataset in a config
+-----------------------------------
+
+Point the recipe ``dataset`` component to your builder.
+
+.. code-block:: yaml
+
+    dataset:
+      _component_: data.dataset.custom_dataset
+
+For deeper details on message construction and custom component registration, see
+:ref:`message_transform_usage_label` and :ref:`custom_components_label`.

--- a/docs/source/basics/datasets_overview.rst
+++ b/docs/source/basics/datasets_overview.rst
@@ -13,6 +13,8 @@ The following tasks are supported:
 - Text supervised fine-tuning
     - :ref:`instruct_dataset_usage_label`
     - :ref:`chat_dataset_usage_label`
+- Fully custom datasets
+    - :ref:`custom_dataset_usage_label`
 - Multimodal supervised fine-tuning
     - :ref:`multimodal_dataset_usage_label`
 - RLHF

--- a/docs/source/basics/message_transforms.rst
+++ b/docs/source/basics/message_transforms.rst
@@ -90,6 +90,9 @@ This can be used directly from the config.
     dataset:
       _component_: data.dataset.custom_dataset
 
+For a full end-to-end walkthrough (custom transform + ``SFTDataset`` + config wiring), see
+:ref:`custom_dataset_usage_label`.
+
 
 Example message transforms
 --------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -129,6 +129,7 @@ torchtune tutorials.
    :hidden:
 
    basics/datasets_overview
+   basics/custom_datasets
    basics/chat_datasets
    basics/instruct_datasets
    basics/multimodal_datasets


### PR DESCRIPTION
## Summary
Add a new Basics page for custom datasets, showing an end-to-end pattern for combining a custom message transform with `SFTDataset`.

## Changes
- Added `docs/source/basics/custom_datasets.rst`.
- Added the new page to the Basics toctree in `docs/source/index.rst`.
- Linked to the new section from `docs/source/basics/datasets_overview.rst`.
- Added a cross-link from `docs/source/basics/message_transforms.rst`.

## Why
Issue #2012 asks for a clear "Custom datasets" section in Basics that explains how to build a fully custom dataset pipeline (custom message transform + `SFTDataset`).

## Validation
- Documentation-only change.
- Tried building docs via `python3 -m sphinx -b dummy source _build/dummy`, but `sphinx` is not installed in this environment.

Fixes #2012
