### PR TITLE
Fix import error after torchao NF4Tensor move

### DIFF
--- a/docs/source/tutorials/qlora_finetune.rst
+++ b/docs/source/tutorials/qlora_finetune.rst
@@ -103,7 +103,7 @@ base model parameters are not quantized. We can see this by printing the base mo
 .. code-block:: python
 
   attn = qlora_model.layers[0].attn
-  print(type(attn.q_proj.weight))  # <class 'torchao.dtypes.nf4tensor.NF4Tensor'>
+  print(type(attn.q_proj.weight))  # <class 'torchao.quantization.quantize_.workflows.nf4.nf4_tensor.NF4Tensor'>
   print(type(attn.k_proj.weight))  # <class 'torch.nn.parameter.Parameter'>
 
 
@@ -220,7 +220,8 @@ a vanilla minimal LoRA layer, taken from :ref:`the LoRA tutorial <lora_finetune_
   import torch
   from torch import nn
   import torch.nn.functional as F
-  from torchao.dtypes.nf4tensor import linear_nf4, to_nf4
+  from torchao.quantization import to_nf4
+  from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import linear_nf4
 
   class LoRALinear(nn.Module):
     def __init__(

--- a/tests/torchtune/models/llama2/scripts/compare_dora.py
+++ b/tests/torchtune/models/llama2/scripts/compare_dora.py
@@ -11,7 +11,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torchao.dtypes.nf4tensor import linear_nf4, to_nf4
+from torchao.quantization import to_nf4
+from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import linear_nf4
 from torchtune import training
 from torchtune.modules.peft import DoRALinear, get_merged_lora_ckpt, LoRALinear
 from torchtune.training.seed import set_seed

--- a/tests/torchtune/models/llama2/test_lora_llama2.py
+++ b/tests/torchtune/models/llama2/test_lora_llama2.py
@@ -11,7 +11,7 @@ import torch
 
 from tests.test_utils import assert_expected, fixed_init_model
 from torch import nn
-from torchao.dtypes.nf4tensor import NF4Tensor
+from torchao.quantization import NF4Tensor
 from torchtune import training
 from torchtune.models.llama2 import llama2, lora_llama2
 from torchtune.models.llama2._component_builders import lora_llama2_self_attention

--- a/tests/torchtune/models/phi3/test_lora_phi3.py
+++ b/tests/torchtune/models/phi3/test_lora_phi3.py
@@ -11,7 +11,7 @@ import torch
 
 from tests.test_utils import assert_expected, fixed_init_model
 from torch import nn
-from torchao.dtypes.nf4tensor import NF4Tensor
+from torchao.quantization import NF4Tensor
 from torchtune import training
 from torchtune.models.phi3 import lora_phi3, phi3
 from torchtune.models.phi3._component_builders import lora_phi3_self_attention

--- a/tests/torchtune/modules/low_precision/test_nf4_dispatch_registration.py
+++ b/tests/torchtune/modules/low_precision/test_nf4_dispatch_registration.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torchao.dtypes import to_nf4
+from torchao.quantization import to_nf4
 
 
 class TestNF4DispatchRegistration:

--- a/tests/torchtune/modules/low_precision/test_nf4_linear.py
+++ b/tests/torchtune/modules/low_precision/test_nf4_linear.py
@@ -6,7 +6,7 @@
 
 import pytest
 import torch
-from torchao.dtypes.nf4tensor import NF4Tensor
+from torchao.quantization import NF4Tensor
 from torchtune.modules.low_precision import FrozenNF4Linear
 from torchtune.training.seed import set_seed
 

--- a/tests/torchtune/modules/peft/test_dora.py
+++ b/tests/torchtune/modules/peft/test_dora.py
@@ -17,7 +17,7 @@ from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._tensor import DTensor, Replicate
 
 from torch.testing._internal.common_fsdp import FSDPTest
-from torchao.dtypes.nf4tensor import NF4Tensor, to_nf4
+from torchao.quantization import NF4Tensor, to_nf4
 from torchtune import training
 from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
 from torchtune.modules.feed_forward import FeedForward

--- a/tests/torchtune/modules/peft/test_lora.py
+++ b/tests/torchtune/modules/peft/test_lora.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 from tests.test_utils import fixed_init_model, mps_ignored_test
 from torch import nn
-from torchao.dtypes.nf4tensor import NF4Tensor, to_nf4
+from torchao.quantization import NF4Tensor, to_nf4
 from torchtune import training
 from torchtune.modules.common_utils import reparametrize_as_dtype_state_dict_post_hook
 from torchtune.modules.peft import LoRALinear, QATLoRALinear

--- a/tests/torchtune/training/test_distributed.py
+++ b/tests/torchtune/training/test_distributed.py
@@ -21,7 +21,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 )
 
 from torch.testing._internal.common_fsdp import FSDPTest, MLP
-from torchao.dtypes.nf4tensor import NF4Tensor
+from torchao.quantization import NF4Tensor
 from torchtune import modules, training
 from torchtune.models.llama2._component_builders import lora_llama2
 from torchtune.models.llama3_1._component_builders import llama3_mlp

--- a/torchtune/modules/common_utils.py
+++ b/torchtune/modules/common_utils.py
@@ -16,7 +16,7 @@ import torch
 
 import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorConverter, FakeTensorMode
-from torchao.dtypes.nf4tensor import NF4Tensor
+from torchao.quantization import NF4Tensor
 
 _use_low_cpu_ram: bool = False
 

--- a/torchtune/modules/low_precision/_register_nf4_dispatch_ops.py
+++ b/torchtune/modules/low_precision/_register_nf4_dispatch_ops.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torchao.dtypes.nf4tensor import implements as nf4_tensor_impl, to_nf4
+from torchao.quantization import to_nf4
+from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import implements as nf4_tensor_impl
 
 
 @nf4_tensor_impl([torch.ops.aten.clone.default])

--- a/torchtune/modules/low_precision/nf4_linear.py
+++ b/torchtune/modules/low_precision/nf4_linear.py
@@ -9,7 +9,8 @@ from typing import Optional
 import torch
 
 import torch.nn as nn
-from torchao.dtypes.nf4tensor import linear_nf4, to_nf4
+from torchao.quantization import to_nf4
+from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import linear_nf4
 
 
 class FrozenNF4Linear(nn.Linear):

--- a/torchtune/modules/peft/dora.py
+++ b/torchtune/modules/peft/dora.py
@@ -12,7 +12,8 @@ import torch.nn.functional as F
 
 from torch import nn
 
-from torchao.dtypes.nf4tensor import linear_nf4, to_nf4
+from torchao.quantization import to_nf4
+from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import linear_nf4
 from torchtune.modules.low_precision import _register_nf4_dispatch_ops  # noqa: F401
 from torchtune.modules.peft import AdapterModule
 

--- a/torchtune/modules/peft/lora.py
+++ b/torchtune/modules/peft/lora.py
@@ -12,7 +12,8 @@ import torch.nn.functional as F
 
 from torch import nn
 
-from torchao.dtypes.nf4tensor import linear_nf4, to_nf4
+from torchao.quantization import to_nf4
+from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import linear_nf4
 from torchtune.modules.low_precision import _register_nf4_dispatch_ops  # noqa: F401
 from torchtune.modules.peft import AdapterModule
 

--- a/torchtune/training/_activation_offloading.py
+++ b/torchtune/training/_activation_offloading.py
@@ -13,7 +13,7 @@ import torch
 import torchao
 from torch import nn
 from torch.autograd.graph import saved_tensors_hooks
-from torchao.dtypes.nf4tensor import NF4Tensor
+from torchao.quantization import NF4Tensor
 
 from torchtune.modules import TiedLinear
 from torchtune.utils import get_logger

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -36,7 +36,7 @@ from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.attention.flex_attention import BlockMask
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.optim import Optimizer
-from torchao.dtypes.nf4tensor import NF4Tensor, to_nf4
+from torchao.quantization import NF4Tensor, to_nf4
 from torchtune.modules import TransformerDecoder
 from torchtune.modules.attention import MultiHeadAttention
 from torchtune.modules.model_fusion import DeepFusionModel, EarlyFusionModel


### PR DESCRIPTION
**Summary:**  https://github.com/pytorch/ao/pull/4256 recently moved `NF4Tensor` to a new location in torchao. This commit just updates references to match this move accordingly.

**Test Plan:** CI