### PR TITLE
Add TrackioLogger metric backend

### DIFF
--- a/docs/source/api_ref_training.rst
+++ b/docs/source/api_ref_training.rst
@@ -99,6 +99,7 @@ Various logging utilities.
 
     metric_logging.CometLogger
     metric_logging.WandBLogger
+    metric_logging.TrackioLogger
     metric_logging.TensorBoardLogger
     metric_logging.StdoutLogger
     metric_logging.DiskLogger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "pytest-mock",
     "pytest-integration",
     "tensorboard",
+    "trackio",
     # Pin urllib3 to avoid transient error from https://github.com/psf/requests/issues/6443
     "urllib3<2.0.0",
     "wandb",

--- a/tests/torchtune/training/test_metric_logging.py
+++ b/tests/torchtune/training/test_metric_logging.py
@@ -26,6 +26,7 @@ from torchtune.training.metric_logging import (
     MLFlowLogger,
     StdoutLogger,
     TensorBoardLogger,
+    TrackioLogger,
     WandBLogger,
 )
 
@@ -208,6 +209,38 @@ class TestWandBLogger:
             expected_config_path = "torchtune_config.yaml"
             mock_save.assert_called_once_with(cfg, expected_config_path)
             mock_wandb_save.assert_called_once_with(expected_config_path)
+
+
+class TestTrackioLogger:
+    def test_log(self) -> None:
+        with (
+            patch("trackio.init") as mock_init,
+            patch("trackio.log") as mock_log,
+            patch("trackio.finish"),
+        ):
+            mock_init.return_value = object()
+            logger = TrackioLogger(project="test_project")
+            for i in range(5):
+                logger.log("test_log", float(i) ** 2, i)
+            logger.close()
+
+            assert mock_log.call_count == 5
+            for i in range(5):
+                mock_log.assert_any_call({"test_log": float(i) ** 2}, step=i)
+
+    def test_log_dict(self) -> None:
+        with (
+            patch("trackio.init") as mock_init,
+            patch("trackio.log") as mock_log,
+            patch("trackio.finish"),
+        ):
+            mock_init.return_value = object()
+            logger = TrackioLogger(project="test_project")
+            metric_dict = {f"log_dict_{i}": float(i) ** 2 for i in range(5)}
+            logger.log_dict(metric_dict, 1)
+            logger.close()
+
+            mock_log.assert_called_with(metric_dict, step=1)
 
 
 class TestCometLogger:

--- a/torchtune/training/metric_logging.py
+++ b/torchtune/training/metric_logging.py
@@ -350,6 +350,104 @@ class WandBLogger(MetricLoggerInterface):
             self._wandb.finish()
 
 
+class TrackioLogger(MetricLoggerInterface):
+    """Logger for use w/ Trackio (https://github.com/gradio-app/trackio), a lightweight,
+    local-first experiment tracker with a wandb-compatible API.
+
+    Args:
+        project (str): Trackio project name. Default is `torchtune`.
+        name (Optional[str]): Run name. If not specified, Trackio assigns one automatically.
+        group (Optional[str]): Group name for organizing related runs.
+        space_id (Optional[str]): Optional Hugging Face Space id (``"username/space"``)
+            to host the dashboard. If unset, runs are kept locally.
+        log_dir (Optional[str]): Directory used by Trackio for local artifacts.
+        **kwargs: additional arguments forwarded to ``trackio.init``.
+
+    Example:
+        >>> from torchtune.training.metric_logging import TrackioLogger
+        >>> logger = TrackioLogger(project="my_project", name="my_run")
+        >>> logger.log("my_metric", 1.0, 1)
+        >>> logger.log_dict({"my_metric": 1.0}, 1)
+        >>> logger.close()
+
+    Raises:
+        ImportError: If ``trackio`` package is not installed.
+
+    Note:
+        This logger requires the trackio package to be installed.
+        You can install it with `pip install trackio`.
+    """
+
+    def __init__(
+        self,
+        project: str = "torchtune",
+        name: Optional[str] = None,
+        group: Optional[str] = None,
+        space_id: Optional[str] = None,
+        log_dir: Optional[str] = None,
+        **kwargs,
+    ):
+        try:
+            import trackio
+        except ImportError as e:
+            raise ImportError(
+                "``trackio`` package not found. Please install trackio using `pip install trackio` to use TrackioLogger."
+                "Alternatively, use the ``StdoutLogger``, which can be specified by setting metric_logger_type='stdout'."
+            ) from e
+        self._trackio = trackio
+
+        self.log_dir = kwargs.pop("dir", log_dir)
+        if self.log_dir is not None and not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
+
+        _, self.rank = get_world_size_and_rank()
+        self._run = None
+
+        if self.rank == 0:
+            init_kwargs = {"project": project, **kwargs}
+            if name is not None:
+                init_kwargs["name"] = name
+            if group is not None:
+                init_kwargs["group"] = group
+            if space_id is not None:
+                init_kwargs["space_id"] = space_id
+            self._run = self._trackio.init(**init_kwargs)
+
+    def log_config(self, config: DictConfig) -> None:
+        """Saves the config locally and logs the resolved config to Trackio.
+
+        Args:
+            config (DictConfig): config to log
+        """
+        if self._run is not None:
+            resolved = OmegaConf.to_container(config, resolve=True)
+            try:
+                self._trackio.config.update(resolved)
+            except Exception as e:
+                log.warning(f"Error updating Trackio config: {e}")
+            save_config(config)
+
+    def log(self, name: str, data: Scalar, step: int) -> None:
+        if self._run is not None:
+            self._trackio.log({name: data}, step=step)
+
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
+        if self._run is not None:
+            self._trackio.log(dict(payload), step=step)
+
+    def __del__(self) -> None:
+        if getattr(self, "_run", None) is not None:
+            try:
+                self._trackio.finish()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._run is not None:
+            self._trackio.finish()
+            self._run = None
+
+
 class TensorBoardLogger(MetricLoggerInterface):
     """Logger for use w/ PyTorch's implementation of TensorBoard (https://pytorch.org/docs/stable/tensorboard.html).
 


### PR DESCRIPTION
## Summary
Adds a `TrackioLogger` to `torchtune/training/metric_logging.py`, mirroring `WandBLogger`. [Trackio](https://github.com/gradio-app/trackio) is a lightweight, local-first experiment tracker with a wandb-compatible API — local SQLite by default, optional sync to a Hugging Face Space.

Opt in from any recipe config:

\`\`\`yaml
metric_logger:
  _component_: torchtune.training.metric_logging.TrackioLogger
  project: my_project
  # name: my_run                       # optional
  # space_id: username/my-dashboard    # optional, syncs to a HF Space
\`\`\`

## Changes
- New `TrackioLogger` class in `torchtune/training/metric_logging.py` (rank-0 only, same shape as `WandBLogger`)
- Listed in `docs/source/api_ref_training.rst`
- `trackio` added to the `dev` optional-deps in `pyproject.toml`
- Test in `tests/torchtune/training/test_metric_logging.py` mirroring the existing wandb test pattern

## Test plan
- [x] New `TestTrackioLogger` unit tests pass
- [ ] Existing logger tests still pass