### PR TITLE
fix(logging): use RANK env var in log_rank_zero before dist init

### DIFF
--- a/tests/torchtune/utils/test_logging.py
+++ b/tests/torchtune/utils/test_logging.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 from io import StringIO
 from unittest import mock
 
@@ -101,3 +102,47 @@ def test_log_rank_zero(capsys):
             log_rank_zero(logger, "this is a test", level=logging.DEBUG)
             output = stream.getvalue().strip()
             assert not output
+
+
+def test_log_rank_zero_before_dist_init(capsys):
+    """log_rank_zero uses RANK env var when distributed is not yet initialized.
+
+    torchrun sets RANK before recipe_main runs, so config.log_config (which
+    calls log_rank_zero) was printing on every rank because dist.is_initialized()
+    was False and the old code fell back to rank=0 unconditionally.
+    """
+    logger = logging.getLogger(__name__ + ".pre_init")
+    logger.setLevel("DEBUG")
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    logger.addHandler(handler)
+
+    not_initialized = mock.patch(
+        "torchtune.utils._logging.dist.is_initialized", return_value=False
+    )
+    dist_available = mock.patch(
+        "torchtune.utils._logging.dist.is_available", return_value=True
+    )
+
+    with not_initialized, dist_available:
+        # RANK=0 in env → rank-zero process should log
+        with mock.patch.dict(os.environ, {"RANK": "0"}):
+            stream.truncate(0)
+            stream.seek(0)
+            log_rank_zero(logger, "rank zero pre-init", level=logging.DEBUG)
+            assert "rank zero pre-init" in stream.getvalue()
+
+        # RANK=1 in env → non-zero process should stay silent
+        with mock.patch.dict(os.environ, {"RANK": "1"}):
+            stream.truncate(0)
+            stream.seek(0)
+            log_rank_zero(logger, "rank one pre-init", level=logging.DEBUG)
+            assert not stream.getvalue().strip()
+
+        # RANK not set (single-device training) → default rank=0, should log
+        env_without_rank = {k: v for k, v in os.environ.items() if k != "RANK"}
+        with mock.patch.dict(os.environ, env_without_rank, clear=True):
+            stream.truncate(0)
+            stream.seek(0)
+            log_rank_zero(logger, "single device", level=logging.DEBUG)
+            assert "single device" in stream.getvalue()

--- a/torchtune/utils/_logging.py
+++ b/torchtune/utils/_logging.py
@@ -6,6 +6,7 @@
 
 import inspect
 import logging
+import os
 import warnings
 from functools import lru_cache, wraps
 from typing import Callable, Optional, TypeVar
@@ -93,13 +94,22 @@ def log_rank_zero(logger: logging.Logger, msg: str, level: int = logging.INFO) -
     """
     Logs a message only on rank zero.
 
+    When the distributed process group is already initialized, the rank is
+    queried directly from ``torch.distributed``. Before initialization (e.g.
+    in ``recipe_main`` before ``setup()`` is called), the ``RANK`` environment
+    variable set by ``torchrun`` is used as a fallback so that only the rank-0
+    process logs the message even before ``init_process_group`` has been called.
+
     Args:
         logger (logging.Logger): The logger.
         msg (str): The warning message.
         level (int): The logging level. See https://docs.python.org/3/library/logging.html#levels for values.
             Defaults to ``logging.INFO``.
     """
-    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+    if dist.is_available() and dist.is_initialized():
+        rank = dist.get_rank()
+    else:
+        rank = int(os.environ.get("RANK", 0))
     if rank != 0:
         return
     logger.log(level, msg, stacklevel=2)


### PR DESCRIPTION


Fixes #2700

## Summary

`log_rank_zero` fell back to `rank=0` for all processes when
`dist.is_initialized()` was `False` (i.e. before `setup()` calls
`init_process_group`). This meant `config.log_config` — called in
`recipe_main` before the recipe is constructed — printed the full
config on **every rank** in a multi-GPU torchrun launch.

`torchrun` always sets `RANK` in the environment before spawning
workers, so we use it as the fallback rank when the process group is
not yet initialized.

## What changed
- `torchtune/utils/_logging.py`: `log_rank_zero` now reads `os.environ["RANK"]` (default `"0"`) as fallback instead of assuming 0
- `tests/torchtune/utils/test_logging.py`: 3 new test cases covering pre-init RANK=0, RANK=1, and no-RANK (single device)

## Impact
Fixes redundant config logging in all distributed recipes
(`full_finetune_distributed`, `lora_finetune_distributed`,
`knowledge_distillation_distributed`, etc.) with a single change.
