### PR TITLE
Fix NameError in torchtune rlhf/loss/dpo.py from missing imports

### DIFF
--- a/torchtune/rlhf/loss/dpo.py
+++ b/torchtune/rlhf/loss/dpo.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
+from typing import Optional, Tuple, TypeVar
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F


### PR DESCRIPTION
Summary:
`torchtune/rlhf/loss/dpo.py` referenced `dataclass` and `TypeVar` (line `T = TypeVar("T", bound=dataclass)`) without importing them, raising `NameError: name 'TypeVar' is not defined` at import time. This blocked every Mitra DPO unit that imports `torchtune.rlhf.loss.DPOLoss` — including the IG Reels interest-judge DPO work.

Adds the missing `from dataclasses import dataclass` and `from typing import Optional, Tuple, TypeVar`.

___

Differential Revision: D108715300


