### PR TITLE
feat(config): warn on CLI overrides introducing unknown top-level keys

### DIFF
--- a/tests/torchtune/config/test_config_utils.py
+++ b/tests/torchtune/config/test_config_utils.py
@@ -242,3 +242,94 @@ class TestUtils:
         cfg = copy.deepcopy(_CONFIG)
         with pytest.raises(KeyError, match="'i'"):
             _remove_key_by_dotpath(cfg, "i")
+
+    @mock.patch(
+        "torchtune.config._parse.OmegaConf.load", return_value=OmegaConf.create(_CONFIG)
+    )
+    def test_merge_warns_on_unused_cli_key(self, mock_load, capsys):
+        parser = TuneRecipeArgumentParser("test parser")
+        yaml_args, cli_args = parser.parse_known_args(
+            [
+                "--config",
+                "test.yaml",
+                "d=6",  # Override existing key — should NOT warn
+                "foo_bar=1",  # Typo or unsupported key — SHOULD warn
+                "foobbar=2",  # Another unknown key similar to "foobar"
+            ]
+        )
+
+        logger = logging.getLogger(__name__)
+        logger.setLevel("DEBUG")
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        logger.addHandler(handler)
+        try:
+            with (
+                mock.patch(
+                    "torchtune.config._utils.get_logger", return_value=logger
+                ),
+                mock.patch(
+                    "torchtune.utils._logging.dist.is_available", return_value=False
+                ),
+            ):
+                _merge_yaml_and_cli_args(yaml_args, cli_args)
+            output = stream.getvalue()
+            # The unknown keys should both be reported
+            assert "foo_bar" in output, (
+                f"Expected 'foo_bar' in warning, got: {output!r}"
+            )
+            assert "foobbar" in output, (
+                f"Expected 'foobbar' in warning, got: {output!r}"
+            )
+            # Existing key 'd' should not appear in the unused list
+            assert "'d' (did you mean" not in output
+        finally:
+            logger.removeHandler(handler)
+
+    @mock.patch(
+        "torchtune.config._parse.OmegaConf.load", return_value=OmegaConf.create(_CONFIG)
+    )
+    def test_merge_no_warning_when_all_keys_known(self, mock_load, capsys):
+        parser = TuneRecipeArgumentParser("test parser")
+        yaml_args, cli_args = parser.parse_known_args(
+            [
+                "--config",
+                "test.yaml",
+                "a=2",  # override existing
+                "d=6",  # override existing
+            ]
+        )
+        logger = logging.getLogger(__name__)
+        logger.setLevel("DEBUG")
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        logger.addHandler(handler)
+        try:
+            with (
+                mock.patch(
+                    "torchtune.config._utils.get_logger", return_value=logger
+                ),
+                mock.patch(
+                    "torchtune.utils._logging.dist.is_available", return_value=False
+                ),
+            ):
+                _merge_yaml_and_cli_args(yaml_args, cli_args)
+            assert not stream.getvalue().strip(), (
+                f"Expected no warning output, got: {stream.getvalue()!r}"
+            )
+        finally:
+            logger.removeHandler(handler)
+
+    def test_closest_yaml_keys(self):
+        from torchtune.config._utils import _closest_yaml_keys
+
+        yaml_keys = {"batch_size", "epochs", "batch", "optimizer", "lr_scheduler"}
+        # exact-ish typo: 'batch_siz' should match 'batch_size' (and maybe 'batch')
+        matches = _closest_yaml_keys("batch_siz", yaml_keys)
+        assert "batch_size" in matches, f"Expected 'batch_size' in {matches}"
+
+        # No matches for a wildly different key
+        assert _closest_yaml_keys("zzz", yaml_keys) == []
+
+        # max_suggestions is respected
+        assert len(_closest_yaml_keys("batch", yaml_keys, max_suggestions=1)) <= 1

--- a/torchtune/config/_utils.py
+++ b/torchtune/config/_utils.py
@@ -155,6 +155,8 @@ def _merge_yaml_and_cli_args(yaml_args: Namespace, cli_args: list[str]) -> DictC
     """
     # Convert Namespace to simple dict
     yaml_kwargs = vars(yaml_args)
+    yaml_top_level_keys = set(yaml_kwargs.keys())
+    unused_keys: list[str] = []
     cli_dotlist = []
     for arg in cli_args:
         # If CLI override uses the remove flag (~), remove the key from the yaml config
@@ -183,6 +185,13 @@ def _merge_yaml_and_cli_args(yaml_args: Namespace, cli_args: list[str]) -> DictC
         if k in yaml_kwargs and _has_component(yaml_kwargs[k]):
             k += "._component_"
 
+        # Track CLI overrides that introduce a new top-level key not defined in the
+        # YAML config. These are likely typos or recipe-unsupported kwargs and should
+        # be surfaced to the user as a warning (see issue #1646).
+        top_level_key = k.split(".")[0]
+        if top_level_key not in yaml_top_level_keys and top_level_key not in unused_keys:
+            unused_keys.append(top_level_key)
+
         # None passed via CLI will be parsed as string, but we really want OmegaConf null
         if v == "None":
             v = "!!null"
@@ -194,12 +203,47 @@ def _merge_yaml_and_cli_args(yaml_args: Namespace, cli_args: list[str]) -> DictC
             v = "!!str " + v
         cli_dotlist.append(f"{k}={v}")
 
+    if unused_keys:
+        logger = get_logger("WARNING")
+        suggestions = ", ".join(
+            f"'{key}' (did you mean one of: "
+            f"{', '.join(_closest_yaml_keys(key, yaml_top_level_keys)) or 'no matches'}?)"
+            for key in unused_keys
+        )
+        log_rank_zero(
+            logger=logger,
+            msg=(
+                "The following CLI override key(s) are not present in the YAML config "
+                f"and may be unused by the recipe: {suggestions}. If this was "
+                "intentional (e.g. adding a brand new field), you can ignore this "
+                "warning. Otherwise, please check the key name against the config and "
+                "recipe for a typo or unsupported option."
+            ),
+        )
+
     # Merge the args
     cli_conf = OmegaConf.from_dotlist(cli_dotlist)
     yaml_conf = OmegaConf.create(yaml_kwargs)
 
     # CLI takes precedence over yaml args
     return OmegaConf.merge(yaml_conf, cli_conf)
+
+
+def _closest_yaml_keys(key: str, yaml_keys: set[str], max_suggestions: int = 3) -> list[str]:
+    """Return up to ``max_suggestions`` keys from ``yaml_keys`` that look similar to
+    ``key``. Uses a simple substring + difflib heuristic to surface likely typos."""
+    import difflib
+
+    candidates: list[tuple[float, str]] = []
+    for yk in yaml_keys:
+        score = difflib.SequenceMatcher(None, key, yk).ratio()
+        # also reward substring containment so prefix typos rank high
+        if key in yk or yk in key:
+            score = max(score, 0.75)
+        if score >= 0.6:
+            candidates.append((score, yk))
+    candidates.sort(reverse=True)
+    return [yk for _, yk in candidates[:max_suggestions]]
 
 
 def _remove_key_by_dotpath(nested_dict: dict[str, Any], dotpath: str) -> None:


### PR DESCRIPTION
## Summary

When a CLI override (e.g. `foobbar=1`) introduces a top-level key that is not present in the YAML config, the user has likely either misspelled a YAML key or passed a kwarg the recipe does not support. Previously the merge happened silently via `OmegaConf.merge(yaml_conf, cli_conf)` and the user would believe the kwarg was active when the recipe ignored it.

This commit adds a post-merge warning that lists each unknown top-level key and surfaces close YAML-key candidates via a simple `difflib` + substring heuristic in `_closest_yaml_keys`. The warning is emitted through `log_rank_zero` so it appears only on rank zero.

## What changed

- `torchtune/config/_utils.py`
  - `_merge_yaml_and_cli_args`: collects top-level keys from each CLI override, tracks ones not present in the YAML top-level keys, and emits a single aggregated warning via `log_rank_zero` before the merge.
  - `_closest_yaml_keys` (new helper): `difflib.SequenceMatcher` ratio + substring containment reward, returns up to `max_suggestions` (default 3) YAML keys that look similar to the offending key.
- `tests/torchtune/config/test_config_utils.py`
  - `test_merge_warns_on_unused_cli_key`: two unknown keys both surface in the warning; existing keys do not.
  - `test_merge_no_warning_when_all_keys_known`: clean override set produces no warning output.
  - `test_closest_yaml_keys`: typo "batch_siz" matches "batch_size"; unrelated keys return empty list; `max_suggestions` is respected.

## Why this is the right place

The merge happens in `_merge_yaml_and_cli_args` (called from `TuneRecipeArgumentParser.parse_known_args`). By the time we reach the merge, the YAML keys are known (`vars(yaml_args)`) and the CLI dotlist is fully parsed. Tracking top-level keys during the CLI loop avoids any extra pass and adds zero overhead when no warning fires.

The implementation intentionally uses `log_rank_zero` (not `logger.warning`) because:
1. Torchtune's distributed recipes call `_merge_yaml_and_cli_args` on every rank; emitting the warning on all ranks would spam logs.
2. The existing `log_config` uses the same helper for the same reason (issue #2700).

## Limitations

- Only top-level keys are tracked. Sub-keys of an existing component (e.g. `model.lora_rank` when `model._component_` exists in YAML) are not flagged because they would produce too many false positives during early recipe prototyping.
- The `difflib` heuristic is intentionally simple; it is a did-you-mean hint, not a guaranteed typo detector. False positives are possible; the warning copy acknowledges this: "If this was intentional ... you can ignore this warning".

## Verification

- `python3 -m py_compile torchtune/config/_utils.py tests/torchtune/config/test_config_utils.py` passes
- `python3 -m ruff check torchtune/config/_utils.py tests/torchtune/config/test_config_utils.py` passes
- `_closest_yaml_keys` standalone validation (without torchao import) produces expected outputs:
  - `closest_yaml_keys("batch_siz", {batch_size,epochs,batch,optimizer,lr_scheduler})` -> `["batch_size", "batch"]`
  - `closest_yaml_keys("zzz", {batch_size,epochs})` -> `[]`
  - `closest_yaml_keys("batch", {batch_size,batch,optimizer}, max_suggestions=1)` -> `["batch"]`
- Full test suite blocked locally by missing `torchao` dependency (per issue install instructions); new tests follow the existing pattern of mocking `dist.is_available` and `get_logger`.

## Backward compatibility

- New behavior is opt-in by triggering a CLI override with a YAML-unknown key. Existing recipes and configs are unaffected.
- No public API change.
- The warning is emitted via `get_logger("WARNING")` and routed through `log_rank_zero`; users who have configured their root logger to ERROR will not see it.

Fixes #1646